### PR TITLE
timeout-minutesを検知するとき付けていてもmissingと検出されるのを修正

### DIFF
--- a/src/core/parse_sbom.go
+++ b/src/core/parse_sbom.go
@@ -178,7 +178,7 @@ func (project *parser) parseInt(node *yaml.Node) *ast.Int {
 }
 
 func (project *parser) parseFloat(node *yaml.Node) *ast.Float {
-	if node.Kind != yaml.ScalarNode || (node.Tag != "!!float" && node.Tag != "!!str") {
+	if node.Kind != yaml.ScalarNode || (node.Tag != "!!int" && node.Tag != "!!float" && node.Tag != "!!str") {
 		project.errorf(node, "expected float node but found %s node with %q tag", nodeKindName(node.Kind), node.Tag)
 		return nil
 	}


### PR DESCRIPTION
```
C:\workspace\shbrgen\brgen>sisakulint
.github\workflows\brgen-test.yaml:14:3: timeout-minutes is not set for job brgen-test; see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes for more details. [missing-timeout-minutes]
       14 👈|  brgen-test:

.github\workflows\brgen-test.yaml:16:22: expected float node but found scalar node with "!!int" tag [syntax]
       16 👈|    timeout-minutes: 10

.github\workflows\deploy.yml:23:3: timeout-minutes is not set for job deploy; see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes for more details. [missing-timeout-minutes]
       23 👈|  deploy:

.github\workflows\deploy.yml:28:22: expected float node but found scalar node with "!!int" tag [syntax]
       28 👈|    timeout-minutes: 10
(以下同様のエラーが大量に)
````
とエラーがでるが、timeout-minutesはyamlファイル自体にはきちんと付けていてしかもgithub actions上では実際に動いている。だが、floatのパースの実装によってint型が弾かれているため、timeout-minutesの部分がsyntaxエラーとなり、さらにASTノードにtimeout-minutesが設定されないのでtimeout-minutesの検査部分でも引っかかってエラーが出る。
これでは他の肝心のエラーを見落とす原因になる。
![image](https://github.com/ultra-supara/sisakulint/assets/62627905/56fcaf9d-2d22-4b48-8957-2b847ccff1fa)

これはfloatをparseするときに!!intタグも含めてしまえば解決する問題だと思われる。
本変更を適用すると以下のようにエラーがスッキリする。
```
C:\workspace\shbrgen\brgen>sisakulint
.github\workflows\release.yml:310:9: undefined variable "startsWith(github". available variables are "env", "github", "inputs", "job", "matrix", "needs", "runner", "secrets", "steps", "strategy", "vars" [expression]
        310 👈|    if: startsWith(github.ref, 'refs/tags/v')

.github\workflows\release.yml:414:3: timeout-minutes is not set for job run-test; see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes for more details. [missing-timeout-minutes]
        414 👈|  run-test:

.github\workflows\test.yml:28:14: Direct use of ${{ ... }} in run steps; Use env instead. see also https://docs.github.com/ja/enterprise-cloud@latest/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack [issue-injection]
       28 👈|          CTEST_OUTPUT_ON_FAILURE=1 BASE_PATH=${{ github.workspace }} ninja -C built/native/Debug test    

```