### PR TITLE
feat: add dangerous-triggers rule

### DIFF
--- a/pkg/core/codeinjection.go
+++ b/pkg/core/codeinjection.go
@@ -176,28 +176,7 @@ func (rule *CodeInjectionRule) VisitJobPre(node *ast.Job) error {
 
 // hasPrivilegedTriggers checks if the workflow has privileged triggers
 func (rule *CodeInjectionRule) hasPrivilegedTriggers() bool {
-	if rule.workflow == nil || rule.workflow.On == nil {
-		return false
-	}
-
-	// Check for privileged triggers
-	// These triggers have write access or run with secrets
-	privilegedTriggers := map[string]bool{
-		"pull_request_target": true,
-		"workflow_run":        true,
-		"issue_comment":       true,
-		"issues":              true,
-		"discussion_comment":  true,
-	}
-
-	for _, event := range rule.workflow.On {
-		eventName := strings.ToLower(event.EventName())
-		if privilegedTriggers[eventName] {
-			return true
-		}
-	}
-
-	return false
+	return HasPrivilegedTriggers(rule.workflow)
 }
 
 // RuleNames implements StepFixer interface

--- a/pkg/core/dangeroustriggersrule.go
+++ b/pkg/core/dangeroustriggersrule.go
@@ -1,0 +1,255 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// Severity constants for dangerous triggers rules
+const (
+	SeverityCritical = "critical"
+	SeverityMedium   = "medium"
+)
+
+// MitigationStatus represents the security mitigations applied to a workflow
+// with privileged triggers. These mitigations help reduce the risk of security
+// vulnerabilities when using dangerous workflow triggers like pull_request_target.
+type MitigationStatus struct {
+	// HasPermissionsRestriction indicates if workflow permissions are explicitly restricted
+	// (not set to write-all). This is the most important mitigation. (+3 points)
+	HasPermissionsRestriction bool
+
+	// HasEnvironmentProtection indicates if the job uses environment protection rules.
+	// Environment protection provides an additional approval gate. (+2 points)
+	HasEnvironmentProtection bool
+
+	// HasLabelCondition indicates if the workflow has label-based conditions
+	// to restrict execution to approved PRs. (+1 point)
+	HasLabelCondition bool
+
+	// HasActorRestriction indicates if the workflow checks the actor
+	// (e.g., github.actor) to restrict who can trigger it. (+1 point)
+	HasActorRestriction bool
+
+	// HasForkCheck indicates if the workflow checks for forks using
+	// github.event.pull_request.head.repo.fork or similar. (+1 point)
+	HasForkCheck bool
+}
+
+// Score calculates the total mitigation score based on the applied security measures.
+// Higher scores indicate better security posture:
+//   - 0: No mitigations (critical risk)
+//   - 1-2: Minimal mitigations (medium risk)
+//   - 3+: Adequate mitigations (acceptable risk)
+//
+// Example:
+//
+//	status := MitigationStatus{
+//	    HasPermissionsRestriction: true,
+//	    HasEnvironmentProtection: true,
+//	}
+//	score := status.Score() // returns 5
+func (m *MitigationStatus) Score() int {
+	score := 0
+
+	if m.HasPermissionsRestriction {
+		score += 3
+	}
+	if m.HasEnvironmentProtection {
+		score += 2
+	}
+	if m.HasLabelCondition {
+		score += 1
+	}
+	if m.HasActorRestriction {
+		score += 1
+	}
+	if m.HasForkCheck {
+		score += 1
+	}
+
+	return score
+}
+
+// Severity returns the severity level based on the mitigation score:
+//   - "critical": No mitigations (score = 0)
+//   - "medium": Minimal mitigations (score = 1-2)
+//   - "": Adequate mitigations (score >= 3)
+//
+// Example:
+//
+//	status := MitigationStatus{} // no mitigations
+//	severity := status.Severity() // returns "critical"
+func (m *MitigationStatus) Severity() string {
+	score := m.Score()
+
+	if score == 0 {
+		return SeverityCritical
+	}
+	if score <= 2 {
+		return SeverityMedium
+	}
+
+	return ""
+}
+
+// FoundMitigations returns a list of mitigation names that are currently applied.
+// This is useful for generating user-friendly messages about what security measures
+// are in place.
+//
+// Example:
+//
+//	status := MitigationStatus{
+//	    HasPermissionsRestriction: true,
+//	    HasLabelCondition: true,
+//	}
+//	mitigations := status.FoundMitigations()
+//	// returns []string{"permissions restriction", "label condition"}
+func (m *MitigationStatus) FoundMitigations() []string {
+	var mitigations []string
+
+	if m.HasPermissionsRestriction {
+		mitigations = append(mitigations, "permissions restriction")
+	}
+	if m.HasEnvironmentProtection {
+		mitigations = append(mitigations, "environment protection")
+	}
+	if m.HasLabelCondition {
+		mitigations = append(mitigations, "label condition")
+	}
+	if m.HasActorRestriction {
+		mitigations = append(mitigations, "actor restriction")
+	}
+	if m.HasForkCheck {
+		mitigations = append(mitigations, "fork check")
+	}
+
+	return mitigations
+}
+
+// CheckMitigations analyzes a workflow for security mitigations applied to
+// privileged triggers. It examines:
+//   - Workflow and job permissions
+//   - Environment protection rules
+//   - Job and step conditions for safety checks
+//
+// Returns a MitigationStatus indicating which security measures are present.
+//
+// Example:
+//
+//	workflow := &ast.Workflow{
+//	    Permissions: &ast.Permissions{
+//	        All: &ast.String{Value: "read-all"},
+//	    },
+//	    // ...
+//	}
+//	status := CheckMitigations(workflow)
+//	// status.HasPermissionsRestriction will be true
+func CheckMitigations(workflow *ast.Workflow) MitigationStatus {
+	if workflow == nil {
+		return MitigationStatus{}
+	}
+
+	status := MitigationStatus{}
+
+	// Check workflow-level permissions
+	if hasPermissionsRestriction(workflow.Permissions) {
+		status.HasPermissionsRestriction = true
+	}
+
+	// Check job-level mitigations
+	for _, job := range workflow.Jobs {
+		if job == nil {
+			continue
+		}
+
+		// Check job-level permissions
+		if !status.HasPermissionsRestriction && hasPermissionsRestriction(job.Permissions) {
+			status.HasPermissionsRestriction = true
+		}
+
+		// Check for environment protection
+		if !status.HasEnvironmentProtection && job.Environment != nil && job.Environment.Name != nil {
+			status.HasEnvironmentProtection = true
+		}
+
+		// Check job condition for mitigations
+		if job.If != nil && job.If.Value != "" {
+			checkConditionForMitigations(job.If.Value, &status)
+		}
+
+		// Check step conditions for mitigations
+		for _, step := range job.Steps {
+			if step == nil || step.If == nil || step.If.Value == "" {
+				continue
+			}
+			checkConditionForMitigations(step.If.Value, &status)
+		}
+	}
+
+	return status
+}
+
+// hasPermissionsRestriction checks if permissions are explicitly set and not write-all.
+// Returns true if permissions restrict write access, false if write-all or not set.
+func hasPermissionsRestriction(perms *ast.Permissions) bool {
+	if perms == nil {
+		return false
+	}
+
+	// If permissions.All is set
+	if perms.All != nil && perms.All.Value != "" {
+		value := strings.ToLower(perms.All.Value)
+		// Only "read-all" or empty is a restriction (write-all is not)
+		return value == "read-all" || value == "{}" || value == "none"
+	}
+
+	// If individual scopes are set, it's a restriction (not write-all)
+	if len(perms.Scopes) > 0 {
+		return true
+	}
+
+	return false
+}
+
+// checkConditionForMitigations checks a condition string for security-related patterns
+// and updates the MitigationStatus accordingly. It looks for:
+//   - Label checks: contains(github.event.pull_request.labels.*.name, 'safe-to-run')
+//   - Actor restrictions: github.actor == 'trusted-user'
+//   - Fork checks: github.event.pull_request.head.repo.fork == false
+//
+// The status parameter is modified in-place to reflect found mitigations.
+func checkConditionForMitigations(condition string, status *MitigationStatus) {
+	if condition == "" || status == nil {
+		return
+	}
+
+	// Convert to lowercase for case-insensitive matching
+	lowerCondition := strings.ToLower(condition)
+
+	// Check for label-based conditions
+	// Pattern: contains(...labels...) or github.event.pull_request.labels
+	if !status.HasLabelCondition {
+		if strings.Contains(lowerCondition, "labels") {
+			status.HasLabelCondition = true
+		}
+	}
+
+	// Check for actor restrictions
+	// Pattern: github.actor, github.triggering_actor, etc.
+	if !status.HasActorRestriction {
+		if strings.Contains(lowerCondition, "github.actor") ||
+			strings.Contains(lowerCondition, "github.triggering_actor") {
+			status.HasActorRestriction = true
+		}
+	}
+
+	// Check for fork checks
+	// Pattern: github.event.pull_request.head.repo.fork
+	if !status.HasForkCheck {
+		if strings.Contains(lowerCondition, "fork") {
+			status.HasForkCheck = true
+		}
+	}
+}

--- a/pkg/core/dangeroustriggersrule_test.go
+++ b/pkg/core/dangeroustriggersrule_test.go
@@ -1,0 +1,717 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+func TestMitigationStatusScore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status MitigationStatus
+		want   int
+	}{
+		{
+			name:   "no mitigations",
+			status: MitigationStatus{},
+			want:   0,
+		},
+		{
+			name: "permissions only",
+			status: MitigationStatus{
+				HasPermissionsRestriction: true,
+			},
+			want: 3,
+		},
+		{
+			name: "environment only",
+			status: MitigationStatus{
+				HasEnvironmentProtection: true,
+			},
+			want: 2,
+		},
+		{
+			name: "label only",
+			status: MitigationStatus{
+				HasLabelCondition: true,
+			},
+			want: 1,
+		},
+		{
+			name: "actor only",
+			status: MitigationStatus{
+				HasActorRestriction: true,
+			},
+			want: 1,
+		},
+		{
+			name: "fork only",
+			status: MitigationStatus{
+				HasForkCheck: true,
+			},
+			want: 1,
+		},
+		{
+			name: "all mitigations",
+			status: MitigationStatus{
+				HasPermissionsRestriction: true,
+				HasEnvironmentProtection:  true,
+				HasLabelCondition:         true,
+				HasActorRestriction:       true,
+				HasForkCheck:              true,
+			},
+			want: 8,
+		},
+		{
+			name: "label and actor (score 2)",
+			status: MitigationStatus{
+				HasLabelCondition:   true,
+				HasActorRestriction: true,
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.status.Score()
+			if got != tt.want {
+				t.Errorf("Score() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMitigationStatusSeverity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status MitigationStatus
+		want   string
+	}{
+		{
+			name:   "no mitigations = critical",
+			status: MitigationStatus{},
+			want:   SeverityCritical,
+		},
+		{
+			name: "score 1 = medium",
+			status: MitigationStatus{
+				HasLabelCondition: true,
+			},
+			want: SeverityMedium,
+		},
+		{
+			name: "score 2 = medium",
+			status: MitigationStatus{
+				HasLabelCondition:   true,
+				HasActorRestriction: true,
+			},
+			want: SeverityMedium,
+		},
+		{
+			name: "score 3 = no warning",
+			status: MitigationStatus{
+				HasPermissionsRestriction: true,
+			},
+			want: "",
+		},
+		{
+			name: "score 5 = no warning",
+			status: MitigationStatus{
+				HasPermissionsRestriction: true,
+				HasEnvironmentProtection:  true,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.status.Severity()
+			if got != tt.want {
+				t.Errorf("Severity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMitigationStatusFoundMitigations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status MitigationStatus
+		want   []string
+	}{
+		{
+			name:   "no mitigations",
+			status: MitigationStatus{},
+			want:   nil,
+		},
+		{
+			name: "all mitigations",
+			status: MitigationStatus{
+				HasPermissionsRestriction: true,
+				HasEnvironmentProtection:  true,
+				HasLabelCondition:         true,
+				HasActorRestriction:       true,
+				HasForkCheck:              true,
+			},
+			want: []string{
+				"permissions restriction",
+				"environment protection",
+				"label condition",
+				"actor restriction",
+				"fork check",
+			},
+		},
+		{
+			name: "partial mitigations",
+			status: MitigationStatus{
+				HasLabelCondition:   true,
+				HasActorRestriction: true,
+			},
+			want: []string{
+				"label condition",
+				"actor restriction",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.status.FoundMitigations()
+
+			if len(got) != len(tt.want) {
+				t.Errorf("FoundMitigations() returned %d items, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i, name := range got {
+				if name != tt.want[i] {
+					t.Errorf("FoundMitigations()[%d] = %v, want %v", i, name, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCheckMitigations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow *ast.Workflow
+		want     MitigationStatus
+	}{
+		{
+			name:     "nil workflow",
+			workflow: nil,
+			want:     MitigationStatus{},
+		},
+		{
+			name: "workflow with read-all permissions",
+			workflow: &ast.Workflow{
+				Permissions: &ast.Permissions{
+					All: &ast.String{Value: "read-all"},
+				},
+			},
+			want: MitigationStatus{
+				HasPermissionsRestriction: true,
+			},
+		},
+		{
+			name: "workflow with empty permissions",
+			workflow: &ast.Workflow{
+				Permissions: &ast.Permissions{
+					All: &ast.String{Value: "{}"},
+				},
+			},
+			want: MitigationStatus{
+				HasPermissionsRestriction: true,
+			},
+		},
+		{
+			name: "workflow with scoped permissions",
+			workflow: &ast.Workflow{
+				Permissions: &ast.Permissions{
+					Scopes: map[string]*ast.PermissionScope{
+						"contents": {Name: &ast.String{Value: "contents"}, Value: &ast.String{Value: "read"}},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasPermissionsRestriction: true,
+			},
+		},
+		{
+			name: "workflow with write-all permissions (not a restriction)",
+			workflow: &ast.Workflow{
+				Permissions: &ast.Permissions{
+					All: &ast.String{Value: "write-all"},
+				},
+			},
+			want: MitigationStatus{},
+		},
+		{
+			name: "job with environment protection",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"deploy": {
+						Environment: &ast.Environment{
+							Name: &ast.String{Value: "production"},
+						},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasEnvironmentProtection: true,
+			},
+		},
+		{
+			name: "job with label condition",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						If: &ast.String{Value: "contains(github.event.pull_request.labels.*.name, 'safe-to-run')"},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasLabelCondition: true,
+			},
+		},
+		{
+			name: "job with actor restriction",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						If: &ast.String{Value: "github.actor == 'dependabot[bot]'"},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasActorRestriction: true,
+			},
+		},
+		{
+			name: "job with fork check",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						If: &ast.String{Value: "github.event.pull_request.head.repo.fork == false"},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasForkCheck: true,
+			},
+		},
+		{
+			name: "step with label condition",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						Steps: []*ast.Step{
+							{
+								If: &ast.String{Value: "contains(github.event.pull_request.labels.*.name, 'approved')"},
+							},
+						},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasLabelCondition: true,
+			},
+		},
+		{
+			name: "job-level permissions (not workflow-level)",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						Permissions: &ast.Permissions{
+							All: &ast.String{Value: "read-all"},
+						},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasPermissionsRestriction: true,
+			},
+		},
+		{
+			name: "multiple mitigations",
+			workflow: &ast.Workflow{
+				Permissions: &ast.Permissions{
+					All: &ast.String{Value: "read-all"},
+				},
+				Jobs: map[string]*ast.Job{
+					"deploy": {
+						Environment: &ast.Environment{
+							Name: &ast.String{Value: "production"},
+						},
+						If: &ast.String{Value: "contains(github.event.pull_request.labels.*.name, 'approved')"},
+					},
+				},
+			},
+			want: MitigationStatus{
+				HasPermissionsRestriction: true,
+				HasEnvironmentProtection:  true,
+				HasLabelCondition:         true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CheckMitigations(tt.workflow)
+
+			if got.HasPermissionsRestriction != tt.want.HasPermissionsRestriction {
+				t.Errorf("HasPermissionsRestriction = %v, want %v", got.HasPermissionsRestriction, tt.want.HasPermissionsRestriction)
+			}
+			if got.HasEnvironmentProtection != tt.want.HasEnvironmentProtection {
+				t.Errorf("HasEnvironmentProtection = %v, want %v", got.HasEnvironmentProtection, tt.want.HasEnvironmentProtection)
+			}
+			if got.HasLabelCondition != tt.want.HasLabelCondition {
+				t.Errorf("HasLabelCondition = %v, want %v", got.HasLabelCondition, tt.want.HasLabelCondition)
+			}
+			if got.HasActorRestriction != tt.want.HasActorRestriction {
+				t.Errorf("HasActorRestriction = %v, want %v", got.HasActorRestriction, tt.want.HasActorRestriction)
+			}
+			if got.HasForkCheck != tt.want.HasForkCheck {
+				t.Errorf("HasForkCheck = %v, want %v", got.HasForkCheck, tt.want.HasForkCheck)
+			}
+		})
+	}
+}
+
+func TestDangerousTriggersCriticalRule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow *ast.Workflow
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "critical: pull_request_target without mitigations",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "dangerous trigger (critical)",
+		},
+		{
+			name: "critical: workflow_run without mitigations",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "workflow_run", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "dangerous trigger (critical)",
+		},
+		{
+			name: "safe: pull_request_target with permissions restriction",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Permissions: &ast.Permissions{
+					All: &ast.String{Value: "read-all", Pos: &ast.Position{Line: 3, Col: 1}},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "safe: normal trigger (pull_request)",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "medium (not critical): pull_request_target with label condition",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						If: &ast.String{Value: "contains(github.event.pull_request.labels.*.name, 'safe')"},
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false, // This is medium, not critical
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rule := NewDangerousTriggersCriticalRule()
+			err := rule.VisitWorkflowPre(tt.workflow)
+			if err != nil {
+				t.Fatalf("VisitWorkflowPre returned error: %v", err)
+			}
+
+			errs := rule.Errors()
+			if tt.wantErr {
+				if len(errs) == 0 {
+					t.Error("expected error but got none")
+					return
+				}
+				if !strings.Contains(errs[0].Description, tt.errMsg) {
+					t.Errorf("error message = %q, want to contain %q", errs[0].Description, tt.errMsg)
+				}
+			} else {
+				if len(errs) > 0 {
+					t.Errorf("expected no error but got: %v", errs[0].Description)
+				}
+			}
+		})
+	}
+}
+
+func TestDangerousTriggersMediumRule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow *ast.Workflow
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "medium: pull_request_target with label condition only",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						If: &ast.String{Value: "contains(github.event.pull_request.labels.*.name, 'safe')"},
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "dangerous trigger (medium)",
+		},
+		{
+			name: "medium: workflow_run with actor restriction only",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "workflow_run", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						If: &ast.String{Value: "github.actor == 'dependabot[bot]'"},
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "dangerous trigger (medium)",
+		},
+		{
+			name: "safe: pull_request_target with permissions restriction",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Permissions: &ast.Permissions{
+					All: &ast.String{Value: "read-all", Pos: &ast.Position{Line: 3, Col: 1}},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false, // score >= 3, no warning
+		},
+		{
+			name: "critical (not medium): no mitigations",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false, // This is critical, not medium
+		},
+		{
+			name: "safe: normal trigger (push)",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "push", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rule := NewDangerousTriggersMediumRule()
+			err := rule.VisitWorkflowPre(tt.workflow)
+			if err != nil {
+				t.Fatalf("VisitWorkflowPre returned error: %v", err)
+			}
+
+			errs := rule.Errors()
+			if tt.wantErr {
+				if len(errs) == 0 {
+					t.Error("expected error but got none")
+					return
+				}
+				if !strings.Contains(errs[0].Description, tt.errMsg) {
+					t.Errorf("error message = %q, want to contain %q", errs[0].Description, tt.errMsg)
+				}
+			} else {
+				if len(errs) > 0 {
+					t.Errorf("expected no error but got: %v", errs[0].Description)
+				}
+			}
+		})
+	}
+}

--- a/pkg/core/dangeroustriggersrulecritical.go
+++ b/pkg/core/dangeroustriggersrulecritical.go
@@ -1,0 +1,160 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+	"gopkg.in/yaml.v3"
+)
+
+// DangerousTriggersCriticalRule detects workflows using privileged triggers
+// (pull_request_target, workflow_run, issue_comment, etc.) without any
+// security mitigations. This is a critical security risk.
+//
+// References:
+// - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+// - https://docs.zizmor.sh/audits/#dangerous-triggers
+type DangerousTriggersCriticalRule struct {
+	BaseRule
+	workflow *ast.Workflow
+}
+
+// NewDangerousTriggersCriticalRule creates a new DangerousTriggersCriticalRule instance.
+func NewDangerousTriggersCriticalRule() *DangerousTriggersCriticalRule {
+	return &DangerousTriggersCriticalRule{
+		BaseRule: BaseRule{
+			RuleName: "dangerous-triggers-critical",
+			RuleDesc: "Detects workflows using privileged triggers without any security mitigations. These triggers grant elevated privileges (write access, secrets) that can be exploited by malicious actors. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",
+		},
+	}
+}
+
+// VisitWorkflowPre checks for privileged triggers without mitigations
+func (rule *DangerousTriggersCriticalRule) VisitWorkflowPre(node *ast.Workflow) error {
+	rule.workflow = node
+
+	// Check if workflow has privileged triggers
+	if !HasPrivilegedTriggers(node) {
+		return nil
+	}
+
+	// Check mitigations
+	status := CheckMitigations(node)
+
+	// Only report if severity is critical (score = 0)
+	if status.Severity() != SeverityCritical {
+		return nil
+	}
+
+	// Get the privileged trigger names for the error message
+	triggerNames := GetPrivilegedTriggerNames(node)
+	triggerEvents := GetPrivilegedTriggerEvents(node)
+
+	// Generate error message
+	triggerList := strings.Join(triggerNames, ", ")
+	msg := fmt.Sprintf(
+		"dangerous trigger (critical): workflow uses privileged trigger(s) [%s] without any security mitigations. "+
+			"These triggers grant write access and secrets access to potentially untrusted code. "+
+			"Add at least one mitigation: restrict permissions (permissions: read-all or permissions: {}), "+
+			"use environment protection, add label conditions, or check github.actor. "+
+			"See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",
+		triggerList,
+	)
+
+	// Report error at the position of the first privileged trigger
+	pos := getEventPosition(triggerEvents, node)
+
+	rule.Errorf(pos, "%s", msg)
+
+	// Add auto-fixer to add permissions: {} to the workflow
+	rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
+		return addEmptyPermissionsToWorkflow(node)
+	}))
+
+	return nil
+}
+
+// getEventPosition returns the position of the first privileged trigger event,
+// or falls back to the workflow name position if not available.
+func getEventPosition(events []ast.Event, workflow *ast.Workflow) *ast.Position {
+	for _, event := range events {
+		// Try to get position from WebhookEvent
+		if webhookEvent, ok := event.(*ast.WebhookEvent); ok && webhookEvent.Pos != nil {
+			return webhookEvent.Pos
+		}
+	}
+
+	// Fallback to workflow name position
+	if workflow != nil && workflow.Name != nil {
+		return workflow.Name.Pos
+	}
+
+	return nil
+}
+
+// addEmptyPermissionsToWorkflow adds permissions: {} to a workflow
+func addEmptyPermissionsToWorkflow(workflow *ast.Workflow) error {
+	if workflow == nil {
+		return nil
+	}
+
+	// Update AST
+	workflow.Permissions = &ast.Permissions{
+		All: &ast.String{
+			Value: "{}",
+			Pos:   &ast.Position{Line: 1, Col: 1},
+		},
+	}
+
+	// Update the YAML node if available
+	if workflow.BaseNode != nil {
+		return addPermissionsToYAMLNode(workflow.BaseNode)
+	}
+
+	return nil
+}
+
+// addPermissionsToYAMLNode adds permissions: {} to the YAML node
+func addPermissionsToYAMLNode(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	// Check if permissions already exists
+	for i := 0; i < len(node.Content); i += 2 {
+		if i+1 < len(node.Content) && node.Content[i].Value == "permissions" {
+			// Already exists, don't add again
+			return nil
+		}
+	}
+
+	// Find position to insert (after 'on:' if possible, otherwise at start)
+	insertIdx := 0
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == "on" {
+			insertIdx = i + 2
+			break
+		}
+	}
+
+	// Create permissions: {} node
+	keyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: "permissions",
+		Tag:   "!!str",
+	}
+	valueNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+	}
+
+	// Insert at the appropriate position
+	newContent := make([]*yaml.Node, 0, len(node.Content)+2)
+	newContent = append(newContent, node.Content[:insertIdx]...)
+	newContent = append(newContent, keyNode, valueNode)
+	newContent = append(newContent, node.Content[insertIdx:]...)
+	node.Content = newContent
+
+	return nil
+}

