### PR TITLE
feat: add missing permissions detection to PermissionRule

### DIFF
--- a/pkg/core/permissionrule.go
+++ b/pkg/core/permissionrule.go
@@ -34,7 +34,7 @@ type PermissionRule struct {
 	isReusableWorkflow bool
 }
 
-// PermissionsRuleは新しいPermissionRuleのインスタンスを作成します。
+// PermissionsRule creates a new PermissionRule instance.
 func PermissionsRule() *PermissionRule {
 	return &PermissionRule{
 		BaseRule: BaseRule{
@@ -69,7 +69,7 @@ func (rule *PermissionRule) VisitWorkflowPre(n *ast.Workflow) error {
 	// Skip this check for reusable workflows as they inherit permissions from caller
 	if n.Permissions == nil && !rule.isReusableWorkflow {
 		pos := &ast.Position{Line: 1, Col: 1}
-		if n.BaseNode != nil {
+		if n.BaseNode != nil && n.BaseNode.Line > 0 {
 			pos = &ast.Position{Line: n.BaseNode.Line, Col: n.BaseNode.Column}
 		}
 		rule.Errorf(pos,

--- a/pkg/core/permissionrule_test.go
+++ b/pkg/core/permissionrule_test.go
@@ -240,6 +240,9 @@ func TestPermissionRule_MissingPermissions(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// When workflow_call is present with other triggers, it's treated as reusable.
+			// This is because the workflow can be called with inherited permissions,
+			// even if it also responds to other events.
 			name: "reusable workflow with other triggers - no error for workflow_call",
 			workflow: &ast.Workflow{
 				Name: &ast.String{Value: "reusable", Pos: &ast.Position{Line: 1, Col: 1}},


### PR DESCRIPTION
## Summary

- Add detection for workflows without explicit `permissions` block (based on CodeQL's `actions-missing-workflow-permissions` rule)
- Skip detection for reusable workflows (`workflow_call`) as they inherit permissions from caller
- Auto-fix adds `permissions: {}` with TODO comment for safety - users must explicitly add required permissions

## Changes

- `pkg/core/permissionrule.go`: Add missing permissions detection and auto-fix logic
- `pkg/core/permissionrule_test.go`: Add comprehensive tests for detection and auto-fix

## Auto-fix behavior

```yaml
# Before
name: Test
on: push
jobs: ...

# After
name: Test
on: push
# TODO: Review and add required permissions. Auto-fix sets empty (no permissions) for safety.
permissions: {}
jobs: ...
```

## Test plan

- [x] Unit tests pass
- [x] Detection works for workflows without permissions
- [x] Reusable workflows (workflow_call) are excluded
- [x] Auto-fix adds empty permissions with TODO comment

## References

- https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/

🤖 Generated with [Claude Code](https://claude.com/claude-code)