### PR TITLE
fix: correct inverted logic in BaseRule.Debug method

### DIFF
--- a/pkg/core/rule.go
+++ b/pkg/core/rule.go
@@ -38,7 +38,7 @@ func (rule *BaseRule) Errorf(position *ast.Position, format string, args ...inte
 // Debugはルールからのdebug logを出力
 // Enable メソッドの引数によって指定されたio.Writerインスタンスはデバッグ情報をコンソール上に出力するために使用される
 func (rule *BaseRule) Debug(format string, args ...interface{}) {
-	if rule.debugOut != nil {
+	if rule.debugOut == nil {
 		return
 	}
 	debugMsg := fmt.Sprintf("[%s] %s\n", rule.RuleName, format)


### PR DESCRIPTION
reopen #197

Fixes the inverted logic in the BaseRule.Debug method where the condition was checking if debugOut != nil instead of == nil, which prevented debug output from being written.