--- a/pkg/core/dangeroustriggersrulemedium.go
+++ b/pkg/core/dangeroustriggersrulemedium.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// DangerousTriggersMediumRule detects workflows using privileged triggers
+// (pull_request_target, workflow_run, issue_comment, etc.) with only partial
+// security mitigations. This is a medium security risk.
+//
+// References:
+// - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+// - https://docs.zizmor.sh/audits/#dangerous-triggers
+type DangerousTriggersMediumRule struct {
+	BaseRule
+	workflow *ast.Workflow
+}
+
+// NewDangerousTriggersMediumRule creates a new DangerousTriggersMediumRule instance.
+func NewDangerousTriggersMediumRule() *DangerousTriggersMediumRule {
+	return &DangerousTriggersMediumRule{
+		BaseRule: BaseRule{
+			RuleName: "dangerous-triggers-medium",
+			RuleDesc: "Detects workflows using privileged triggers with only partial security mitigations. Consider adding more mitigations for defense in depth. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",
+		},
+	}
+}
+
+// VisitWorkflowPre checks for privileged triggers with partial mitigations
+func (rule *DangerousTriggersMediumRule) VisitWorkflowPre(node *ast.Workflow) error {
+	rule.workflow = node
+
+	// Check if workflow has privileged triggers
+	if !HasPrivilegedTriggers(node) {
+		return nil
+	}
+
+	// Check mitigations
+	status := CheckMitigations(node)
+
+	// Only report if severity is medium (score = 1-2)
+	if status.Severity() != SeverityMedium {
+		return nil
+	}
+
+	// Get the privileged trigger names for the error message
+	triggerNames := GetPrivilegedTriggerNames(node)
+	triggerEvents := GetPrivilegedTriggerEvents(node)
+
+	// Get found mitigations for the message
+	foundMitigations := status.FoundMitigations()
+	mitigationList := strings.Join(foundMitigations, ", ")
+
+	// Generate error message
+	triggerList := strings.Join(triggerNames, ", ")
+	msg := fmt.Sprintf(
+		"dangerous trigger (medium): workflow uses privileged trigger(s) [%s] with partial mitigations (%s). "+
+			"Consider adding more mitigations for defense in depth: restrict permissions (permissions: read-all), "+
+			"use environment protection, add label conditions, or check github.actor. "+
+			"See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",
+		triggerList,
+		mitigationList,
+	)
+
+	// Report error at the position of the first privileged trigger
+	pos := getEventPosition(triggerEvents, node)
+
+	rule.Errorf(pos, "%s", msg)
+
+	// Add auto-fixer if permissions are not already restricted
+	if !status.HasPermissionsRestriction {
+		rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
+			return addEmptyPermissionsToWorkflow(node)
+		}))
+	}
+
+	return nil
+}

