### PR TITLE
go version update 1.23.3

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.21.4"
+          go-version: "1.23.2"
       - name: Check Go sources are formatted
         run: |
           diffs="$(gofmt -d ./pkg/core/*.go ./cmd/sisakulint/*.go)"
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
         with:
           build-args: |
-            GOLANG_VER=1.21.4
+            GOLANG_VER=1.23.3
             "TOKEN=${{ steps.generate_token.outputs.token }}"
           push: false
       # - name: Test Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.21.4"
+          go-version: "1.23.3"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VER=1.21.4
+ARG GOLANG_VER=1.23.3
 ARG ALPINE_VER=latest
 
 FROM golang:${GOLANG_VER} as builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ultra-supara/sisakulint
 
-go 1.21.4
+go 1.23.3
 
 require (
 	github.com/fatih/color v1.18.0

--- a/script/commitsha.yaml
+++ b/script/commitsha.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.3"
+          go-version: "1.23.3"
       - name: Run GolangCI-Lint
         uses: golangci/golangci-lint-action@v2
         with:


### PR DESCRIPTION
## todo

Goのバージョンを1.21.4から1.23.3に変更する。これが今のローカルのバージョンである。