### PR TITLE
fix isNull function to detect null node correctly

### DIFF
--- a/pkg/core/parse_sbom.go
+++ b/pkg/core/parse_sbom.go
@@ -49,7 +49,7 @@ func positionAt(node *yaml.Node) *ast.Position {
 }
 
 func isNull(node *yaml.Node) bool {
-	return node.Kind == yaml.ScalarNode && node.Tag == SBOMNullTag && node.Value == ExprNullValue
+	return node.Kind == yaml.ScalarNode && node.Tag == SBOMNullTag
 }
 
 func newString(node *yaml.Node) *ast.String {


### PR DESCRIPTION
parse_sbom.go内のisNull関数をnullを正しく判定するように修正
備考: 
fmt.Printfを該当の箇所に仕込んでビルドして実行したところnullノードは以下のようであった。
```
&yaml.Node{Kind:0x8, Style:0x0, Tag:"!!null", Value:"", Anchor:"", Alias:(*yaml.Node)(nil), Content:[]*yaml.Node(nil), HeadComment:"", LineComment:"", FootComment:"", Line:4, Column:21}
```
元コードではValueを比較していたがこの通り"!!null"だけ判定すれば事足りると思われるためその式を削除した。
これにより
```
workflow_dispatch:
```
のように空文字列でnullにしている箇所でエラーとならなくなる