--- a/pkg/core/envpathinjection.go
+++ b/pkg/core/envpathinjection.go
@@ -171,28 +171,7 @@ func (rule *EnvPathInjectionRule) VisitJobPre(node *ast.Job) error {
 
 // hasPrivilegedTriggers checks if the workflow has privileged triggers
 func (rule *EnvPathInjectionRule) hasPrivilegedTriggers() bool {
-	if rule.workflow == nil || rule.workflow.On == nil {
-		return false
-	}
-
-	// Check for privileged triggers
-	// These triggers have write access or run with secrets
-	privilegedTriggers := map[string]bool{
-		"pull_request_target": true,
-		"workflow_run":        true,
-		"issue_comment":       true,
-		"issues":              true,
-		"discussion_comment":  true,
-	}
-
-	for _, event := range rule.workflow.On {
-		eventName := strings.ToLower(event.EventName())
-		if privilegedTriggers[eventName] {
-			return true
-		}
-	}
-
-	return false
+	return HasPrivilegedTriggers(rule.workflow)
 }
 
 // RuleNames implements StepFixer interface

--- a/pkg/core/envvarinjection.go
+++ b/pkg/core/envvarinjection.go
@@ -171,28 +171,7 @@ func (rule *EnvVarInjectionRule) VisitJobPre(node *ast.Job) error {
 
 // hasPrivilegedTriggers checks if the workflow has privileged triggers
 func (rule *EnvVarInjectionRule) hasPrivilegedTriggers() bool {
-	if rule.workflow == nil || rule.workflow.On == nil {
-		return false
-	}
-
-	// Check for privileged triggers
-	// These triggers have write access or run with secrets
-	privilegedTriggers := map[string]bool{
-		"pull_request_target": true,
-		"workflow_run":        true,
-		"issue_comment":       true,
-		"issues":              true,
-		"discussion_comment":  true,
-	}
-
-	for _, event := range rule.workflow.On {
-		eventName := strings.ToLower(event.EventName())
-		if privilegedTriggers[eventName] {
-			return true
-		}
-	}
-
-	return false
+	return HasPrivilegedTriggers(rule.workflow)
 }
 
 // RuleNames implements StepFixer interface

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -515,10 +515,10 @@ func makeRules(filePath string, localActions *LocalActionsMetadataCache, localRe
 		CodeInjectionMediumRule(),      // Detects untrusted input in normal workflow triggers
 		EnvVarInjectionCriticalRule(),  // Detects envvar injection in privileged workflow triggers
 		EnvVarInjectionMediumRule(),    // Detects envvar injection in normal workflow triggers
-		EnvPathInjectionCriticalRule(),  // Detects PATH injection in privileged workflow triggers
-		EnvPathInjectionMediumRule(),    // Detects PATH injection in normal workflow triggers
-		OutputClobberingCriticalRule(),  // Detects output clobbering in privileged workflow triggers
-		OutputClobberingMediumRule(),    // Detects output clobbering in normal workflow triggers
+		EnvPathInjectionCriticalRule(), // Detects PATH injection in privileged workflow triggers
+		EnvPathInjectionMediumRule(),   // Detects PATH injection in normal workflow triggers
+		OutputClobberingCriticalRule(), // Detects output clobbering in privileged workflow triggers
+		OutputClobberingMediumRule(),   // Detects output clobbering in normal workflow triggers
 		CommitShaRule(),
 		ArtifactPoisoningRule(),
 		NewArtifactPoisoningMediumRule(),
@@ -544,6 +544,8 @@ func makeRules(filePath string, localActions *LocalActionsMetadataCache, localRe
 		NewSecretsInArtifactsRule(),                                   // Detects secrets exposure in artifact uploads (CWE-312)
 		NewSecretExfiltrationRule(),                                   // Detects secret exfiltration via network commands
 		NewReusableWorkflowTaintRule(filePath, localReusableWorkflow), // Detects untrusted inputs passed to reusable workflows
+		NewDangerousTriggersCriticalRule(),                            // Detects dangerous triggers without any mitigations
+		NewDangerousTriggersMediumRule(),                              // Detects dangerous triggers with partial mitigations
 	}
 }
 

--- a/pkg/core/outputclobbering.go
+++ b/pkg/core/outputclobbering.go
@@ -231,28 +231,7 @@ func (rule *OutputClobberingRule) usesHeredocSyntax(lines []string, currentLineI
 
 // hasPrivilegedTriggers checks if the workflow has privileged triggers
 func (rule *OutputClobberingRule) hasPrivilegedTriggers() bool {
-	if rule.workflow == nil || rule.workflow.On == nil {
-		return false
-	}
-
-	// Check for privileged triggers
-	// These triggers have write access or run with secrets
-	privilegedTriggers := map[string]bool{
-		"pull_request_target": true,
-		"workflow_run":        true,
-		"issue_comment":       true,
-		"issues":              true,
-		"discussion_comment":  true,
-	}
-
-	for _, event := range rule.workflow.On {
-		eventName := strings.ToLower(event.EventName())
-		if privilegedTriggers[eventName] {
-			return true
-		}
-	}
-
-	return false
+	return HasPrivilegedTriggers(rule.workflow)
 }
 
 // RuleNames implements StepFixer interface

--- a/pkg/core/privilegedtriggers.go
+++ b/pkg/core/privilegedtriggers.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// PrivilegedTriggers contains the list of workflow triggers that grant elevated privileges.
+// These triggers have write access to the repository or can access secrets, making them
+// potentially dangerous when combined with untrusted input.
+//
+// References:
+// - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+// - https://docs.zizmor.sh/audits/#dangerous-triggers
+var PrivilegedTriggers = map[string]bool{
+	"pull_request_target": true, // Has write access and secrets, triggered by untrusted PRs
+	"workflow_run":        true, // Executes with elevated privileges after another workflow
+	"issue_comment":       true, // Triggered by untrusted issue/PR comments
+	"issues":              true, // Can be triggered by external users
+	"discussion_comment":  true, // Triggered by untrusted discussion comments
+}
+
+// HasPrivilegedTriggers checks if a workflow has any privileged triggers.
+// It returns true if any of the workflow's triggers are in the PrivilegedTriggers list.
+//
+// Example:
+//
+//	workflow := &ast.Workflow{
+//	    On: []ast.Event{
+//	        &ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+//	    },
+//	}
+//	if HasPrivilegedTriggers(workflow) {
+//	    // Handle privileged workflow
+//	}
+func HasPrivilegedTriggers(workflow *ast.Workflow) bool {
+	if workflow == nil || workflow.On == nil {
+		return false
+	}
+
+	for _, event := range workflow.On {
+		eventName := strings.ToLower(event.EventName())
+		if PrivilegedTriggers[eventName] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetPrivilegedTriggerNames returns a slice of privileged trigger names found in the workflow.
+// Returns an empty slice if no privileged triggers are found.
+//
+// Example:
+//
+//	workflow := &ast.Workflow{
+//	    On: []ast.Event{
+//	        &ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+//	        &ast.WebhookEvent{Hook: &ast.String{Value: "workflow_run"}},
+//	    },
+//	}
+//	triggers := GetPrivilegedTriggerNames(workflow)
+//	// triggers = []string{"pull_request_target", "workflow_run"}
+func GetPrivilegedTriggerNames(workflow *ast.Workflow) []string {
+	if workflow == nil || workflow.On == nil {
+		return nil
+	}
+
+	var triggers []string
+	for _, event := range workflow.On {
+		eventName := strings.ToLower(event.EventName())
+		if PrivilegedTriggers[eventName] {
+			triggers = append(triggers, eventName)
+		}
+	}
+
+	return triggers
+}
+
+// GetPrivilegedTriggerEvents returns the Event objects for privileged triggers in the workflow.
+// This is useful when you need access to the full event configuration (e.g., for position info).
+//
+// Example:
+//
+//	events := GetPrivilegedTriggerEvents(workflow)
+//	for _, event := range events {
+//	    pos := event.Pos() // Get position for error reporting
+//	}
+func GetPrivilegedTriggerEvents(workflow *ast.Workflow) []ast.Event {
+	if workflow == nil || workflow.On == nil {
+		return nil
+	}
+
+	var events []ast.Event
+	for _, event := range workflow.On {
+		eventName := strings.ToLower(event.EventName())
+		if PrivilegedTriggers[eventName] {
+			events = append(events, event)
+		}
+	}
+
+	return events
+}

--- a/pkg/core/privilegedtriggers_test.go
+++ b/pkg/core/privilegedtriggers_test.go
@@ -1,0 +1,330 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+func TestHasPrivilegedTriggers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow *ast.Workflow
+		want     bool
+	}{
+		{
+			name:     "nil workflow",
+			workflow: nil,
+			want:     false,
+		},
+		{
+			name: "nil On",
+			workflow: &ast.Workflow{
+				On: nil,
+			},
+			want: false,
+		},
+		{
+			name: "empty On",
+			workflow: &ast.Workflow{
+				On: []ast.Event{},
+			},
+			want: false,
+		},
+		{
+			name: "pull_request_target is privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "workflow_run is privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "workflow_run"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "issue_comment is privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "issue_comment"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "issues is privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "issues"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "discussion_comment is privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "discussion_comment"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pull_request is not privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "push is not privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "push"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "schedule is not privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.ScheduledEvent{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "mixed triggers with one privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "mixed triggers all non-privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "push"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "case insensitive - uppercase",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "PULL_REQUEST_TARGET"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "case insensitive - mixed case",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "Pull_Request_Target"}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := HasPrivilegedTriggers(tt.workflow)
+			if got != tt.want {
+				t.Errorf("HasPrivilegedTriggers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPrivilegedTriggerNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow *ast.Workflow
+		want     []string
+	}{
+		{
+			name:     "nil workflow",
+			workflow: nil,
+			want:     nil,
+		},
+		{
+			name: "no privileged triggers",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "push"}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "single privileged trigger",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+				},
+			},
+			want: []string{"pull_request_target"},
+		},
+		{
+			name: "multiple privileged triggers",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "workflow_run"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "issue_comment"}},
+				},
+			},
+			want: []string{"pull_request_target", "workflow_run", "issue_comment"},
+		},
+		{
+			name: "mixed privileged and non-privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "push"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request"}},
+				},
+			},
+			want: []string{"pull_request_target"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := GetPrivilegedTriggerNames(tt.workflow)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("GetPrivilegedTriggerNames() returned %d items, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i, name := range got {
+				if name != tt.want[i] {
+					t.Errorf("GetPrivilegedTriggerNames()[%d] = %v, want %v", i, name, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetPrivilegedTriggerEvents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		workflow  *ast.Workflow
+		wantCount int
+	}{
+		{
+			name:      "nil workflow",
+			workflow:  nil,
+			wantCount: 0,
+		},
+		{
+			name: "no privileged triggers",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request"}},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "single privileged trigger",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "multiple privileged triggers",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+					&ast.WebhookEvent{Hook: &ast.String{Value: "workflow_run"}},
+				},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := GetPrivilegedTriggerEvents(tt.workflow)
+
+			if len(got) != tt.wantCount {
+				t.Errorf("GetPrivilegedTriggerEvents() returned %d events, want %d", len(got), tt.wantCount)
+			}
+
+			// Verify all returned events are privileged
+			for _, event := range got {
+				if !PrivilegedTriggers[event.EventName()] {
+					t.Errorf("GetPrivilegedTriggerEvents() returned non-privileged event: %s", event.EventName())
+				}
+			}
+		})
+	}
+}
+
+func TestPrivilegedTriggersMap(t *testing.T) {
+	t.Parallel()
+
+	// Ensure all expected privileged triggers are in the map
+	expectedTriggers := []string{
+		"pull_request_target",
+		"workflow_run",
+		"issue_comment",
+		"issues",
+		"discussion_comment",
+	}
+
+	for _, trigger := range expectedTriggers {
+		if !PrivilegedTriggers[trigger] {
+			t.Errorf("Expected %s to be in PrivilegedTriggers map", trigger)
+		}
+	}
+
+	// Ensure common non-privileged triggers are NOT in the map
+	nonPrivilegedTriggers := []string{
+		"pull_request",
+		"push",
+		"workflow_dispatch",
+		"schedule",
+		"release",
+		"create",
+		"delete",
+	}
+
+	for _, trigger := range nonPrivilegedTriggers {
+		if PrivilegedTriggers[trigger] {
+			t.Errorf("Expected %s to NOT be in PrivilegedTriggers map", trigger)
+		}
+	}
+}

