### PR TITLE
fix(impostor-commit): detect fake tag pointing to fork commit not reachable from default branch

### DIFF
--- a/pkg/core/impostorcommit.go
+++ b/pkg/core/impostorcommit.go
@@ -181,19 +181,27 @@ func (rule *ImpostorCommitRule) doVerifyCommit(owner, repo, sha string) *commitV
 	}
 	var latestTag string
 	for _, tag := range tags {
+		tagName := tag.GetName()
 		if tag.GetCommit().GetSHA() == sha {
-			return &commitVerificationResult{isImpostor: false}
+			// Do NOT use this tag as a latestTag suggestion. A fake tag pointing to
+			// the impostor SHA must not be offered as an auto-fix target — doing so
+			// would "fix" the workflow to the same malicious commit (Trivy 2026-03).
+			// Fall through to the reachability check without returning early.
+			continue
 		}
-		if latestTag == "" && tag.GetName() != "" {
-			tagName := tag.GetName()
-			if strings.HasPrefix(tagName, "v") {
-				latestTag = tagName
-			}
+		if latestTag == "" && tagName != "" && strings.HasPrefix(tagName, "v") {
+			latestTag = tagName
 		}
 	}
 
 	if latestTag == "" && len(tags) > 0 {
-		latestTag = tags[0].GetName()
+		// Use the first tag that does NOT point to the impostor SHA.
+		for _, tag := range tags {
+			if tag.GetCommit().GetSHA() != sha && tag.GetName() != "" {
+				latestTag = tag.GetName()
+				break
+			}
+		}
 	}
 
 	rule.latestTagCacheMu.Lock()
@@ -237,8 +245,10 @@ func (rule *ImpostorCommitRule) doVerifyCommit(owner, repo, sha string) *commitV
 	}
 
 	// Check reachability from recent tags (limited to avoid exhausting API rate limits).
