### PR TITLE
Fix incorrect validation logic for workflow_dispatch inputs

### DIFF
--- a/pkg/core/parse_sbom.go
+++ b/pkg/core/parse_sbom.go
@@ -434,7 +434,7 @@ func (project *parser) parseWorkflowDispatchEvent(pos *ast.Position, node *yaml.
 	ret := &ast.WorkflowDispatchEvent{Pos: pos}
 
 	for _, kv := range project.parseSectionMapping("workflow_dispatch", node, true, true) {
-		if kv.id == "inputs" {
+		if kv.id != "inputs" {
 			project.unexpectedKey(kv.key, "workflow_dispatch", []string{"inputs"})
 			continue
 		}


### PR DESCRIPTION
## Summary
- Fixed a logic error in `parseWorkflowDispatchEvent` where the validation condition was inverted
- Changed `if kv.id == "inputs"` to `if kv.id != "inputs"` in `pkg/core/parse_sbom.go:437`
- This resolves the contradictory error message: "expected 'inputs' key for 'workflow_dispatch' section but got 'inputs'"

## Problem
When parsing `workflow_dispatch` events with valid `inputs` keys, the parser incorrectly flagged them as errors. The logic was checking if the key **equals** "inputs" and then reporting it as unexpected, when it should only report keys that are **not** "inputs".

## Solution
Inverted the condition from `==` to `!=` so that:
- ✅ Valid `inputs` keys are accepted
- ❌ Invalid keys (anything other than "inputs") trigger an error

## Test Plan
- [x] Built the project successfully
- [x] Tested with valid `workflow_dispatch` with `inputs` → No error
- [x] Tested with invalid key (`invalid_key`) → Appropriate error message
- [x] Verified error message is now correct and non-contradictory

## References
Issue discovered in: https://github.com/harvard-edge/cs249r_book/blob/dev/.github/workflows/infra-health-check.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)