### PR TITLE
fix: false positives in cond and expression rules

### DIFF
--- a/pkg/core/available.go
+++ b/pkg/core/available.go
@@ -17,7 +17,7 @@ func WorkflowKeyAvailability(key string) ([]string, []string) {
 	case KeyPathJobEnvironmentURL:
 		return []string{ContextEnv, ContextGithub, ContextInputs, ContextJob, ContextMatrix, ContextNeeds, ContextRunner, ContextSteps, ContextStrategy, ContextVars}, []string{}
 	case KeyPathJobStepsIf:
-		return []string{ContextEnv, ContextGithub, ContextInputs, ContextJob, ContextMatrix, ContextNeeds, ContextRunner, ContextSteps, ContextStrategy, ContextVars}, []string{FunctionAlways, FunctionCanceled, FunctionFailure, FunctionHashFiles, FunctionSuccess}
+		return []string{ContextEnv, ContextGithub, ContextInputs, ContextJob, ContextMatrix, ContextNeeds, ContextRunner, ContextSteps, ContextStrategy, ContextVars}, []string{FunctionAlways, FunctionCanceled, FunctionCancelled, FunctionFailure, FunctionHashFiles, FunctionSuccess}
 	case KeyPathJobContainerCredentials, KeyPathJobServicesCredentials:
 		return []string{ContextEnv, ContextGithub, ContextInputs, ContextMatrix, ContextNeeds, ContextSecrets, ContextStrategy, ContextVars}, []string{}
 	case KeyPathJobDefaultsRun:
@@ -31,7 +31,7 @@ func WorkflowKeyAvailability(key string) ([]string, []string) {
 	case KeyPathJobStrategy:
 		return []string{ContextGithub, ContextInputs, ContextNeeds, ContextVars}, []string{}
 	case KeyPathJobIf:
-		return []string{ContextGithub, ContextInputs, ContextNeeds, ContextVars}, []string{FunctionAlways, FunctionCanceled, FunctionFailure, FunctionSuccess}
+		return []string{ContextGithub, ContextInputs, ContextNeeds, ContextVars}, []string{FunctionAlways, FunctionCanceled, FunctionCancelled, FunctionFailure, FunctionSuccess}
 	case AvailableEnv:
 		return []string{ContextGithub, ContextInputs, ContextSecrets, ContextVars}, []string{}
 	case AvailableConcurrency, KeyPathOnWorkflowCallInputsDefault, KeyPathRunName:

--- a/pkg/core/conditionalrule.go
+++ b/pkg/core/conditionalrule.go
@@ -45,14 +45,58 @@ func (rule *ConditionalRule) checkcond(n *ast.String) {
 	if !n.ContainsExpression() {
 		return
 	}
-	// checknumber of ${{ }} for conditions like ${{ flase }} or ${{ true }} , which are evaluated to true!
+
+	// Skip if condition contains multiple ${{ }} blocks (e.g., "${{ a }} == ${{ b }}")
+	// These are valid comparison expressions that can evaluate to true or false
+	if strings.Count(n.Value, "${{") > 1 {
+		return
+	}
+
+	// Skip if condition is a single ${{ }} block covering the entire condition
+	// This is a valid expression (e.g., "${{ github.event_name == 'push' }}")
 	if strings.HasPrefix(n.Value, "${{") && strings.HasSuffix(n.Value, "}}") && strings.Count(n.Value, "${{") == 1 {
 		return
 	}
-	// rule
+
+	// Skip if there are operators outside ${{ }} blocks (e.g., "${{ steps.foo.outputs.result }} == 'success'")
+	// Remove all ${{ ... }} blocks and check if remaining text contains meaningful operators
+	remaining := removeExpressionBlocks(n.Value)
+	if containsOperator(remaining) {
+		return
+	}
+
+	// Report error for invalid conditions that will always evaluate to true
 	rule.Errorf(
 		n.Pos,
 		"The condition '%s' will always evaluate to true. If you intended to use a literal value, please use ${{ true }}. Ensure there are no extra characters within the ${{ }} brackets in conditions.",
 		n.Value,
 	)
+}
+
+// removeExpressionBlocks removes all ${{ ... }} blocks from the string
+func removeExpressionBlocks(s string) string {
+	result := s
+	for {
+		start := strings.Index(result, "${{")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start:], "}}")
+		if end == -1 {
+			break
+		}
+		result = result[:start] + result[start+end+2:]
+	}
+	return result
+}
+
+// containsOperator checks if the string contains meaningful operators
+func containsOperator(s string) bool {
+	operators := []string{"==", "!=", ">=", "<=", ">", "<", "&&", "||", "!"}
+	for _, op := range operators {
+		if strings.Contains(s, op) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/core/conditionalrule_test.go
+++ b/pkg/core/conditionalrule_test.go
@@ -105,25 +105,171 @@ func TestConditionalRule_VisitJobPost(t *testing.T) {
 }
 
 func TestConditionalRule_checkcond(t *testing.T) {
-	type fields struct {
-		BaseRule BaseRule
-	}
-	type args struct {
-		n *ast.String
-	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name      string
+		condition string
+		wantError bool
 	}{
-		// TODO: Add test cases.
+		// Valid conditions - should NOT produce error
+		{
+			name:      "single expression block",
+			condition: "${{ github.event_name == 'push' }}",
+			wantError: false,
+		},
+		{
+			name:      "multiple expression blocks with comparison",
+			condition: "${{ github.event.repository.owner.id }} == ${{ github.event.sender.id }}",
+			wantError: false,
+		},
+		{
+			name:      "expression block with external comparison and function",
+			condition: "${{ steps.disk.outputs.status }} == 'success' && !cancelled()",
+			wantError: false,
+		},
+		{
+			name:      "expression block with external comparison",
+			condition: "${{ env.PACKAGED_STATUS }} == 'success' && !cancelled()",
+			wantError: false,
+		},
+		{
+			name:      "parenthesized cancelled function",
+			condition: "(!cancelled())",
+			wantError: false,
+		},
+		{
+			name:      "success function expression",
+			condition: "${{ success() }}",
+			wantError: false,
+		},
+		{
+			name:      "always function expression",
+			condition: "${{ always() }}",
+			wantError: false,
+		},
+		{
+			name:      "expression with != operator outside block",
+			condition: "${{ steps.test.outputs.result }} != 'failure'",
+			wantError: false,
+		},
+		{
+			name:      "expression with || operator outside block",
+			condition: "${{ steps.a.outputs.done }} || ${{ steps.b.outputs.done }}",
+			wantError: false,
+		},
+		// Note: The following are edge cases - expressions like "${{ true }}" or "${{ false }}"
+		// are intentionally NOT flagged as errors because they are valid expressions
+		// The rule only flags malformed conditions that are clearly broken
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := &ConditionalRule{
-				BaseRule: tt.fields.BaseRule,
+			rule := NewConditionalRule()
+			astString := &ast.String{
+				Value: tt.condition,
+				Pos:   &ast.Position{Line: 1, Col: 1},
 			}
-			rule.checkcond(tt.args.n)
+			rule.checkcond(astString)
+			hasError := len(rule.Errors()) > 0
+			if hasError != tt.wantError {
+				if tt.wantError {
+					t.Errorf("checkcond() expected error for condition %q but got none", tt.condition)
+				} else {
+					t.Errorf("checkcond() unexpected error for condition %q: %v", tt.condition, rule.Errors())
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveExpressionBlocks(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single block",
+			input: "${{ github.event_name }}",
+			want:  "",
+		},
+		{
+			name:  "two blocks with operator",
+			input: "${{ a }} == ${{ b }}",
+			want:  " == ",
+		},
+		{
+			name:  "block with trailing text",
+			input: "${{ steps.foo.outputs.result }} == 'success'",
+			want:  " == 'success'",
+		},
+		{
+			name:  "no blocks",
+			input: "success()",
+			want:  "success()",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := removeExpressionBlocks(tt.input)
+			if got != tt.want {
+				t.Errorf("removeExpressionBlocks(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsOperator(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "contains ==",
+			input: " == 'success'",
+			want:  true,
+		},
+		{
+			name:  "contains !=",
+			input: " != 'failure'",
+			want:  true,
+		},
+		{
+			name:  "contains &&",
+			input: " && !cancelled()",
+			want:  true,
+		},
+		{
+			name:  "contains ||",
+			input: " || ",
+			want:  true,
+		},
+		{
+			name:  "contains !",
+			input: "!cancelled()",
+			want:  true,
+		},
+		{
+			name:  "contains >=",
+			input: " >= 5",
+			want:  true,
+		},
+		{
+			name:  "no operators",
+			input: "success()",
+			want:  false,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsOperator(tt.input)
+			if got != tt.want {
+				t.Errorf("containsOperator(%q) = %v, want %v", tt.input, got, tt.want)
+			}
 		})
 	}
 }

--- a/pkg/core/constants.go
+++ b/pkg/core/constants.go
@@ -91,6 +91,7 @@ const (
 	// Special function name constants for workflow key availability
 	FunctionAlways    = "always"
 	FunctionCanceled  = "canceled"
+	FunctionCancelled = "cancelled" // British English alias for canceled
 	FunctionFailure   = "failure"
 	FunctionHashFiles = "hashfiles"
 	FunctionSuccess   = "success"

--- a/pkg/expressions/semantic.go
+++ b/pkg/expressions/semantic.go
@@ -181,6 +181,13 @@ var BuiltinFuncSignatures = map[string][]*FuncSignature{
 		Ret:    BoolType{},
 		Params: []ExprType{},
 	}},
+	// cancelled is an alias for canceled (British English spelling)
+	// https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
+	"cancelled": {{
+		Name:   "cancelled",
+		Ret:    BoolType{},
+		Params: []ExprType{},
+	}},
 	"failure": {{
 		Name:   "failure",
 		Ret:    BoolType{},
@@ -483,9 +490,10 @@ func (sema *ExprSemanticsChecker) checkSpecialFunctionAvailability(n *FuncCallNo
 	// どの関数が特別で、どのワークフロー キーがそれらをサポートしているかを把握します。
 	//* https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
 	var SpecialFunctionNames = map[string][]string{
-		"always":   {"jobs.<job_id>.if", "jobs.<job_id>.steps.if"},
-		"canceled": {"jobs.<job_id>.if", "jobs.<job_id>.steps.if"},
-		"failure":  {"jobs.<job_id>.if", "jobs.<job_id>.steps.if"},
+		"always":    {"jobs.<job_id>.if", "jobs.<job_id>.steps.if"},
+		"canceled":  {"jobs.<job_id>.if", "jobs.<job_id>.steps.if"},
+		"cancelled": {"jobs.<job_id>.if", "jobs.<job_id>.steps.if"},
+		"failure":   {"jobs.<job_id>.if", "jobs.<job_id>.steps.if"},
 		"hashfiles": {"jobs.<job_id>.steps.continue-on-error",
 			"jobs.<job_id>.steps.env", "jobs.<job_id>.steps.if",
 			"jobs.<job_id>.steps.name", "jobs.<job_id>.steps.run",


### PR DESCRIPTION
## Summary
- Add `cancelled` function alias (British English spelling) to fix "undefined function" errors
- Fix `cond` rule to properly handle multiple `${{ }}` expression blocks
- Fix `cond` rule to allow operators outside `${{ }}` blocks

## Changes
1. **pkg/expressions/semantic.go**: Added `cancelled` to `BuiltinFuncSignatures` and `SpecialFunctionNames`
2. **pkg/core/constants.go**: Added `FunctionCancelled` constant  
3. **pkg/core/available.go**: Added `FunctionCancelled` to `KeyPathJobStepsIf` and `KeyPathJobIf`
4. **pkg/core/conditionalrule.go**: Improved condition validation logic to:
   - Skip validation when multiple `${{ }}` blocks exist (valid comparison expressions)
   - Skip validation when operators (`==`, `!=`, `&&`, `||`, etc.) exist outside blocks
5. **pkg/core/conditionalrule_test.go**: Added comprehensive tests for the fix

## Test Cases (False Positives Fixed)
```yaml
# These should NOT produce errors anymore:
if: ${{ github.event.repository.owner.id }} == ${{ github.event.sender.id }}
if: ${{ steps.disk.outputs.status }} == 'success' && !cancelled()
if: ${{ env.PACKAGED_STATUS }} == 'success' && !cancelled()
if: (!cancelled())
if: ${{ !cancelled() }}
```

Fixes #242