### PR TITLE
timeout-minutesのパース部分でpanicが発生していたので修正

### DIFF
--- a/src/core/parse_sbom.go
+++ b/src/core/parse_sbom.go
@@ -202,7 +202,7 @@ func (project *parser) parseFloat(node *yaml.Node) *ast.Float {
 // *https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
 func (project *parser) parseTimeoutMinutes(node *yaml.Node) *ast.Float {
 	f := project.parseFloat(node)
-	if f == nil && f.Expression == nil && f.Value < 0 {
+	if f != nil && f.Expression == nil && f.Value < 0 {
 		project.errorf(node, "expected positive number for timeout-minutes but found %v", node.Value)
 	}
 	return f


### PR DESCRIPTION
以下のようなエラーが出ましたので調べたところ条件が間違っていたので直しました。
```
C:\workspace\shbrgen\brgen>sisakulint
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x8 pc=0x4802ea]

goroutine 8 [running]:
github.com/ultra-supara/sisakulint/src/core.(*parser).parseTimeoutMinutes(0x4ec86d?, 0xc000077360)
        C:/workspace/sisakulint/src/core/parse_sbom.go:205 +0x2a
github.com/ultra-supara/sisakulint/src/core.(*parser).parseJob(0x0?, 0xc0000650c0, 0x2e0785?)
        C:/workspace/sisakulint/src/core/parse_sub.go:308 +0xb51
github.com/ultra-supara/sisakulint/src/core.(*parser).parseJobs(0xc000155c08?, 0xc000076c80?)
        C:/workspace/sisakulint/src/core/parse_sub.go:420 +0xaa
github.com/ultra-supara/sisakulint/src/core.(*parser).parse(0xc000155c08, 0xc0000768c0)
        C:/workspace/sisakulint/src/core/parse_main.go:63 +0x305
github.com/ultra-supara/sisakulint/src/core.Parse({0xc000148000, 0x2ff, 0x300})
        C:/workspace/sisakulint/src/core/parse_main.go:117 +0x9b
github.com/ultra-supara/sisakulint/src/core.(*Linter).validate(0xc000144000, {0xc00002237b, 0x1a}, {0xc000148000, 0x2ff, 0x300}, 0xc000064d40, 0x0?, 0xc000070940, 0xc000074280)
        C:/workspace/sisakulint/src/core/linter.go:514 +0x23c
github.com/ultra-supara/sisakulint/src/core.(*Linter).LintFiles.func1()
        C:/workspace/sisakulint/src/core/linter.go:368 +0x150
golang.org/x/sync/errgroup.(*Group).Go.func1()
        C:/Users/ukfco/go/pkg/mod/golang.org/x/sync@v0.5.0/errgroup/errgroup.go:75 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        C:/Users/ukfco/go/pkg/mod/golang.org/x/sync@v0.5.0/errgroup/errgroup.go:72 +0x96
```