### PR TITLE
feat(rules): add DependabotGitHubActionsRule for version update automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ sisakulint is a static analysis tool for GitHub Actions workflow files (.github/
      - `pkg/core/archived_uses.go` - **ArchivedUsesRule**: Detects usage of archived actions/reusable workflows that are no longer maintained
      - `pkg/core/unpinned_images.go` - **UnpinnedImagesRule**: Detects container images not pinned by SHA256 digest
      - `pkg/core/secretexfiltration.go` - **SecretExfiltrationRule**: Detects secret exfiltration via network commands (curl, wget, nc, etc.)
+     - `pkg/core/dependabot_github_actions.go` - **DependabotGitHubActionsRule**: Checks if dependabot.yaml has github-actions ecosystem configured when unpinned actions are detected (with auto-fix)
      - `pkg/core/rule_add_temp_normal.go` - **AddRule**: Template rule for adding new rules
 
 4. **AST Processing**:
@@ -265,6 +266,7 @@ sisakulint includes the following security rules (as of pkg/core/linter.go:500-5
 42. **SecretExfiltrationRule** - Detects secret exfiltration via network commands (curl, wget, nc, etc.)
 43. **ReusableWorkflowTaintRule** - Detects untrusted inputs passed to reusable workflows and used unsafely (auto-fix supported)
 44. **SecretsInheritRule** - Detects excessive secret inheritance using 'secrets: inherit' in reusable workflow calls (auto-fix supported)
+45. **DependabotGitHubActionsRule** - Checks if dependabot.yaml has github-actions ecosystem configured when unpinned actions are detected (auto-fix supported)
 
 ## Key Files
 

--- a/pkg/core/dependabot_github_actions.go
+++ b/pkg/core/dependabot_github_actions.go
@@ -1,0 +1,288 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+	"gopkg.in/yaml.v3"
+)
+
+// DependabotGitHubActionsRule checks if dependabot.yaml has github-actions ecosystem configured
+// when unpinned actions are detected in the workflow.
+type DependabotGitHubActionsRule struct {
+	BaseRule
+	// workflowPath stores the workflow file path to find the project root
+	workflowPath string
+	// hasUnpinnedAction tracks if any unpinned action was found
+	hasUnpinnedAction bool
+	// projectRoot stores the detected project root directory
+	projectRoot string
+	// alreadyChecked prevents duplicate checks across multiple workflows
+	alreadyChecked map[string]bool
+}
+
+// NewDependabotGitHubActionsRule creates a new DependabotGitHubActionsRule instance.
+// workflowPath is the path to the workflow file being analyzed.
+func NewDependabotGitHubActionsRule(workflowPath string) *DependabotGitHubActionsRule {
+	rule := &DependabotGitHubActionsRule{
+		BaseRule: BaseRule{
+			RuleName: "dependabot-github-actions",
+			RuleDesc: "Check if dependabot.yaml has github-actions ecosystem configured when unpinned actions are detected",
+		},
+		workflowPath:   workflowPath,
+		alreadyChecked: make(map[string]bool),
+	}
+	// Find project root from workflow path
+	rule.projectRoot = rule.findProjectRoot(workflowPath)
+	return rule
+}
+
+// dependabotConfig represents the structure of dependabot.yaml
+type dependabotConfig struct {
+	Version int `yaml:"version"`
+	Updates []struct {
+		PackageEcosystem string `yaml:"package-ecosystem"`
+		Directory        string `yaml:"directory"`
+		Schedule         struct {
+			Interval string `yaml:"interval"`
+		} `yaml:"schedule"`
+	} `yaml:"updates"`
+}
+
+// actionFullShaPattern checks if the given action ref is pinned to a full length commit SHA
+var actionFullShaPattern = regexp.MustCompile(`^.+@([0-9a-f]{40})$`)
+
+// VisitWorkflowPre resets state for a new workflow.
+func (rule *DependabotGitHubActionsRule) VisitWorkflowPre(_ *ast.Workflow) error {
+	rule.hasUnpinnedAction = false
+	return nil
+}
+
+// VisitJobPre is a no-op for this rule.
+func (rule *DependabotGitHubActionsRule) VisitJobPre(_ *ast.Job) error {
+	return nil
+}
+
+// VisitJobPost is a no-op for this rule.
+func (rule *DependabotGitHubActionsRule) VisitJobPost(_ *ast.Job) error {
+	return nil
+}
+
+// VisitStep checks if the step uses an action without a full SHA pinning.
+func (rule *DependabotGitHubActionsRule) VisitStep(step *ast.Step) error {
+	if action, ok := step.Exec.(*ast.ExecAction); ok {
+		if action.Uses == nil {
+			return nil
+		}
+		usesValue := action.Uses.Value
+		// Skip local actions (starting with ./)
+		if strings.HasPrefix(usesValue, "./") {
+			return nil
+		}
+		// Skip Docker actions
+		if strings.HasPrefix(usesValue, "docker://") {
+			return nil
+		}
+		// Check if the action is pinned to a full SHA
+		if !actionFullShaPattern.MatchString(usesValue) {
+			rule.hasUnpinnedAction = true
+		}
+	}
+	return nil
+}
+
+// VisitWorkflowPost checks dependabot configuration if unpinned actions were found.
+func (rule *DependabotGitHubActionsRule) VisitWorkflowPost(_ *ast.Workflow) error {
+	if !rule.hasUnpinnedAction {
+		return nil
+	}
+
+	if rule.projectRoot == "" {
+		return nil
+	}
+
+	// Avoid duplicate checks for the same project
+	if rule.alreadyChecked[rule.projectRoot] {
+		return nil
+	}
+	rule.alreadyChecked[rule.projectRoot] = true
+
+	// Check for dependabot.yaml or dependabot.yml
+	dependabotPath := rule.findDependabotFile(rule.projectRoot)
+
+	if dependabotPath == "" {
+		// dependabot.yaml does not exist
+		rule.Errorf(
+			&ast.Position{Line: 1, Col: 1},
+			"dependabot.yaml does not exist. Without Dependabot, major version updates (e.g., v3 -> v4) for GitHub Actions won't be automated. "+
+				"Create .github/dependabot.yaml with github-actions ecosystem. See https://sisaku-security.github.io/lint/docs/rules/dependabotgithubactionsrule/",
+		)
+		rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
+			return createDependabotFile(rule.projectRoot)
+		}))
+		return nil
+	}
+
+	// dependabot.yaml exists, check if github-actions ecosystem is configured
+	hasGitHubActionsEcosystem, err := rule.checkDependabotConfig(dependabotPath)
+	if err != nil {
+		rule.Debug("failed to parse dependabot config: %v", err)
+		return nil
+	}
+
+	if !hasGitHubActionsEcosystem {
+		rule.Errorf(
+			&ast.Position{Line: 1, Col: 1},
+			"dependabot.yaml exists but github-actions ecosystem is not configured. "+
+				"Without it, major version updates (e.g., v3 -> v4) for GitHub Actions won't be automated. "+
+				"See https://sisaku-security.github.io/lint/docs/rules/dependabotgithubactionsrule/",
+		)
+		rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
+			return updateDependabotFile(dependabotPath)
+		}))
+	}
+
+	return nil
+}
+
+// findProjectRoot finds the project root directory by looking for .github directory.
+func (rule *DependabotGitHubActionsRule) findProjectRoot(workflowPath string) string {
+	// Convert to absolute path if needed
+	absPath, err := filepath.Abs(workflowPath)
+	if err != nil {
+		return ""
+	}
+
+	dir := filepath.Dir(absPath)
+	for {
+		// Check if .github directory exists
+		githubDir := filepath.Join(dir, ".github")
+		if info, err := os.Stat(githubDir); err == nil && info.IsDir() {
+			return dir
+		}
+
+		// Move to parent directory
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached root
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+// findDependabotFile finds the dependabot configuration file.
+func (rule *DependabotGitHubActionsRule) findDependabotFile(projectRoot string) string {
+	yamlPath := filepath.Join(projectRoot, ".github", "dependabot.yaml")
+	if _, err := os.Stat(yamlPath); err == nil {
+		return yamlPath
+	}
+
+	ymlPath := filepath.Join(projectRoot, ".github", "dependabot.yml")
+	if _, err := os.Stat(ymlPath); err == nil {
+		return ymlPath
+	}
+
+	return ""
+}
+
+// checkDependabotConfig checks if the dependabot config has github-actions ecosystem.
+func (rule *DependabotGitHubActionsRule) checkDependabotConfig(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	var config dependabotConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return false, err
+	}
+
+	for _, update := range config.Updates {
+		if update.PackageEcosystem == "github-actions" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// createDependabotFile creates a new dependabot.yaml file with github-actions ecosystem.
+func createDependabotFile(projectRoot string) error {
+	path := filepath.Join(projectRoot, ".github", "dependabot.yaml")
+
+	content := `version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`
+
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// updateDependabotFile updates existing dependabot.yaml to add github-actions ecosystem.
+func updateDependabotFile(dependabotPath string) error {
+	data, err := os.ReadFile(dependabotPath)
+	if err != nil {
+		return err
+	}
+
+	// Parse YAML while preserving structure
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return err
+	}
+
+	// Find the updates array and append github-actions config
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil
+	}
+
+	docContent := root.Content[0]
+	if docContent.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	// Find the "updates" key
+	for i := 0; i < len(docContent.Content); i += 2 {
+		if docContent.Content[i].Value == "updates" {
+			updatesNode := docContent.Content[i+1]
+			if updatesNode.Kind == yaml.SequenceNode {
+				// Create new github-actions entry
+				newEntry := &yaml.Node{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "package-ecosystem"},
+						{Kind: yaml.ScalarNode, Value: "github-actions", Style: yaml.DoubleQuotedStyle},
+						{Kind: yaml.ScalarNode, Value: "directory"},
+						{Kind: yaml.ScalarNode, Value: "/", Style: yaml.DoubleQuotedStyle},
+						{Kind: yaml.ScalarNode, Value: "schedule"},
+						{
+							Kind: yaml.MappingNode,
+							Content: []*yaml.Node{
+								{Kind: yaml.ScalarNode, Value: "interval"},
+								{Kind: yaml.ScalarNode, Value: "weekly", Style: yaml.DoubleQuotedStyle},
+							},
+						},
+					},
+				}
+				updatesNode.Content = append(updatesNode.Content, newEntry)
+			}
+			break
+		}
+	}
+
+	// Write back
+	output, err := yaml.Marshal(&root)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(dependabotPath, output, 0o644)
+}

