### PR TITLE
fix: remove dangerous auto-fix logic from action-list rule

### DIFF
--- a/pkg/core/actionlist.go
+++ b/pkg/core/actionlist.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/ultra-supara/sisakulint/pkg/ast"
-	"gopkg.in/yaml.v3"
 )
 
 // ActionList はアクション参照のホワイトリスト/ブラックリストを実装するルール
@@ -52,43 +51,15 @@ func compileActionPattern(pattern string) (*regexp.Regexp, error) {
 	return re, nil
 }
 
-// ここにVisitJobPre, VisitJobPost, VisitWorkflowPre, VisitWorkflowPostを実装
+// VisitJobPre checks if actions used in job steps are allowed
 func (rule *ActionList) VisitJobPre(node *ast.Job) error {
-	var currentFixTargetSteps []*ast.Step
 	for _, step := range node.Steps {
 		if action, ok := step.Exec.(*ast.ExecAction); ok {
 			usesValue := action.Uses.Value
 			allowed, reason := rule.isActionAllowed(usesValue)
 			if !allowed {
 				rule.Errorf(step.Pos, "%s in step '%s'", reason, step.String())
-				currentFixTargetSteps = append(currentFixTargetSteps, step)
 			}
-		}
-	}
-	if len(currentFixTargetSteps) > 0 {
-		rule.AddAutoFixer(NewFuncFixer("action-list", func() error {
-			return rule.fixJob(node, currentFixTargetSteps)
-		}))
-	}
-	return nil
-}
-
-// FixStep は非準拠のアクション参照を修正するためのAutoFixer
-func (rule *ActionList) fixJob(job *ast.Job, steps []*ast.Step) error {
-	for i, node := range job.BaseNode.Content {
-		if node.Value == "steps" {
-			seqNode := job.BaseNode.Content[i+1]
-			var newContent []*yaml.Node
-		OUTER:
-			for _, step := range seqNode.Content {
-				for _, targetStep := range steps {
-					if step == targetStep.BaseNode {
-						continue OUTER // 修正対象のステップはスキップ
-					}
-				}
-				newContent = append(newContent, step)
-			}
-			seqNode.Content = newContent
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Removed the dangerous auto-fix functionality from the action-list rule that was deleting non-compliant workflow steps
- Simplified the rule to only detect and report violations without modifying workflow files

## Changes

- **Removed `fixJob()` function**: This function was deleting workflow steps that didn't match the whitelist, which could break existing workflows
- **Simplified `VisitJobPre()`**: Now only reports violations without collecting steps for auto-fix
- **Removed unused import**: Cleaned up `gopkg.in/yaml.v3` import that was only used by the auto-fix logic

## Motivation

The previous auto-fix implementation was problematic because:
1. It silently deleted workflow steps without user awareness
2. This could break existing workflows by removing critical steps
3. There's no safe way to "auto-fix" a step that uses a non-whitelisted action

The rule now provides safer behavior by only reporting violations, allowing users to manually review and fix issues.

## Test Plan

- [x] Build succeeds: `go build ./cmd/sisakulint`
- [x] No behavioral change for detection logic - violations are still reported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)