### PR TITLE
Revert "Revert "fix(impostor-commit): replace N-dependent fallback with O(1) default branch reachability check (#356)""

### DIFF
--- a/pkg/core/impostorcommit.go
+++ b/pkg/core/impostorcommit.go
@@ -15,28 +15,20 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Pagination limits for GitHub API requests
-const (
-	// maxTagPages is the maximum number of pages to fetch for repository tags.
-	// With 100 items per page, this allows fetching up to 500 tags.
-	maxTagPages = 5
-	// maxBranchPages is the maximum number of pages to fetch for repository branches.
-	// With 100 items per page, this allows fetching up to 300 branches.
-	maxBranchPages = 3
-)
+const maxTagPages = 1
 
 type ImpostorCommitRule struct {
 	BaseRule
-	client           *github.Client
-	clientOnce       sync.Once
-	commitCache      map[string]*commitVerificationResult
-	commitCacheMu    sync.Mutex
-	tagCache         map[string][]*github.RepositoryTag
-	tagCacheMu       sync.Mutex
-	branchCache      map[string][]*github.Branch
-	branchCacheMu    sync.Mutex
-	latestTagCache   map[string]string
-	latestTagCacheMu sync.Mutex
+	client               *github.Client
+	clientOnce           sync.Once
+	commitCache          map[string]*commitVerificationResult
+	commitCacheMu        sync.Mutex
+	tagCache             map[string][]*github.RepositoryTag
+	tagCacheMu           sync.Mutex
+	latestTagCache       map[string]string
+	latestTagCacheMu     sync.Mutex
+	defaultBranchCache   map[string]string
+	defaultBranchCacheMu sync.Mutex
 }
 
 type commitVerificationResult struct {
@@ -51,10 +43,10 @@ func ImpostorCommitRuleFactory() *ImpostorCommitRule {
 			RuleName: "impostor-commit",
 			RuleDesc: "Detects impostor commits that exist in the fork network but not in the repository's branches or tags",
 		},
-		commitCache:    make(map[string]*commitVerificationResult),
-		tagCache:       make(map[string][]*github.RepositoryTag),
-		branchCache:    make(map[string][]*github.Branch),
-		latestTagCache: make(map[string]string),
+		commitCache:        make(map[string]*commitVerificationResult),
+		tagCache:           make(map[string][]*github.RepositoryTag),
+		latestTagCache:     make(map[string]string),
+		defaultBranchCache: make(map[string]string),
 	}
 }
 
