### PR TITLE
fix(artifact-poisoning): add bare ubuntu label support and strict runner.temp matching

### DIFF
--- a/pkg/core/artifactpoisoningcritical.go
+++ b/pkg/core/artifactpoisoningcritical.go
@@ -40,7 +40,7 @@ func detectRunnerOS(runner *ast.Runner) string {
 		}
 		v := label.Value
 		lower := strings.ToLower(v)
-		if strings.HasPrefix(lower, "ubuntu-") || strings.EqualFold(v, "linux") {
+		if strings.HasPrefix(lower, "ubuntu-") || strings.EqualFold(v, "ubuntu") || strings.EqualFold(v, "linux") {
 			return "linux"
 		}
 		if strings.HasPrefix(lower, "windows-") || strings.EqualFold(v, "windows") {

--- a/pkg/core/artifactpoisoningcritical_test.go
+++ b/pkg/core/artifactpoisoningcritical_test.go
@@ -113,6 +113,17 @@ func TestDetectRunnerOS(t *testing.T) {
 			runner: &ast.Runner{Labels: []*ast.String{{Value: "MacOS-Latest"}}},
 			wantOS: "macos",
 		},
+		// bare distro names (no version suffix)
+		{
+			name:   "bare ubuntu label",
+			runner: &ast.Runner{Labels: []*ast.String{{Value: "ubuntu"}}},
+			wantOS: "linux",
+		},
+		{
+			name:   "bare Ubuntu label (uppercase)",
+			runner: &ast.Runner{Labels: []*ast.String{{Value: "Ubuntu"}}},
+			wantOS: "linux",
+		},
 		// unknown
 		{
 			name:   "self-hosted only",

--- a/pkg/core/artifactpoisoningmedium.go
+++ b/pkg/core/artifactpoisoningmedium.go
@@ -125,8 +125,10 @@ func (rule *ArtifactPoisoningMedium) VisitStep(node *ast.Step) error {
 	hasSafePath := false
 	if pathInput, ok := action.Inputs["path"]; ok && pathInput != nil && pathInput.Value != nil {
 		pathValue := pathInput.Value.Value
-		// Check if path uses runner.temp (safe extraction location)
-		if strings.Contains(pathValue, "runner.temp") || strings.Contains(pathValue, "RUNNER_TEMP") {
+		// Check if path uses runner.temp (safe extraction location).
+		// Use strict prefix matching to avoid false positives from similar-named variables
+		// (e.g. runner.tempDir) or path-traversal bypasses (e.g. runner.temp/../_work).
+		if isRunnerTempPath(pathValue) {
 			hasSafePath = true
 		}
 	}

--- a/pkg/core/artifactpoisoningmedium_test.go
+++ b/pkg/core/artifactpoisoningmedium_test.go
@@ -269,6 +269,46 @@ func TestArtifactPoisoningMedium_VisitStep(t *testing.T) {
 			wantErrors: 1,
 			wantFixers: 1, // Should fix unsafe path
 		},
+		{
+			// runner.tempDir is NOT runner.temp; must be treated as unsafe
+			name:     "runner.tempDir is not a safe path",
+			triggers: []string{"workflow_run"},
+			step: &ast.Step{
+				ID: &ast.String{Value: "download"},
+				Exec: &ast.ExecAction{
+					Uses: &ast.String{Value: "dawidd6/action-download-artifact@v2"},
+					Inputs: map[string]*ast.Input{
+						"path": {
+							Name:  &ast.String{Value: "path"},
+							Value: &ast.String{Value: "${{ runner.tempDir }}/artifacts"},
+						},
+					},
+				},
+				Pos: &ast.Position{Line: 10, Col: 5},
+			},
+			wantErrors: 1,
+			wantFixers: 1, // unsafe path should trigger fixer
+		},
+		{
+			// Path traversal via runner.temp must not be treated as safe
+			name:     "runner.temp path traversal is unsafe",
+			triggers: []string{"workflow_run"},
+			step: &ast.Step{
+				ID: &ast.String{Value: "download"},
+				Exec: &ast.ExecAction{
+					Uses: &ast.String{Value: "dawidd6/action-download-artifact@v2"},
+					Inputs: map[string]*ast.Input{
+						"path": {
+							Name:  &ast.String{Value: "path"},
+							Value: &ast.String{Value: "${{ runner.temp }}/../_work/repo"},
+						},
+					},
+				},
+				Pos: &ast.Position{Line: 10, Col: 5},
+			},
+			wantErrors: 1,
+			wantFixers: 1, // unsafe path should trigger fixer
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Follow-up to #403.

- `detectRunnerOS`: `ubuntu` / `Ubuntu` など suffix なしのラベルを linux として認識するよう追加
- `ArtifactPoisoningMedium`: `strings.Contains` を `isRunnerTempPath()` に置き換え、`runner.tempDir` や `runner.temp/../_work` のような偽陰性・パストラバーサルバイパスを防止
- 上記に対応するテストケースを追加

## Test plan

- [ ] `go test ./pkg/core -run TestDetectRunnerOS` — bare ubuntu ラベルのケースを確認
- [ ] `go test ./pkg/core -run TestArtifactPoisoningMedium` — runner.tempDir / パストラバーサルのケースを確認
- [ ] `go test ./...` — 全パッケージ通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Ubuntu ランナーの OS 検出を改善しました。バージョンサフィックスなしの "ubuntu" ラベルに対応しました。
  * アーティファクトダウンロード時のパス安全性検証を強化しました。より正確なパス判定によりパストラバーサル攻撃の検出精度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->