### PR TITLE
fix(linter): correct garbled verbose log messages

### DIFF
--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -627,7 +627,7 @@ func (l *Linter) validate(
 
 	if l.loggingLevel >= LogLevelDetailedOutput {
 		elapsed := time.Since(validationStart)
-		l.log("parsed workflow in", len(allErrors), elapsed.Milliseconds(), "ms", filePath)
+		l.log(fmt.Sprintf("parsed workflow in %dms", elapsed.Milliseconds()), filePath)
 	}
 
 	var allAutoFixers []AutoFixer
@@ -723,7 +723,7 @@ func (l *Linter) filterAndLogErrors(filePath string, allErrors *[]*LintingError,
 
 	if l.loggingLevel >= LogLevelDetailedOutput {
 		elapsed := time.Since(validationStart)
-		l.log("Found total", len(*allErrors), "errors found in", elapsed.Milliseconds(), "found in ms", filePath)
+		l.log(fmt.Sprintf("found %d errors in %dms", len(*allErrors), elapsed.Milliseconds()), filePath)
 	}
 }
 

--- a/pkg/core/linter_verbose_log_test.go
+++ b/pkg/core/linter_verbose_log_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVerboseLogFormat(t *testing.T) {
+	t.Parallel()
+
+	workflow := `name: Test
+on: push
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo hello
+`
+
+	var logBuf bytes.Buffer
+	opts := &LinterOptions{
+		IsVerboseOutputEnabled: true,
+		LogOutputDestination:   &logBuf,
+	}
+	linter, err := NewLinter(bytes.NewBuffer(nil), opts)
+	if err != nil {
+		t.Fatalf("NewLinter failed: %v", err)
+	}
+
+	_, err = linter.Lint("test.yaml", []byte(workflow), nil)
+	if err != nil {
+		t.Fatalf("Lint failed: %v", err)
+	}
+
+	logOutput := logBuf.String()
+	lines := strings.Split(strings.TrimSpace(logOutput), "\n")
+
+	for _, line := range lines {
+		// "found in" が2回現れてはならない
+		if count := strings.Count(line, "found in"); count > 1 {
+			t.Errorf("verbose log contains duplicate 'found in': %q", line)
+		}
+		// 数値が連続してスペースで区切られてはならない (例: "0 0 ms")
+		// "parsed workflow in" の行の検証
+		if strings.Contains(line, "parsed workflow in") {
+			if strings.Contains(line, "in 0 0") || strings.Contains(line, "in 1 ") {
+				t.Errorf("verbose log 'parsed workflow in' has garbled format: %q", line)
+			}
+		}
+		// "Found total" の行の検証
+		if strings.Contains(line, "Found total") || strings.Contains(line, "found total") {
+			if strings.Contains(line, "found in") && strings.Contains(line, "errors found") {
+				t.Errorf("verbose log total errors line has garbled format: %q", line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `-verbose` フラグ使用時の verbose ログメッセージが文字化けしていたバグを修正
- `l.log()` が `fmt.Fprintln` のスペース区切り引数を使っているため、引数の過不足で出力が崩れていた

## 修正内容

**Bug 1: `parsed workflow in` ログ**

```
# Before
[sisaku:🤔] parsed workflow in 0 0 ms test.yaml

# After
[sisaku:🤔] parsed workflow in 0ms test.yaml
```

原因: 不要な `len(allErrors)` 引数が混入し、単位 `"ms"` が別トークンになっていた

**Bug 2: `found total errors` ログ**

```
# Before
[sisaku:🤔] Found total 20 errors found in 1978 found in ms test.yaml

# After
[sisaku:🤔] found 20 errors in 1894ms test.yaml
```

原因: `"errors found in"` と `"found in ms"` で `found in` が重複し文字化け

## 修正方法

両箇所を `fmt.Sprintf` でフォーマットするように変更

## Test plan

- [x] `TestVerboseLogFormat` を追加してリグレッション防止
- [x] `go test ./...` 全テストパス
- [x] `-verbose` フラグでの実際の出力を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ログメッセージのフォーマットを改善し、ワークフロー解析時間とエラー検出情報の表示方法を統一しました。

* **テスト**
  * 詳細ログモードのフォーマット正確性を検証する新しいテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->