-	// Track whether any comparison succeeded to detect API degradation.
-	var tagCompareSuccess bool
+	// hadComparableTag tracks whether at least one tag (other than a self-pointing fake
+	// tag) was attempted. tagCompareSuccess tracks whether at least one API call succeeded.
+	// We only fail-open when API calls were attempted but all failed.
+	var tagCompareSuccess, hadComparableTag bool
 	for i, tag := range tags {
 		if i >= maxTagCompareCommits {
 			break
@@ -247,6 +257,13 @@ func (rule *ImpostorCommitRule) doVerifyCommit(owner, repo, sha string) *commitV
 		if tagSha == "" {
 			continue
 		}
+		// Skip comparing the SHA against itself. A fake tag pointing directly to
+		// the impostor SHA would cause CompareCommits(sha, sha) → "identical",
+		// falsely clearing the impostor flag (Trivy supply chain attack).
+		if tagSha == sha {
+			continue
+		}
+		hadComparableTag = true
 		comparison, _, err := client.Repositories.CompareCommits(ctx, owner, repo, tagSha, sha, nil)
 		if err != nil {
 			continue
@@ -258,10 +275,12 @@ func (rule *ImpostorCommitRule) doVerifyCommit(owner, repo, sha string) *commitV
 		}
 	}
 
-	// If we had tags to compare but all API calls failed, fail open
-	if len(tags) > 0 && !tagCompareSuccess {
+	// If we had non-self tags to compare but all API calls failed, fail open to avoid
+	// false positives caused by transient API degradation.
+	if hadComparableTag && !tagCompareSuccess {
 		return &commitVerificationResult{
 			isImpostor: false,
+			latestTag:  latestTag,
 			err:        fmt.Errorf("all tag comparison API calls failed for %s/%s, failing open", owner, repo),
 		}
 	}

--- a/pkg/core/impostorcommit_test.go
+++ b/pkg/core/impostorcommit_test.go
@@ -1144,6 +1144,122 @@ func TestImpostorCommitRule_ForkNetworkImpostor(t *testing.T) {
 	}
 }
 
+// TestImpostorCommitRule_LatestTagExcludesFakeTag tests that latestTag in the result
+// does NOT point to the impostor SHA itself. When a fake tag (e.g. v0.69.4) points
+// to the impostor commit and a legitimate previous tag (e.g. v0.69.3) also exists,
+// auto-fix must use the legitimate tag — not the attacker-controlled one.
+func TestImpostorCommitRule_LatestTagExcludesFakeTag(t *testing.T) {
+	t.Parallel()
+
+	const impostorSha = "1885610ba91f78a85bd655ee2d5bc4bc06d2e43b"
+	const legitimateSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "/tags"):
+			// v0.69.4 is the fake tag pointing to impostor; v0.69.3 is the legitimate previous tag
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w,
+				`[{"name":"v0.69.4","commit":{"sha":"%s"}},{"name":"v0.69.3","commit":{"sha":"%s"}}]`,
+				impostorSha, legitimateSha)
+		case strings.Contains(path, "/branches-where-head"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(path, "/branches") && !strings.Contains(path, "/commits/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"name":"main","commit":{"sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}]`))
+		case strings.HasSuffix(path, "/repos/aquasecurity/trivy-action"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"default_branch":"main"}`))
+		case strings.Contains(path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"diverged","ahead_by":5,"behind_by":0,"commits":[],"files":[]}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	rule := ImpostorCommitRuleFactory()
+	setTestClient(rule, server.URL)
+
+	result := rule.doVerifyCommit("aquasecurity", "trivy-action", impostorSha)
+	if !result.isImpostor {
+		t.Error("expected isImpostor to be true")
+	}
+	// auto-fix must NOT suggest the fake tag that points to the impostor SHA
+	if result.latestTag == "v0.69.4" {
+		t.Errorf("latestTag must not be the fake tag 'v0.69.4' that points to the impostor SHA; auto-fix would re-use the malicious commit")
+	}
+	if result.latestTag != "v0.69.3" {
+		t.Errorf("expected latestTag to be the legitimate previous tag 'v0.69.3', got %q", result.latestTag)
+	}
+}
+
+// TestImpostorCommitRule_TagPointingToForkCommitIsImpostor tests that a SHA which is
+// pointed to by a tag but NOT reachable from the default branch is flagged as an impostor.
+// This reproduces the Trivy supply chain attack pattern where an attacker with
+// write access created a fake tag (e.g. v0.69.4) pointing to a fork commit, bypassing
+// the previous early-return check that treated any tag-SHA match as legitimate.
+func TestImpostorCommitRule_TagPointingToForkCommitIsImpostor(t *testing.T) {
+	t.Parallel()
+
+	// The fork commit injected by the attacker via a fake tag
+	const impostorSha = "1885610ba91f78a85bd655ee2d5bc4bc06d2e43b"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "/tags"):
+			// The attacker created a fake v0.69.4 tag pointing to the impostor SHA
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `[{"name":"v0.69.4","commit":{"sha":"%s"}}]`, impostorSha)
+		case strings.Contains(path, "/branches-where-head"):
+			// Not a branch HEAD in the official repo
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(path, "/branches") && !strings.Contains(path, "/commits/"):
+			// Official branches — none match the impostor SHA
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"name":"main","commit":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]`))
+		case strings.HasSuffix(path, "/repos/aquasecurity/trivy-action"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"default_branch":"main"}`))
+		case strings.Contains(path, "/compare/"):
+			// Fork commit is diverged from all branches and the fake tag itself
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"diverged","ahead_by":5,"behind_by":0,"commits":[],"files":[]}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	rule := ImpostorCommitRuleFactory()
+	setTestClient(rule, server.URL)
+
+	result := rule.doVerifyCommit("aquasecurity", "trivy-action", impostorSha)
+	if !result.isImpostor {
+		t.Error("expected isImpostor to be true: tag v0.69.4 points to a fork commit not reachable from main, but got false")
+	}
+	if result.err != nil {
+		t.Errorf("unexpected error: %v", result.err)
+	}
+	// The only tag (v0.69.4) points to the impostor SHA itself — it must not be
+	// used as an auto-fix suggestion. No safe alternative tag exists, so latestTag
+	// should be empty.
+	if result.latestTag != "" {
+		t.Errorf("expected latestTag to be empty (fake tag must not be suggested), got %q", result.latestTag)
+	}
+}
+
 // TestImpostorCommitRule_BranchHeadAPIUnavailable_FallthroughToReachability tests that
 // when the branches-where-head API is unavailable (500), the rule falls through to
 // the default branch reachability check and succeeds.


### PR DESCRIPTION
## Summary

- `ImpostorCommitRule` がタグのSHAと一致した時点で即 `isImpostor: false` を返す早期リターンバグを修正
- 偽タグが指すSHAを `latestTag`（auto-fix提案）に使わないよう修正
- per-tag `CompareCommits(sha, sha)` による別経路の誤クリアを修正
- fail-openガードを self-pointing タグをスキップした場合に誤発動しないよう修正

## 背景

Trivyサプライチェーン攻撃（2026-03）で使われた手法への対応。攻撃者はリポジトリへのwrite権限（窃取したPAT）を使い、forkネットワーク上の悪意あるコミットに偽タグ（`v0.69.4`）を作成した。修正前は「タグが存在する = 正規コミット」と判定していたため検出が漏れていた。

修正後はデフォルトブランチからの到達可能性まで確認するため、偽タグが付いたforkコミットも正しく検出できる。

ref: https://diary.shift-js.info/trivy-compromise/

## Test plan

- [x] `TestImpostorCommitRule_TagPointingToForkCommitIsImpostor` — 偽タグ経由のforkコミットを検出
- [x] `TestImpostorCommitRule_LatestTagExcludesFakeTag` — auto-fixが偽タグを提案しないことを確認
- [x] 既存の全テストがgreen

Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インポスターコミット検出時のタグ処理ロジックを改善しました。
  * 重複コミット比較による誤検出を防止し、検出精度を向上させました。

* **テスト**
  * インポスター検出とタグ選択に関するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->