@@ -78,8 +70,6 @@ func parseImpostorActionRef(usesValue string) (owner, repo, ref string, skip boo
 
 func (rule *ImpostorCommitRule) getGitHubClient() *github.Client {
 	rule.clientOnce.Do(func() {
-		// Check for GITHUB_TOKEN environment variable for authenticated requests
-		// Authenticated requests have higher rate limits (5000/hour vs 60/hour)
 		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 			ts := oauth2.StaticTokenSource(
 				&oauth2.Token{AccessToken: token},
@@ -107,7 +97,6 @@ func (rule *ImpostorCommitRule) VisitStep(step *ast.Step) error {
 
 	result := rule.verifyCommit(owner, repo, ref)
 	if result.err != nil {
-		// API errors should not fail the lint - just log and skip
 		rule.Debug("Error verifying commit %s/%s@%s: %v", owner, repo, ref, result.err)
 		return nil //nolint:nilerr // Intentional: API errors are logged but don't fail linting
 	}
@@ -136,7 +125,6 @@ func (rule *ImpostorCommitRule) VisitStep(step *ast.Step) error {
 func (rule *ImpostorCommitRule) verifyCommit(owner, repo, sha string) *commitVerificationResult {
 	cacheKey := fmt.Sprintf("%s/%s@%s", owner, repo, sha)
 
-	// First check without lock (fast path)
 	rule.commitCacheMu.Lock()
 	if result, ok := rule.commitCache[cacheKey]; ok {
 		rule.commitCacheMu.Unlock()
@@ -144,13 +132,10 @@ func (rule *ImpostorCommitRule) verifyCommit(owner, repo, sha string) *commitVer
 	}
 	rule.commitCacheMu.Unlock()
 
-	// Perform verification (potentially slow)
 	result := rule.doVerifyCommit(owner, repo, sha)
 
-	// Double-checked locking: check again before caching to avoid duplicate work
 	rule.commitCacheMu.Lock()
 	if existingResult, ok := rule.commitCache[cacheKey]; ok {
-		// Another goroutine already cached the result
 		rule.commitCacheMu.Unlock()
 		return existingResult
 	}
@@ -174,20 +159,13 @@ func (rule *ImpostorCommitRule) doVerifyCommit(owner, repo, sha string) *commitV
 		if tag.GetCommit().GetSHA() == sha {
 			return &commitVerificationResult{isImpostor: false}
 		}
-		// For annotated tags, also check if the SHA matches the tag object itself
-		// This handles cases where workflows use the tag SHA directly (e.g., actions/checkout@<tag-sha>)
-		tagRef, _, err := client.Git.GetRef(ctx, owner, repo, "tags/"+tag.GetName())
-		if err == nil && tagRef != nil && tagRef.GetObject().GetSHA() == sha {
-			return &commitVerificationResult{isImpostor: false}
-		}
-		if latestTag == "" && tag.GetName() != "" {
+		if latestTag == "" {
 			tagName := tag.GetName()
 			if strings.HasPrefix(tagName, "v") {
 				latestTag = tagName
 			}
 		}
 	}
-
 	if latestTag == "" && len(tags) > 0 {
 		latestTag = tags[0].GetName()
 	}
@@ -198,51 +176,52 @@ func (rule *ImpostorCommitRule) doVerifyCommit(owner, repo, sha string) *commitV
 	}
 	rule.latestTagCacheMu.Unlock()
 
-	branches := rule.getBranches(ctx, client, owner, repo)
-	for _, branch := range branches {
-		if branch.GetCommit().GetSHA() == sha {
-			return &commitVerificationResult{isImpostor: false}
-		}
+	// Check reachability from the repository's default branch only.
+	// A SHA reachable from the default branch (status "behind" or "identical") is considered legitimate.
+	// Commits that exist only on non-default branches or forks without a corresponding tag are reported as impostors.
+	defaultBranch := rule.getDefaultBranch(ctx, client, owner, repo)
+	reachable, err := rule.isReachableFromBranch(ctx, client, owner, repo, defaultBranch, sha)
+	if err != nil {
+		rule.Debug("Error checking reachability for %s/%s@%s from branch %s: %v", owner, repo, sha, defaultBranch, err)
+		return &commitVerificationResult{err: err}
 	}
-
-	branchCommitsURL := fmt.Sprintf("repos/%s/%s/commits/%s/branches-where-head", owner, repo, sha)
-	req, err := client.NewRequest("GET", branchCommitsURL, nil)
-	if err == nil {
-		var branchList []*github.Branch
-		resp, err := client.Do(ctx, req, &branchList)
-		if err == nil && resp.StatusCode == http.StatusOK && len(branchList) > 0 {
-			return &commitVerificationResult{isImpostor: false, latestTag: latestTag}
-		}
-	}
-
-	mainBranches := []string{"main", "master", "develop"}
-	for _, branchName := range mainBranches {
-		comparison, _, err := client.Repositories.CompareCommits(ctx, owner, repo, branchName, sha, nil)
-		if err != nil {
-			continue
-		}
-		status := comparison.GetStatus()
-		if status == "behind" || status == "identical" {
-			return &commitVerificationResult{isImpostor: false, latestTag: latestTag}
-		}
-	}
-
-	for _, tag := range tags {
-		tagSha := tag.GetCommit().GetSHA()
-		if tagSha == "" {
-			continue
-		}
-		comparison, _, err := client.Repositories.CompareCommits(ctx, owner, repo, tagSha, sha, nil)
-		if err != nil {
-			continue
-		}
-		status := comparison.GetStatus()
-		if status == "behind" || status == "identical" {
-			return &commitVerificationResult{isImpostor: false, latestTag: latestTag}
-		}
+	if reachable {
+		return &commitVerificationResult{isImpostor: false, latestTag: latestTag}
 	}
 
 	return &commitVerificationResult{isImpostor: true, latestTag: latestTag}
+}
+
+func (rule *ImpostorCommitRule) getDefaultBranch(ctx context.Context, client *github.Client, owner, repo string) string {
+	cacheKey := fmt.Sprintf("%s/%s", owner, repo)
+
+	rule.defaultBranchCacheMu.Lock()
+	if branch, ok := rule.defaultBranchCache[cacheKey]; ok {
+		rule.defaultBranchCacheMu.Unlock()
+		return branch
+	}
+	rule.defaultBranchCacheMu.Unlock()
+
+	repoInfo, _, err := client.Repositories.Get(ctx, owner, repo)
+	defaultBranch := "main" // fallback when API is unavailable
+	if err == nil && repoInfo.GetDefaultBranch() != "" {
+		defaultBranch = repoInfo.GetDefaultBranch()
+	}
+
+	rule.defaultBranchCacheMu.Lock()
+	rule.defaultBranchCache[cacheKey] = defaultBranch
+	rule.defaultBranchCacheMu.Unlock()
+
+	return defaultBranch
+}
+
+func (rule *ImpostorCommitRule) isReachableFromBranch(ctx context.Context, client *github.Client, owner, repo, branch, sha string) (bool, error) {
+	comparison, _, err := client.Repositories.CompareCommits(ctx, owner, repo, branch, sha, nil)
+	if err != nil {
+		return false, err
+	}
+	shaIsAncestorOfBranch := comparison.GetStatus() == "behind" || comparison.GetStatus() == "identical"
+	return shaIsAncestorOfBranch, nil
 }
 
 func (rule *ImpostorCommitRule) getTags(ctx context.Context, client *github.Client, owner, repo string) []*github.RepositoryTag {
@@ -275,38 +254,6 @@ func (rule *ImpostorCommitRule) getTags(ctx context.Context, client *github.Clie
 	rule.tagCacheMu.Unlock()
 
 	return allTags
-}
-
-func (rule *ImpostorCommitRule) getBranches(ctx context.Context, client *github.Client, owner, repo string) []*github.Branch {
-	cacheKey := fmt.Sprintf("%s/%s", owner, repo)
-
-	rule.branchCacheMu.Lock()
-	if branches, ok := rule.branchCache[cacheKey]; ok {
-		rule.branchCacheMu.Unlock()
-		return branches
-	}
-	rule.branchCacheMu.Unlock()
-
-	var allBranches []*github.Branch
-	opts := &github.BranchListOptions{ListOptions: github.ListOptions{PerPage: 100}}
-
-	for range maxBranchPages {
-		branches, resp, err := client.Repositories.ListBranches(ctx, owner, repo, opts)
-		if err != nil {
-			break
-		}
-		allBranches = append(allBranches, branches...)
-		if resp.NextPage == 0 {
-			break
-		}
-		opts.Page = resp.NextPage
-	}
-
-	rule.branchCacheMu.Lock()
-	rule.branchCache[cacheKey] = allBranches
-	rule.branchCacheMu.Unlock()
-
-	return allBranches
 }
 
 type impostorCommitFixer struct {

--- a/pkg/core/impostorcommit_test.go
+++ b/pkg/core/impostorcommit_test.go
@@ -1,9 +1,15 @@
 package core
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/google/go-github/v68/github"
 	"github.com/sisaku-security/sisakulint/pkg/ast"
 )
 
@@ -27,8 +33,8 @@ func TestImpostorCommitRuleFactory(t *testing.T) {
 	if rule.tagCache == nil {
 		t.Error("Expected tagCache to be initialized")
 	}
-	if rule.branchCache == nil {
-		t.Error("Expected branchCache to be initialized")
+	if rule.defaultBranchCache == nil {
+		t.Error("Expected defaultBranchCache to be initialized")
 	}
 }
 
@@ -554,5 +560,177 @@ func TestImpostorCommitRule_ErrorMessage(t *testing.T) {
 		if !strings.Contains(errMsg, substr) {
 			t.Errorf("Error message should contain '%s', got: %s", substr, errMsg)
 		}
+	}
+}
+
+// newTestGitHubClient creates a *github.Client pointing at the given test server URL.
+func newTestGitHubClient(serverURL string) *github.Client {
+	client := github.NewClient(nil)
+	baseURL, _ := url.Parse(serverURL + "/")
+	client.BaseURL = baseURL
+	return client
+}
+
+// TestImpostorCommitRule_getDefaultBranch tests getDefaultBranch with a mocked GitHub API.
+func TestImpostorCommitRule_getDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		responseBody string
+		statusCode   int
+		wantBranch   string
+	}{
+		{
+			name:         "returns default branch from API",
+			responseBody: `{"default_branch": "main"}`,
+			statusCode:   http.StatusOK,
+			wantBranch:   "main",
+		},
+		{
+			name:         "returns master when API says master",
+			responseBody: `{"default_branch": "master"}`,
+			statusCode:   http.StatusOK,
+			wantBranch:   "master",
+		},
+		{
+			name:         "falls back to main on API error",
+			responseBody: `{"message": "Internal Server Error"}`,
+			statusCode:   http.StatusInternalServerError,
+			wantBranch:   "main",
+		},
+		{
+			name:         "falls back to main when default_branch is empty",
+			responseBody: `{"default_branch": ""}`,
+			statusCode:   http.StatusOK,
+			wantBranch:   "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			rule := ImpostorCommitRuleFactory()
+			client := newTestGitHubClient(server.URL)
+			branch := rule.getDefaultBranch(context.Background(), client, "owner", "repo")
+
+			if branch != tt.wantBranch {
+				t.Errorf("getDefaultBranch() = %q, want %q", branch, tt.wantBranch)
+			}
+		})
+	}
+}
+
+// TestImpostorCommitRule_getDefaultBranch_UsesCache verifies the second call uses the cache.
+func TestImpostorCommitRule_getDefaultBranch_UsesCache(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"default_branch": "develop"}`))
+	}))
+	defer server.Close()
+
+	rule := ImpostorCommitRuleFactory()
+	client := newTestGitHubClient(server.URL)
+	ctx := context.Background()
+
+	branch1 := rule.getDefaultBranch(ctx, client, "owner", "repo")
+	branch2 := rule.getDefaultBranch(ctx, client, "owner", "repo")
+
+	if branch1 != "develop" || branch2 != "develop" {
+		t.Errorf("expected both calls to return 'develop', got %q and %q", branch1, branch2)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 API call (cache hit on second), got %d", callCount)
+	}
+}
+
+// TestImpostorCommitRule_isReachableFromBranch tests reachability with a mocked GitHub API.
+func TestImpostorCommitRule_isReachableFromBranch(t *testing.T) {
+	t.Parallel()
+
+	const sha = "a81bbbf8298c0fa03ea29cdc473d45769f953675"
+
+	tests := []struct {
+		name          string
+		status        string
+		httpStatus    int
+		wantReachable bool
+		wantErr       bool
+	}{
+		{
+			name:          "behind means reachable",
+			status:        "behind",
+			httpStatus:    http.StatusOK,
+			wantReachable: true,
+		},
+		{
+			name:          "identical means reachable",
+			status:        "identical",
+			httpStatus:    http.StatusOK,
+			wantReachable: true,
+		},
+		{
+			name:          "ahead means not reachable",
+			status:        "ahead",
+			httpStatus:    http.StatusOK,
+			wantReachable: false,
+		},
+		{
+			name:          "diverged means not reachable",
+			status:        "diverged",
+			httpStatus:    http.StatusOK,
+			wantReachable: false,
+		},
+		{
+			name:       "API error is propagated",
+			httpStatus: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.httpStatus)
+				if tt.httpStatus == http.StatusOK {
+					_, _ = fmt.Fprintf(w, `{"status":%q,"ahead_by":0,"behind_by":1,"commits":[],"files":[]}`, tt.status)
+				} else {
+					_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+				}
+			}))
+			defer server.Close()
+
+			rule := ImpostorCommitRuleFactory()
+			client := newTestGitHubClient(server.URL)
+			reachable, err := rule.isReachableFromBranch(context.Background(), client, "owner", "repo", "main", sha)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if reachable != tt.wantReachable {
+				t.Errorf("isReachableFromBranch() = %v, want %v", reachable, tt.wantReachable)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Reverts sisaku-security/sisakulint#358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * コミット検証ロジックを最適化し、GitHub APIの呼び出し回数を削減しました。

* **Bug Fixes**
  * デフォルトブランチからのコミット到達可能性チェックに変更し、より正確な検証を実現しました。

* **Tests**
  * デフォルトブランチの取得とコミット検証シナリオに関する包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->