### PR TITLE
fix(impostor-commit): replace N-dependent fallback with O(1) default branch reachability check

### DIFF
--- a/pkg/core/impostorcommit.go
+++ b/pkg/core/impostorcommit.go
@@ -176,8 +176,16 @@ func (rule *ImpostorCommitRule) doVerifyCommit(owner, repo, sha string) *commitV
 	}
 	rule.latestTagCacheMu.Unlock()
 
+	// Check reachability from the repository's default branch only.
+	// A SHA reachable from the default branch (status "behind" or "identical") is considered legitimate.
+	// Commits that exist only on non-default branches or forks without a corresponding tag are reported as impostors.
 	defaultBranch := rule.getDefaultBranch(ctx, client, owner, repo)
-	if rule.isReachableFromBranch(ctx, client, owner, repo, defaultBranch, sha) {
+	reachable, err := rule.isReachableFromBranch(ctx, client, owner, repo, defaultBranch, sha)
+	if err != nil {
+		rule.Debug("Error checking reachability for %s/%s@%s from branch %s: %v", owner, repo, sha, defaultBranch, err)
+		return &commitVerificationResult{err: err}
+	}
+	if reachable {
 		return &commitVerificationResult{isImpostor: false, latestTag: latestTag}
 	}
 
@@ -207,13 +215,13 @@ func (rule *ImpostorCommitRule) getDefaultBranch(ctx context.Context, client *gi
 	return defaultBranch
 }
 
-func (rule *ImpostorCommitRule) isReachableFromBranch(ctx context.Context, client *github.Client, owner, repo, branch, sha string) bool {
+func (rule *ImpostorCommitRule) isReachableFromBranch(ctx context.Context, client *github.Client, owner, repo, branch, sha string) (bool, error) {
 	comparison, _, err := client.Repositories.CompareCommits(ctx, owner, repo, branch, sha, nil)
 	if err != nil {
-		return false
+		return false, err
 	}
 	shaIsAncestorOfBranch := comparison.GetStatus() == "behind" || comparison.GetStatus() == "identical"
-	return shaIsAncestorOfBranch
+	return shaIsAncestorOfBranch, nil
 }
 
 func (rule *ImpostorCommitRule) getTags(ctx context.Context, client *github.Client, owner, repo string) []*github.RepositoryTag {
@@ -247,7 +255,6 @@ func (rule *ImpostorCommitRule) getTags(ctx context.Context, client *github.Clie
 
 	return allTags
 }
-
 
 type impostorCommitFixer struct {
 	rule      *ImpostorCommitRule

--- a/pkg/core/impostorcommit_test.go
+++ b/pkg/core/impostorcommit_test.go
@@ -1,9 +1,15 @@
 package core
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/google/go-github/v68/github"
 	"github.com/sisaku-security/sisakulint/pkg/ast"
 )
 
@@ -554,5 +560,177 @@ func TestImpostorCommitRule_ErrorMessage(t *testing.T) {
 		if !strings.Contains(errMsg, substr) {
 			t.Errorf("Error message should contain '%s', got: %s", substr, errMsg)
 		}
+	}
+}
+
+// newTestGitHubClient creates a *github.Client pointing at the given test server URL.
+func newTestGitHubClient(serverURL string) *github.Client {
+	client := github.NewClient(nil)
+	baseURL, _ := url.Parse(serverURL + "/")
+	client.BaseURL = baseURL
+	return client
+}
+
+// TestImpostorCommitRule_getDefaultBranch tests getDefaultBranch with a mocked GitHub API.
+func TestImpostorCommitRule_getDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		responseBody string
+		statusCode   int
+		wantBranch   string
+	}{
+		{
+			name:         "returns default branch from API",
+			responseBody: `{"default_branch": "main"}`,
+			statusCode:   http.StatusOK,
+			wantBranch:   "main",
+		},
+		{
+			name:         "returns master when API says master",
+			responseBody: `{"default_branch": "master"}`,
+			statusCode:   http.StatusOK,
+			wantBranch:   "master",
+		},
+		{
+			name:         "falls back to main on API error",
+			responseBody: `{"message": "Internal Server Error"}`,
+			statusCode:   http.StatusInternalServerError,
+			wantBranch:   "main",
+		},
+		{
+			name:         "falls back to main when default_branch is empty",
+			responseBody: `{"default_branch": ""}`,
+			statusCode:   http.StatusOK,
+			wantBranch:   "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			rule := ImpostorCommitRuleFactory()
+			client := newTestGitHubClient(server.URL)
+			branch := rule.getDefaultBranch(context.Background(), client, "owner", "repo")
+
+			if branch != tt.wantBranch {
+				t.Errorf("getDefaultBranch() = %q, want %q", branch, tt.wantBranch)
+			}
+		})
+	}
+}
+
+// TestImpostorCommitRule_getDefaultBranch_UsesCache verifies the second call uses the cache.
+func TestImpostorCommitRule_getDefaultBranch_UsesCache(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"default_branch": "develop"}`))
+	}))
+	defer server.Close()
+
+	rule := ImpostorCommitRuleFactory()
+	client := newTestGitHubClient(server.URL)
+	ctx := context.Background()
+
+	branch1 := rule.getDefaultBranch(ctx, client, "owner", "repo")
+	branch2 := rule.getDefaultBranch(ctx, client, "owner", "repo")
+
+	if branch1 != "develop" || branch2 != "develop" {
+		t.Errorf("expected both calls to return 'develop', got %q and %q", branch1, branch2)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 API call (cache hit on second), got %d", callCount)
+	}
+}
+
+// TestImpostorCommitRule_isReachableFromBranch tests reachability with a mocked GitHub API.
+func TestImpostorCommitRule_isReachableFromBranch(t *testing.T) {
+	t.Parallel()
+
+	const sha = "a81bbbf8298c0fa03ea29cdc473d45769f953675"
+
+	tests := []struct {
+		name          string
+		status        string
+		httpStatus    int
+		wantReachable bool
+		wantErr       bool
+	}{
+		{
+			name:          "behind means reachable",
+			status:        "behind",
+			httpStatus:    http.StatusOK,
+			wantReachable: true,
+		},
+		{
+			name:          "identical means reachable",
+			status:        "identical",
+			httpStatus:    http.StatusOK,
+			wantReachable: true,
+		},
+		{
+			name:          "ahead means not reachable",
+			status:        "ahead",
+			httpStatus:    http.StatusOK,
+			wantReachable: false,
+		},
+		{
+			name:          "diverged means not reachable",
+			status:        "diverged",
+			httpStatus:    http.StatusOK,
+			wantReachable: false,
+		},
+		{
+			name:       "API error is propagated",
+			httpStatus: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.httpStatus)
+				if tt.httpStatus == http.StatusOK {
+					_, _ = fmt.Fprintf(w, `{"status":%q,"ahead_by":0,"behind_by":1,"commits":[],"files":[]}`, tt.status)
+				} else {
+					_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+				}
+			}))
+			defer server.Close()
+
+			rule := ImpostorCommitRuleFactory()
+			client := newTestGitHubClient(server.URL)
+			reachable, err := rule.isReachableFromBranch(context.Background(), client, "owner", "repo", "main", sha)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if reachable != tt.wantReachable {
+				t.Errorf("isReachableFromBranch() = %v, want %v", reachable, tt.wantReachable)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- \`doVerifyCommit\` のブランチ反復・タグ反復による O(N) API呼び出しを廃止
- デフォルトブランチへの到達性チェック（\`CompareCommits\`）に一本化し、API呼び出しを O(1) に固定
- \`getBranches\`・\`branchCache\`・\`maxBranchPages\` を完全削除

## 変更後のチェック順序

| ステップ | API呼び出し | 説明 |
|---|---|---|
| タグHEAD直接一致 | 0（キャッシュ済） | fast path |
| デフォルトブランチ到達性 | 1（リポジトリ毎にキャッシュ） | \`CompareCommits(defaultBranch, sha)\` → \`"behind"\` or \`"identical"\` |
| どちらにも該当しない | — | インポスターコミットとして報告 |

## 設計上の判断

デフォルトブランチにマージされていないリリースブランチのみに存在し、かつ対応するタグも持たないSHAはインポスターとして報告する。タグなしでリリースブランチのSHAを直接固定する行為自体がセキュリティ上推奨されない固定方法であり、警告が出ることは妥当。

## Issue #324 との対応確認

#324 で報告された偽陽性のケースは \`actions/upload-artifact@b7c566a...\`。

調査の結果、このコミットのメッセージは:

> Merge pull request #745 from actions/upload-artifact-v6-release

であり、\`upload-artifact-v6-release\` ブランチの内容を \`main\` にマージしたコミットそのものである。
つまり **\`b7c566a...\` は \`main\` の直接の祖先**であり、\`CompareCommits(main, b7c566a...)\` は \`"behind"\` を返すため、本修正により偽陽性は解消される。

また \`actions/upload-artifact\` のタグ運用は以下の通り:

- \`v6\` / \`v6.0.0\` はどちらも同一コミットを直接指すフローティングタグ
- メジャーバージョンタグは常にそのメジャー最新コミットのHEADを指す

したがって「タグの祖先コミットを固定する」ユースケース自体が成立せず、デフォルトブランチ到達性チェックで十分にカバーできる。

## Closes

Closes #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 検証をリポジトリのデフォルトブランチへの到達可能性チェックに切替え、性能向上
  * デフォルトブランチのキャッシュを導入してAPI呼び出しを削減
  * タグ取得を簡素化して最大ページ数を5→1に削減、タグキャッシュで高速化
  * 検証結果にエラー情報を追加しエラーハンドリングを強化
  * 自動修復が最新タグを参照して正しいコミットを解決するよう更新
* **テスト**
  * デフォルトブランチ解決、到達可能性チェック、キャッシュ動作を検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->