### PR TITLE
feat: Add models and attestations permission scopes

### DIFF
--- a/pkg/core/permissionrule.go
+++ b/pkg/core/permissionrule.go
@@ -7,12 +7,14 @@ import (
 
 var allPermissionScopes = map[string]struct{}{
 	"actions":             {},
+	"attestations":        {},
 	"checks":              {},
 	"contents":            {},
 	"deployments":         {},
+	"discussions":         {},
 	"id-token":            {},
 	"issues":              {},
-	"discussions":         {},
+	"models":              {},
 	"packages":            {},
 	"pages":               {},
 	"pull-requests":       {},

--- a/pkg/core/permissionrule_test.go
+++ b/pkg/core/permissionrule_test.go
@@ -100,3 +100,58 @@ func TestPermissionRule_checkPermissions(t *testing.T) {
 		})
 	}
 }
+
+func TestPermissionRule_ValidScopes(t *testing.T) {
+	// Test that all valid permission scopes are recognized
+	validScopes := []string{
+		"actions",
+		"attestations",
+		"checks",
+		"contents",
+		"deployments",
+		"discussions",
+		"id-token",
+		"issues",
+		"models",
+		"packages",
+		"pages",
+		"pull-requests",
+		"repository-projects",
+		"security-events",
+		"statuses",
+	}
+
+	for _, scope := range validScopes {
+		t.Run(scope, func(t *testing.T) {
+			rule := PermissionsRule()
+			permissions := &ast.Permissions{
+				Scopes: map[string]*ast.PermissionScope{
+					scope: {
+						Name:  &ast.String{Value: scope, Pos: &ast.Position{Line: 1, Col: 1}},
+						Value: &ast.String{Value: "read", Pos: &ast.Position{Line: 1, Col: 10}},
+					},
+				},
+			}
+			rule.checkPermissions(permissions)
+			if len(rule.Errors()) > 0 {
+				t.Errorf("scope %q should be valid, but got error: %v", scope, rule.Errors()[0])
+			}
+		})
+	}
+}
+
+func TestPermissionRule_InvalidScope(t *testing.T) {
+	rule := PermissionsRule()
+	permissions := &ast.Permissions{
+		Scopes: map[string]*ast.PermissionScope{
+			"invalid-scope": {
+				Name:  &ast.String{Value: "invalid-scope", Pos: &ast.Position{Line: 1, Col: 1}},
+				Value: &ast.String{Value: "read", Pos: &ast.Position{Line: 1, Col: 20}},
+			},
+		},
+	}
+	rule.checkPermissions(permissions)
+	if len(rule.Errors()) == 0 {
+		t.Error("expected error for invalid scope, but got none")
+	}
+}


### PR DESCRIPTION
## 概要

GitHub Actions の新しいパーミッションスコープ (`models`、`attestations`) に対応しました。

## 詳細

- **models**: GitHub Models へのアクセス権限
- **attestations**: アテステーション管理の権限

これらのスコープは GitHub Actions GITHUB_TOKEN の有効なスコープですが、sisakulint では未対応でした。本修正により、これらを使用するワークフローでも正しく検証されるようになります。

## テスト

- 全パーミッションスコープの検証テスト追加
- 無効なスコープのエラー検出テスト追加
- 既存テストはすべてパス

## 関連 Issue

Fixes sisaku-security/sisakuintel-worker#326