### PR TITLE
feat: add pull_request_review as privileged trigger

### DIFF
--- a/pkg/core/codeinjectioncritical_test.go
+++ b/pkg/core/codeinjectioncritical_test.go
@@ -46,6 +46,12 @@ func TestCodeInjectionCritical_PrivilegedTriggers(t *testing.T) {
 			description:  "issues should be detected as privileged",
 		},
 		{
+			name:         "pull_request_review is privileged",
+			trigger:      "pull_request_review",
+			shouldDetect: true,
+			description:  "pull_request_review should be detected as privileged (review body is attacker-controlled)",
+		},
+		{
 			name:         "pull_request is not privileged",
 			trigger:      "pull_request",
 			shouldDetect: false,
@@ -131,6 +137,13 @@ func TestCodeInjectionCritical_RunScript(t *testing.T) {
 			runScript:   `echo "${{ github.event.pull_request.title }}"`,
 			wantErrors:  0,
 			description: "Should not detect in non-privileged trigger",
+		},
+		{
+			name:        "pull_request_review trigger + review body injection",
+			trigger:     "pull_request_review",
+			runScript:   `echo "${{ github.event.review.body }}"`,
+			wantErrors:  1,
+			description: "Should detect review body injection in pull_request_review trigger",
 		},
 		{
 			name:        "privileged trigger + trusted input",

--- a/pkg/core/privilegedtriggers.go
+++ b/pkg/core/privilegedtriggers.go
@@ -19,6 +19,7 @@ var PrivilegedTriggers = map[string]bool{
 	"issue_comment":       true, // Triggered by untrusted issue/PR comments
 	"issues":              true, // Can be triggered by external users
 	"discussion_comment":  true, // Triggered by untrusted discussion comments
+	"pull_request_review": true, // Review body is attacker-controlled; runs in base repo context with secrets access
 }
 
 // HasPrivilegedTriggers checks if a workflow has any privileged triggers.

--- a/pkg/core/privilegedtriggers_test.go
+++ b/pkg/core/privilegedtriggers_test.go
@@ -79,6 +79,15 @@ func TestHasPrivilegedTriggers(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "pull_request_review is privileged",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_review"}},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "pull_request is not privileged",
 			workflow: &ast.Workflow{
 				On: []ast.Event{
@@ -303,6 +312,7 @@ func TestPrivilegedTriggersMap(t *testing.T) {
 		"issue_comment",
 		"issues",
 		"discussion_comment",
+		"pull_request_review",
 	}
 
 	for _, trigger := range expectedTriggers {

--- a/pkg/core/reusable_workflow_taint_rule.go
+++ b/pkg/core/reusable_workflow_taint_rule.go
@@ -586,14 +586,7 @@ func (rule *ReusableWorkflowTaintRule) generateEnvVarName(inputName string) stri
 // not "workflow_call". For detecting potential danger in reusable workflows,
 // use isDangerousTriggerForAnalysis which includes workflow_call.
 func isPrivilegedTrigger(eventName string) bool {
-	privilegedTriggers := map[string]bool{
-		"pull_request_target": true,
-		"workflow_run":        true,
-		"issue_comment":       true,
-		"issues":              true,
-		"discussion_comment":  true,
-	}
-	return privilegedTriggers[eventName]
+	return PrivilegedTriggers[eventName]
 }
 
 // isDangerousTriggerForAnalysis checks if an event name should be considered

--- a/script/actions/pull_request_review_injection-safe.yaml
+++ b/script/actions/pull_request_review_injection-safe.yaml
@@ -1,0 +1,12 @@
+# Safe: pull_request_review trigger with review body passed via environment variable
+on: pull_request_review
+
+jobs:
+  process-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process review comment
+        env:
+          REVIEW_BODY: ${{ github.event.review.body }}
+        run: |
+          echo "Review: $REVIEW_BODY"

--- a/script/actions/pull_request_review_injection.yaml
+++ b/script/actions/pull_request_review_injection.yaml
@@ -1,0 +1,13 @@
+# Vulnerable: pull_request_review trigger with review body injection
+# The review body is attacker-controlled and can be used for code injection.
+# Attackers with write access to the repo can submit a malicious review.
+# See: https://adnanekhan.github.io/gato-x/user-guide/advanced/vulnerabilities/
+on: pull_request_review
+
+jobs:
+  process-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process review comment
+        run: |
+          echo "Review: ${{ github.event.review.body }}"


### PR DESCRIPTION
## Summary

- `pull_request_review` をPrivileged Triggerとして追加し、`github.event.review.body` インジェクションを Critical として検出可能にした
- `isPrivilegedTrigger()` が独自マップを持っていた重複を解消し、公開済みの `PrivilegedTriggers` マップへ委譲するようリファクタリング
- サンプルワークフロー (`script/actions/pull_request_review_injection*.yaml`) を追加

## 背景

Gato-X が挙げる **Pull Request Review Injection** シナリオへの対応。

`pull_request_review` イベントはベースリポジトリのコンテキストで実行されるためシークレットにアクセスでき、`issue_comment` と同等のリスクがある。これまで `PrivilegedTriggers` に含まれていなかったため、以下のパターンが検出されていなかった:

```yaml
on: pull_request_review
steps:
  - run: echo "${{ github.event.review.body }}"  # 未検出だった
```

## 変更点

| ファイル | 変更内容 |
|---|---|
| `pkg/core/privilegedtriggers.go` | `pull_request_review` を追加 |
| `pkg/core/reusable_workflow_taint_rule.go` | `isPrivilegedTrigger()` の重複マップを削除し `PrivilegedTriggers` へ委譲 |
| `pkg/core/privilegedtriggers_test.go` | `pull_request_review` のテストケース追加 |
| `pkg/core/codeinjectioncritical_test.go` | review body インジェクション検出テスト追加 |

## Test plan

- [ ] `go test ./...` がすべてパスすること
- [ ] `sisakulint script/actions/pull_request_review_injection.yaml` で `code-injection-critical` が検出されること
- [ ] `sisakulint script/actions/pull_request_review_injection-safe.yaml` でコードインジェクションが検出されないこと

## 参考

- https://adnanekhan.github.io/gato-x/user-guide/advanced/vulnerabilities/
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * pull_request_reviewトリガーに対するコード注入脆弱性の検出機能を追加しました。

* **テスト**
  * pull_request_reviewトリガーの脆弱性検出に関するテストを拡張しました。
  * 特権トリガーの検証テストを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->