--- a/script/actions/dangerous-triggers-critical.yaml
+++ b/script/actions/dangerous-triggers-critical.yaml
@@ -1,0 +1,14 @@
+# Vulnerable: pull_request_target without any security mitigations
+# This should trigger dangerous-triggers-critical rule
+name: Dangerous Triggers Critical Example
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Building PR"

--- a/script/actions/dangerous-triggers-medium.yaml
+++ b/script/actions/dangerous-triggers-medium.yaml
@@ -1,0 +1,15 @@
+# Partial mitigation: pull_request_target with only label condition
+# This should trigger dangerous-triggers-medium rule
+name: Dangerous Triggers Medium Example
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-run')
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Building approved PR"

--- a/script/actions/dangerous-triggers-safe.yaml
+++ b/script/actions/dangerous-triggers-safe.yaml
@@ -1,0 +1,18 @@
+# Safe: pull_request_target with adequate mitigations (permissions restriction)
+# This should NOT trigger any dangerous-triggers rule
+name: Dangerous Triggers Safe Example
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Building PR with restricted permissions"


### PR DESCRIPTION
## Summary

Implement `dangerous-triggers` rule that warns about privileged workflow triggers when appropriate security mitigations are not in place.

- Add `DangerousTriggersCriticalRule`: Detects dangerous triggers without any mitigations
- Add `DangerousTriggersMediumRule`: Detects dangerous triggers with partial mitigations
- Add shared `HasPrivilegedTriggers` utility and refactor existing rules to use it
- Auto-fix support: Adds `permissions: {}` when missing

### Privileged Triggers Detected
- `pull_request_target`
- `workflow_run`
- `issue_comment`
- `issues`
- `discussion_comment`

### Mitigations Considered
| Mitigation | Score |
|------------|-------|
| permissions restriction | 3 |
| environment protection | 2 |
| label condition | 1 |
| actor restriction | 1 |
| fork check | 1 |

### Severity
- Score 0 = critical (no mitigations)
- Score 1-2 = medium (partial mitigations)
- Score 3+ = no warning (sufficient mitigations)

## Test Plan

- [x] Unit tests for privileged triggers utility
- [x] Unit tests for mitigation detection
- [x] Unit tests for critical rule
- [x] Unit tests for medium rule
- [x] Integration test with example workflow files
- [x] All existing tests pass after refactoring

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)