### PR TITLE
fix: correct inverted logic in BaseRule.Debug method

### DIFF
--- a/pkg/core/rule.go
+++ b/pkg/core/rule.go
@@ -38,7 +38,7 @@ func (rule *BaseRule) Errorf(position *ast.Position, format string, args ...inte
 // Debugはルールからのdebug logを出力
 // Enable メソッドの引数によって指定されたio.Writerインスタンスはデバッグ情報をコンソール上に出力するために使用される
 func (rule *BaseRule) Debug(format string, args ...interface{}) {
-	if rule.debugOut != nil {
+	if rule.debugOut == nil {
 		return
 	}
 	debugMsg := fmt.Sprintf("[%s] %s\n", rule.RuleName, format)


### PR DESCRIPTION
## Summary

- Fixed inverted logic in `BaseRule.Debug()` method in `pkg/core/rule.go`

## Problem

The condition was checking `!= nil` when it should check `== nil`:

```go
if rule.debugOut != nil {  // Bug: inverted logic
    return
}
fmt.Fprintf(rule.debugOut, debugMsg, args...)  // Panic when debugOut is nil
```

This caused:
- Debug output to be **disabled** when `debugOut` is set
- **nil pointer dereference panic** when `debugOut` is nil and the method tries to write to it

## Solution

Changed the condition to correctly check for nil:

```go
if rule.debugOut == nil {
    return
}
fmt.Fprintf(rule.debugOut, debugMsg, args...)
```

## Test Plan

- [x] Verified existing tests still pass
- [x] No regression in functionality

Fixes #196