--- a/pkg/core/dependabot_github_actions_test.go
+++ b/pkg/core/dependabot_github_actions_test.go
@@ -1,0 +1,427 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+func TestDependabotGitHubActionsRule_NoDependabotFile(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github", "workflows")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a workflow file path (file doesn't need to exist for the rule)
+	workflowPath := filepath.Join(githubDir, "test.yaml")
+
+	rule := NewDependabotGitHubActionsRule(workflowPath)
+
+	// Simulate visiting a workflow with unpinned action
+	workflow := &ast.Workflow{}
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate step with unpinned action
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "actions/checkout@v4"},
+		},
+	}
+
+	if err := rule.VisitStep(step); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rule.VisitWorkflowPost(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := rule.Errors()
+	if len(errors) != 1 {
+		t.Errorf("expected 1 error, got %d", len(errors))
+	}
+
+	if len(errors) > 0 && errors[0].Type != "dependabot-github-actions" {
+		t.Errorf("expected rule type 'dependabot-github-actions', got '%s'", errors[0].Type)
+	}
+
+	// Check that auto-fixer is added
+	fixers := rule.AutoFixers()
+	if len(fixers) != 1 {
+		t.Errorf("expected 1 auto-fixer, got %d", len(fixers))
+	}
+}
+
+func TestDependabotGitHubActionsRule_DependabotWithoutGitHubActions(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github")
+	workflowsDir := filepath.Join(githubDir, "workflows")
+	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create dependabot.yaml without github-actions
+	dependabotContent := `version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+`
+	dependabotPath := filepath.Join(githubDir, "dependabot.yaml")
+	if err := os.WriteFile(dependabotPath, []byte(dependabotContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowPath := filepath.Join(workflowsDir, "test.yaml")
+
+	rule := NewDependabotGitHubActionsRule(workflowPath)
+
+	workflow := &ast.Workflow{}
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "actions/checkout@v4"},
+		},
+	}
+
+	if err := rule.VisitStep(step); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rule.VisitWorkflowPost(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := rule.Errors()
+	if len(errors) != 1 {
+		t.Errorf("expected 1 error, got %d", len(errors))
+	}
+
+	if len(errors) > 0 {
+		expected := "dependabot.yaml exists but github-actions ecosystem is not configured"
+		if !strings.Contains(errors[0].Description, expected) {
+			t.Errorf("error message should contain '%s', got '%s'", expected, errors[0].Description)
+		}
+	}
+}
+
+func TestDependabotGitHubActionsRule_DependabotWithGitHubActions(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github")
+	workflowsDir := filepath.Join(githubDir, "workflows")
+	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create dependabot.yaml with github-actions
+	dependabotContent := `version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`
+	dependabotPath := filepath.Join(githubDir, "dependabot.yaml")
+	if err := os.WriteFile(dependabotPath, []byte(dependabotContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowPath := filepath.Join(workflowsDir, "test.yaml")
+
+	rule := NewDependabotGitHubActionsRule(workflowPath)
+
+	workflow := &ast.Workflow{}
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "actions/checkout@v4"},
+		},
+	}
+
+	if err := rule.VisitStep(step); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rule.VisitWorkflowPost(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := rule.Errors()
+	if len(errors) != 0 {
+		t.Errorf("expected 0 errors when github-actions is configured, got %d", len(errors))
+	}
+}
+
+func TestDependabotGitHubActionsRule_PinnedActions(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github", "workflows")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowPath := filepath.Join(githubDir, "test.yaml")
+
+	rule := NewDependabotGitHubActionsRule(workflowPath)
+
+	workflow := &ast.Workflow{}
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step with SHA-pinned action
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11"},
+		},
+	}
+
+	if err := rule.VisitStep(step); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rule.VisitWorkflowPost(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := rule.Errors()
+	if len(errors) != 0 {
+		t.Errorf("expected 0 errors when action is SHA-pinned, got %d", len(errors))
+	}
+}
+
+func TestDependabotGitHubActionsRule_LocalAction(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github", "workflows")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowPath := filepath.Join(githubDir, "test.yaml")
+
+	rule := NewDependabotGitHubActionsRule(workflowPath)
+
+	workflow := &ast.Workflow{}
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	// Local action should be skipped
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "./local-action"},
+		},
+	}
+
+	if err := rule.VisitStep(step); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rule.VisitWorkflowPost(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := rule.Errors()
+	if len(errors) != 0 {
+		t.Errorf("expected 0 errors for local action, got %d", len(errors))
+	}
+}
+
+func TestDependabotGitHubActionsRule_DockerAction(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github", "workflows")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowPath := filepath.Join(githubDir, "test.yaml")
+
+	rule := NewDependabotGitHubActionsRule(workflowPath)
+
+	workflow := &ast.Workflow{}
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	// Docker action should be skipped
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "docker://alpine:3.8"},
+		},
+	}
+
+	if err := rule.VisitStep(step); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rule.VisitWorkflowPost(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := rule.Errors()
+	if len(errors) != 0 {
+		t.Errorf("expected 0 errors for docker action, got %d", len(errors))
+	}
+}
+
+func TestCreateDependabotFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := createDependabotFile(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the file was created
+	createdPath := filepath.Join(githubDir, "dependabot.yaml")
+	data, err := os.ReadFile(createdPath)
+	if err != nil {
+		t.Fatalf("expected dependabot.yaml to be created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "github-actions") {
+		t.Error("created file should contain github-actions ecosystem")
+	}
+	if !strings.Contains(content, "weekly") {
+		t.Error("created file should contain weekly schedule")
+	}
+}
+
+func TestUpdateDependabotFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create existing dependabot.yaml without github-actions
+	existingContent := `version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+`
+	dependabotPath := filepath.Join(githubDir, "dependabot.yaml")
+	if err := os.WriteFile(dependabotPath, []byte(existingContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateDependabotFile(dependabotPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the file was updated
+	data, err := os.ReadFile(dependabotPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(data)
+	// Should still contain npm
+	if !strings.Contains(content, "npm") {
+		t.Error("updated file should still contain npm ecosystem")
+	}
+	// Should now contain github-actions
+	if !strings.Contains(content, "github-actions") {
+		t.Error("updated file should contain github-actions ecosystem")
+	}
+}
+
+func TestDependabotGitHubActionsRule_DependabotYml(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	githubDir := filepath.Join(tmpDir, ".github")
+	workflowsDir := filepath.Join(githubDir, "workflows")
+	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create dependabot.yml (not .yaml) with github-actions
+	dependabotContent := `version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`
+	dependabotPath := filepath.Join(githubDir, "dependabot.yml")
+	if err := os.WriteFile(dependabotPath, []byte(dependabotContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowPath := filepath.Join(workflowsDir, "test.yaml")
+
+	rule := NewDependabotGitHubActionsRule(workflowPath)
+
+	workflow := &ast.Workflow{}
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "actions/checkout@v4"},
+		},
+	}
+
+	if err := rule.VisitStep(step); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rule.VisitWorkflowPost(workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	errors := rule.Errors()
+	if len(errors) != 0 {
+		t.Errorf("expected 0 errors when github-actions is configured in .yml file, got %d", len(errors))
+	}
+}

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -520,6 +520,7 @@ func makeRules(filePath string, localActions *LocalActionsMetadataCache, localRe
 		OutputClobberingCriticalRule(), // Detects output clobbering in privileged workflow triggers
 		OutputClobberingMediumRule(),   // Detects output clobbering in normal workflow triggers
 		CommitShaRule(),
+		NewDependabotGitHubActionsRule(filePath), // Checks dependabot.yaml has github-actions ecosystem when unpinned actions found
 		ArtifactPoisoningRule(),
 		NewArtifactPoisoningMediumRule(),
 		NewActionListRule(),


### PR DESCRIPTION
## Summary

- CommitSHARuleの自動修正ではv3→v4のようなメジャーバージョンアップに対応できない問題を補完
- SHA未固定のアクションが検出された際、dependabot.yamlにgithub-actionsエコシステムの設定がなければ警告
- 自動修正でdependabot.yamlの新規作成または既存ファイルへの設定追加をサポート

## Changes

- `pkg/core/dependabot_github_actions.go` - ルール本体
- `pkg/core/dependabot_github_actions_test.go` - テスト（9ケース）
- `pkg/core/linter.go` - ルール登録
- `CLAUDE.md` - ドキュメント更新

## Test plan

- [x] dependabot.yamlが存在しない場合に警告が出ることを確認
- [x] dependabot.yamlにgithub-actions設定がない場合に警告が出ることを確認
- [x] dependabot.yamlにgithub-actions設定がある場合は警告が出ないことを確認
- [x] SHA固定済みのアクションでは警告が出ないことを確認
- [x] ローカルアクション、Dockerアクションはスキップされることを確認
- [x] 自動修正でファイル作成/更新が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHubアクション用の新しいセキュリティルールを追加しました。ピンされていないアクション参照を検出し、Dependabot設定を自動で修正できるようになりました。
  * dependabot.yamlファイルの作成または更新を自動実行する機能に対応しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->