### PR TITLE
Lexerを修正

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,8 @@
             "type":"go",
             "request":"launch",
             "program":"${workspaceFolder}/cmd/sisakulint",
-            "args": ["-format","{{sarif}}"]
+            "cwd": "${workspaceFolder}",
+            "args": ["-format","{{sarif}}","./script/starts_with.yml"]
         }
     ]
 }

--- a/pkg/expressions/tokenizer.go
+++ b/pkg/expressions/tokenizer.go
@@ -238,6 +238,7 @@ func (t *Tokenizer) unexpectedEOF() *Token {
 
 // lexIdent は識別子を字句解析します。
 func (t *Tokenizer) lexIdent() *Token {
+	t.start = t.scanner.Pos() // トークンの開始位置を設定
 	for {
 		if r := t.eat(); !isAlnum(r) && r != '_' && r != '-' {
 			return t.token(TokenKindIdent)

--- a/script/starts_with.yml
+++ b/script/starts_with.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  use_pr_title:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - name: Print PR Title
+      if: startsWith(github.event.pull_request.title, 'WIP')
+      run: echo "Hello!"


### PR DESCRIPTION
Lexerが`startsWith(github.event.pull_request.title, 'WIP')`のような関数呼び出しになっているときに
なぜか`startsWith(github`みたいな奇っ怪なものを作り
```
script/starts_with.yml:10:11: undefined variable "startsWith(github". available variables are "env", "github", "inputs", "job", "matrix", "needs", "runner", "secrets", "steps", "strategy", "vars" [expression]
       10 👈|      if: startsWith(github.event.pull_request.title, 'WIP')
```
のようなエラーになっていたのを修正