### PR TITLE
feat: Apply WorkflowTaintMap cross-job taint to EnvVarInjection / ArgumentInjection / RequestForgery rules

### DIFF
--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -22,8 +22,6 @@ type ArgumentInjectionRule struct {
 	taintTracker *TaintTracker
 	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
 	pendingCrossJobChecks []pendingCrossJobCheck
-	// workflowTriggers stores all trigger names from the workflow
-	workflowTriggers []string
 }
 
 type stepWithArgumentInjection struct {
@@ -133,18 +131,6 @@ func newArgumentInjectionRule(severityLevel string, checkPrivileged bool, wfTain
 
 func (rule *ArgumentInjectionRule) VisitWorkflowPre(node *ast.Workflow) error {
 	rule.workflow = node
-	rule.workflowTriggers = nil
-
-	for _, event := range node.On {
-		switch e := event.(type) {
-		case *ast.WebhookEvent:
-			if e.Hook != nil {
-				rule.workflowTriggers = append(rule.workflowTriggers, e.Hook.Value)
-			}
-		case *ast.WorkflowCallEvent:
-			rule.workflowTriggers = append(rule.workflowTriggers, "workflow_call")
-		}
-	}
 
 	if rule.workflowTaintMap != nil {
 		rule.workflowTaintMap.Reset()

--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -22,6 +22,8 @@ type ArgumentInjectionRule struct {
 	taintTracker *TaintTracker
 	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
 	pendingCrossJobChecks []pendingCrossJobCheck
+	// pendingCrossJobSet deduplicates pending checks by expr.raw + commandName + step pointer.
+	pendingCrossJobSet map[string]bool
 }
 
 type stepWithArgumentInjection struct {
@@ -135,6 +137,7 @@ func (rule *ArgumentInjectionRule) VisitWorkflowPre(node *ast.Workflow) error {
 	if rule.workflowTaintMap != nil {
 		rule.workflowTaintMap.Reset()
 		rule.pendingCrossJobChecks = nil
+		rule.pendingCrossJobSet = nil
 	}
 
 	return nil
@@ -277,10 +280,17 @@ func (rule *ArgumentInjectionRule) analyzeExpressions(
 			}
 		}
 
-		// Register cross-job pending checks for each dangerous usage (one per occurrence)
+		// Register cross-job pending checks for each dangerous usage (deduplicated by expr+command+step)
 		if rule.workflowTaintMap != nil && isNeedsOutputExpr(*expr) {
 			for _, usage := range dangerousUsages {
-				rule.addPendingArgInjCrossJobCheck(*expr, usage.CommandName, s)
+				key := fmt.Sprintf("%s@%s@%p", expr.raw, usage.CommandName, s)
+				if rule.pendingCrossJobSet == nil {
+					rule.pendingCrossJobSet = make(map[string]bool)
+				}
+				if !rule.pendingCrossJobSet[key] {
+					rule.pendingCrossJobSet[key] = true
+					rule.addPendingArgInjCrossJobCheck(*expr, usage.CommandName, s)
+				}
 			}
 		}
 
@@ -390,6 +400,7 @@ func (rule *ArgumentInjectionRule) VisitWorkflowPost(node *ast.Workflow) error {
 	}
 
 	rule.pendingCrossJobChecks = nil
+	rule.pendingCrossJobSet = nil
 	return nil
 }
 

--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -15,6 +15,15 @@ type ArgumentInjectionRule struct {
 	checkPrivileged    bool
 	stepsWithUntrusted []*stepWithArgumentInjection
 	workflow           *ast.Workflow
+	// workflowTaintMap is shared between Critical and Medium rule instances.
+	// Nil if cross-job taint propagation is disabled (e.g., in unit tests).
+	workflowTaintMap *WorkflowTaintMap
+	// taintTracker tracks intra-job taint; used only for RegisterJobOutputs.
+	taintTracker *TaintTracker
+	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
+	pendingCrossJobChecks []pendingCrossJobCheck
+	// workflowTriggers stores all trigger names from the workflow
+	workflowTriggers []string
 }
 
 type stepWithArgumentInjection struct {
@@ -101,7 +110,7 @@ func init() {
 	}
 }
 
-func newArgumentInjectionRule(severityLevel string, checkPrivileged bool) *ArgumentInjectionRule {
+func newArgumentInjectionRule(severityLevel string, checkPrivileged bool, wfTaintMap *WorkflowTaintMap) *ArgumentInjectionRule {
 	var desc string
 
 	if checkPrivileged {
@@ -118,15 +127,45 @@ func newArgumentInjectionRule(severityLevel string, checkPrivileged bool) *Argum
 		severityLevel:      severityLevel,
 		checkPrivileged:    checkPrivileged,
 		stepsWithUntrusted: make([]*stepWithArgumentInjection, 0),
+		workflowTaintMap:   wfTaintMap,
 	}
 }
 
 func (rule *ArgumentInjectionRule) VisitWorkflowPre(node *ast.Workflow) error {
 	rule.workflow = node
+	rule.workflowTriggers = nil
+
+	for _, event := range node.On {
+		switch e := event.(type) {
+		case *ast.WebhookEvent:
+			if e.Hook != nil {
+				rule.workflowTriggers = append(rule.workflowTriggers, e.Hook.Value)
+			}
+		case *ast.WorkflowCallEvent:
+			rule.workflowTriggers = append(rule.workflowTriggers, "workflow_call")
+		}
+	}
+
+	if rule.workflowTaintMap != nil {
+		rule.workflowTaintMap.Reset()
+		rule.pendingCrossJobChecks = nil
+	}
+
 	return nil
 }
 
 func (rule *ArgumentInjectionRule) VisitJobPre(node *ast.Job) error {
+	// Initialize taint tracker per job for cross-job output registration.
+	rule.taintTracker = NewTaintTracker()
+	for _, s := range node.Steps {
+		rule.taintTracker.AnalyzeStep(s)
+	}
+
+	// Register this job's outputs into WorkflowTaintMap for downstream jobs.
+	if rule.workflowTaintMap != nil && node.ID != nil {
+		rule.workflowTaintMap.RegisterJobOutputs(node.ID.Value, rule.taintTracker, node.Outputs)
+	}
+
 	if !rule.shouldProcessJob() {
 		return nil
 	}
@@ -190,6 +229,9 @@ func (rule *ArgumentInjectionRule) buildUntrustedSet(exprs []parsedExpression, e
 		untrustedPaths := rule.checkUntrustedInput(expr)
 		if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, env) {
 			untrustedSet[expr.raw] = untrustedPaths
+		}
+		if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
+			rule.addPendingArgInjCrossJobCheck(expr)
 		}
 	}
 	return untrustedSet
@@ -280,6 +322,55 @@ func (rule *ArgumentInjectionRule) reportArgumentInjection(pos *ast.Position, pa
 		cmdName,
 		suffix,
 	)
+}
+
+// addPendingArgInjCrossJobCheck queues a needs.*.outputs.* expression for deferred cross-job resolution.
+func (rule *ArgumentInjectionRule) addPendingArgInjCrossJobCheck(expr parsedExpression) {
+	exprStr := exprNodeToString(expr.node)
+	lower := strings.ToLower(exprStr)
+	parts := strings.Split(lower, ".")
+	if len(parts) < 4 || parts[0] != "needs" || parts[2] != "outputs" {
+		return
+	}
+	rule.pendingCrossJobChecks = append(rule.pendingCrossJobChecks, pendingCrossJobCheck{
+		expr:       expr,
+		needsJobID: parts[1],
+		outputName: strings.Join(parts[3:], "."),
+	})
+}
+
+// VisitWorkflowPost resolves deferred needs.*.outputs.* checks via WorkflowTaintMap.
+func (rule *ArgumentInjectionRule) VisitWorkflowPost(node *ast.Workflow) error {
+	if rule.workflowTaintMap == nil || len(rule.pendingCrossJobChecks) == 0 {
+		return nil
+	}
+
+	for _, pending := range rule.pendingCrossJobChecks {
+		sources, stillPending := rule.workflowTaintMap.ResolveFromExprNode(pending.expr.node)
+		if stillPending || len(sources) == 0 {
+			continue
+		}
+
+		taintPath := fmt.Sprintf("%s (tainted via %s)", pending.expr.raw, strings.Join(sources, ", "))
+
+		severity := "medium"
+		suffix := ""
+		if rule.checkPrivileged {
+			severity = "critical"
+			suffix = " in a workflow with privileged triggers"
+		}
+
+		rule.Errorf(
+			pending.expr.pos,
+			"argument injection (%s): \"%s\" is potentially untrusted and may be used as command-line argument%s. Attackers can inject malicious options (e.g., --output=/etc/passwd). Use '--' to end option parsing or pass through environment variables. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions",
+			severity,
+			taintPath,
+			suffix,
+		)
+	}
+
+	rule.pendingCrossJobChecks = nil
+	return nil
 }
 
 func (rule *ArgumentInjectionRule) hasPrivilegedTriggers() bool {

--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -277,14 +277,10 @@ func (rule *ArgumentInjectionRule) analyzeExpressions(
 			}
 		}
 
-		// Register cross-job pending checks for each dangerous usage (unique commands)
+		// Register cross-job pending checks for each dangerous usage (one per occurrence)
 		if rule.workflowTaintMap != nil && isNeedsOutputExpr(*expr) {
-			registered := make(map[string]bool)
 			for _, usage := range dangerousUsages {
-				if !registered[usage.CommandName] {
-					registered[usage.CommandName] = true
-					rule.addPendingArgInjCrossJobCheck(*expr, usage.CommandName, s)
-				}
+				rule.addPendingArgInjCrossJobCheck(*expr, usage.CommandName, s)
 			}
 		}
 

--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -181,7 +181,20 @@ func (rule *ArgumentInjectionRule) processStep(s *ast.Step) {
 	}
 
 	untrustedSet := rule.buildUntrustedSet(exprs, s.Env)
-	if len(untrustedSet) == 0 {
+
+	// Even if no expressions are directly untrusted, needs output expressions
+	// may be tainted cross-job and need shell AST analysis for context.
+	hasNeedsOutputs := false
+	if rule.workflowTaintMap != nil {
+		for _, expr := range exprs {
+			if isNeedsOutputExpr(expr) {
+				hasNeedsOutputs = true
+				break
+			}
+		}
+	}
+
+	if len(untrustedSet) == 0 && !hasNeedsOutputs {
 		return
 	}
 
@@ -215,9 +228,6 @@ func (rule *ArgumentInjectionRule) buildUntrustedSet(exprs []parsedExpression, e
 		untrustedPaths := rule.checkUntrustedInput(expr)
 		if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, env) {
 			untrustedSet[expr.raw] = untrustedPaths
-		}
-		if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
-			rule.addPendingArgInjCrossJobCheck(expr)
 		}
 	}
 	return untrustedSet
@@ -256,19 +266,34 @@ func (rule *ArgumentInjectionRule) analyzeExpressions(
 	for i := range exprs {
 		expr := &exprs[i]
 
+		placeholderName := exprToPlaceholder[expr.raw]
+		varUsages := parser.FindVarUsageAsCommandArg(placeholderName, dangerousCmdNames)
+
+		// Filter to dangerous usages (not after --)
+		var dangerousUsages []shell.VarArgUsage
+		for _, varUsage := range varUsages {
+			if !varUsage.IsAfterDoubleDash {
+				dangerousUsages = append(dangerousUsages, varUsage)
+			}
+		}
+
+		// Register cross-job pending checks for each dangerous usage (unique commands)
+		if rule.workflowTaintMap != nil && isNeedsOutputExpr(*expr) {
+			registered := make(map[string]bool)
+			for _, usage := range dangerousUsages {
+				if !registered[usage.CommandName] {
+					registered[usage.CommandName] = true
+					rule.addPendingArgInjCrossJobCheck(*expr, usage.CommandName, s)
+				}
+			}
+		}
+
 		untrustedPaths, isUntrusted := untrustedSet[expr.raw]
 		if !isUntrusted {
 			continue
 		}
 
-		placeholderName := exprToPlaceholder[expr.raw]
-		varUsages := parser.FindVarUsageAsCommandArg(placeholderName, dangerousCmdNames)
-
-		for _, varUsage := range varUsages {
-			if varUsage.IsAfterDoubleDash {
-				continue
-			}
-
+		for _, varUsage := range dangerousUsages {
 			if stepUntrusted == nil {
 				stepUntrusted = &stepWithArgumentInjection{step: s}
 			}
@@ -311,7 +336,8 @@ func (rule *ArgumentInjectionRule) reportArgumentInjection(pos *ast.Position, pa
 }
 
 // addPendingArgInjCrossJobCheck queues a needs.*.outputs.* expression for deferred cross-job resolution.
-func (rule *ArgumentInjectionRule) addPendingArgInjCrossJobCheck(expr parsedExpression) {
+// commandName is the sink command confirmed by shell AST analysis to be in a dangerous arg position.
+func (rule *ArgumentInjectionRule) addPendingArgInjCrossJobCheck(expr parsedExpression, commandName string, step *ast.Step) {
 	exprStr := exprNodeToString(expr.node)
 	lower := strings.ToLower(exprStr)
 	parts := strings.Split(lower, ".")
@@ -319,9 +345,11 @@ func (rule *ArgumentInjectionRule) addPendingArgInjCrossJobCheck(expr parsedExpr
 		return
 	}
 	rule.pendingCrossJobChecks = append(rule.pendingCrossJobChecks, pendingCrossJobCheck{
-		expr:       expr,
-		needsJobID: parts[1],
-		outputName: strings.Join(parts[3:], "."),
+		expr:        expr,
+		needsJobID:  parts[1],
+		outputName:  strings.Join(parts[3:], "."),
+		commandName: commandName,
+		step:        step,
 	})
 }
 
@@ -337,7 +365,16 @@ func (rule *ArgumentInjectionRule) VisitWorkflowPost(node *ast.Workflow) error {
 			continue
 		}
 
+		if pending.step != nil && rule.isDefinedInEnv(pending.expr, pending.step.Env) {
+			continue
+		}
+
 		taintPath := fmt.Sprintf("%s (tainted via %s)", pending.expr.raw, strings.Join(sources, ", "))
+
+		cmdDesc := pending.commandName
+		if cmdDesc == "" {
+			cmdDesc = "command"
+		}
 
 		severity := "medium"
 		suffix := ""
@@ -348,9 +385,10 @@ func (rule *ArgumentInjectionRule) VisitWorkflowPost(node *ast.Workflow) error {
 
 		rule.Errorf(
 			pending.expr.pos,
-			"argument injection (%s): \"%s\" is potentially untrusted and may be used as command-line argument%s. Attackers can inject malicious options (e.g., --output=/etc/passwd). Use '--' to end option parsing or pass through environment variables. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions",
+			"argument injection (%s): \"%s\" is potentially untrusted and used as command-line argument to '%s'%s. Attackers can inject malicious options (e.g., --output=/etc/passwd). Use '--' to end option parsing or pass through environment variables. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions",
 			severity,
 			taintPath,
+			cmdDesc,
 			suffix,
 		)
 	}

--- a/pkg/core/argumentinjection_test.go
+++ b/pkg/core/argumentinjection_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestArgumentInjectionCriticalRule(t *testing.T) {
 	t.Parallel()
-	rule := ArgumentInjectionCriticalRule()
+	rule := ArgumentInjectionCriticalRule(nil)
 	if rule.RuleName != "argument-injection-critical" {
 		t.Errorf("RuleName = %q, want %q", rule.RuleName, "argument-injection-critical")
 	}
@@ -17,7 +17,7 @@ func TestArgumentInjectionCriticalRule(t *testing.T) {
 
 func TestArgumentInjectionMediumRule(t *testing.T) {
 	t.Parallel()
-	rule := ArgumentInjectionMediumRule()
+	rule := ArgumentInjectionMediumRule(nil)
 	if rule.RuleName != "argument-injection-medium" {
 		t.Errorf("RuleName = %q, want %q", rule.RuleName, "argument-injection-medium")
 	}
@@ -67,7 +67,7 @@ func TestArgumentInjection_PrivilegedTriggers(t *testing.T) {
 		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			rule := ArgumentInjectionCriticalRule()
+			rule := ArgumentInjectionCriticalRule(nil)
 
 			// Create workflow with specified trigger
 			workflow := &ast.Workflow{
@@ -208,7 +208,7 @@ func TestArgumentInjection_DangerousCommands(t *testing.T) {
 		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			rule := ArgumentInjectionCriticalRule()
+			rule := ArgumentInjectionCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -298,7 +298,7 @@ func TestArgumentInjection_SafePatterns(t *testing.T) {
 		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			rule := ArgumentInjectionCriticalRule()
+			rule := ArgumentInjectionCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -369,7 +369,7 @@ echo "safe"`,
 		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			rule := ArgumentInjectionCriticalRule()
+			rule := ArgumentInjectionCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -439,7 +439,7 @@ func TestArgumentInjection_MediumRule(t *testing.T) {
 		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			rule := ArgumentInjectionMediumRule()
+			rule := ArgumentInjectionMediumRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -499,7 +499,7 @@ func TestArgumentInjection_ErrorMessages(t *testing.T) {
 		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			rule := ArgumentInjectionCriticalRule()
+			rule := ArgumentInjectionCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -541,7 +541,7 @@ func TestArgumentInjection_ErrorMessages(t *testing.T) {
 
 func TestArgumentInjection_GenerateEnvVarName(t *testing.T) {
 	t.Parallel()
-	rule := ArgumentInjectionCriticalRule()
+	rule := ArgumentInjectionCriticalRule(nil)
 
 	tests := []struct {
 		path     string

--- a/pkg/core/argumentinjectioncritical.go
+++ b/pkg/core/argumentinjectioncritical.go
@@ -1,5 +1,5 @@
 package core
 
-func ArgumentInjectionCriticalRule() *ArgumentInjectionRule {
-	return newArgumentInjectionRule("critical", true)
+func ArgumentInjectionCriticalRule(wfTaintMap *WorkflowTaintMap) *ArgumentInjectionRule {
+	return newArgumentInjectionRule("critical", true, wfTaintMap)
 }

--- a/pkg/core/argumentinjectionmedium.go
+++ b/pkg/core/argumentinjectionmedium.go
@@ -1,5 +1,5 @@
 package core
 
-func ArgumentInjectionMediumRule() *ArgumentInjectionRule {
-	return newArgumentInjectionRule("medium", false)
+func ArgumentInjectionMediumRule(wfTaintMap *WorkflowTaintMap) *ArgumentInjectionRule {
+	return newArgumentInjectionRule("medium", false, wfTaintMap)
 }

--- a/pkg/core/codeinjection.go
+++ b/pkg/core/codeinjection.go
@@ -204,7 +204,7 @@ func (rule *CodeInjectionRule) VisitJobPre(node *ast.Job) error {
 			for _, expr := range exprs {
 				// Use checkUntrustedInputWithTaint to also detect tainted step outputs
 				untrustedPaths := rule.checkUntrustedInputWithTaint(expr)
-				if rule.workflowTaintMap != nil && rule.isNeedsOutputExpr(expr) {
+				if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
 					rule.addPendingCrossJobCheck(expr, s, true, nil)
 				}
 				if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, s.Env) {
@@ -232,7 +232,7 @@ func (rule *CodeInjectionRule) VisitJobPre(node *ast.Job) error {
 					for _, expr := range exprs {
 						// Use checkUntrustedInputWithTaint to also detect tainted step outputs
 						untrustedPaths := rule.checkUntrustedInputWithTaint(expr)
-						if rule.workflowTaintMap != nil && rule.isNeedsOutputExpr(expr) {
+						if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
 							rule.addPendingCrossJobCheck(expr, s, false, scriptInput)
 						}
 						if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, s.Env) {
@@ -612,7 +612,8 @@ func (rule *CodeInjectionRule) checkUntrustedInputWithTaint(expr parsedExpressio
 }
 
 // isNeedsOutputExpr returns true if the expression is a needs.X.outputs.Y reference.
-func (rule *CodeInjectionRule) isNeedsOutputExpr(expr parsedExpression) bool {
+// This is a package-level function so it can be reused by multiple injection rules.
+func isNeedsOutputExpr(expr parsedExpression) bool {
 	exprStr := exprNodeToString(expr.node)
 	lower := strings.ToLower(exprStr)
 	parts := strings.Split(lower, ".")

--- a/pkg/core/codeinjection.go
+++ b/pkg/core/codeinjection.go
@@ -62,6 +62,10 @@ type pendingCrossJobCheck struct {
 	step          *ast.Step  // the step containing the expression; needed for isDefinedInEnv and auto-fix
 	isInRunScript bool       // true = run: script, false = actions/github-script
 	scriptInput   *ast.Input // non-nil when isInRunScript is false
+	// commandName is the sink command (e.g., "git", "curl"); used by argument-injection and request-forgery rules.
+	commandName string
+	// reqForgerySeverity preserves the original severity from the sink analysis; used by request-forgery rule.
+	reqForgerySeverity RequestForgerySeverity
 }
 
 // stepWithUntrustedInput tracks steps that need auto-fixing

--- a/pkg/core/envvarinjection.go
+++ b/pkg/core/envvarinjection.go
@@ -26,8 +26,6 @@ type EnvVarInjectionRule struct {
 	taintTracker *TaintTracker
 	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
 	pendingCrossJobChecks []pendingCrossJobCheck
-	// workflowTriggers stores all trigger names from the workflow
-	workflowTriggers []string
 }
 
 // stepWithEnvVarInjection tracks steps that need auto-fixing for environment variable injection
@@ -81,18 +79,6 @@ func newEnvVarInjectionRule(severityLevel string, checkPrivileged bool, wfTaintM
 // VisitWorkflowPre is called before visiting a workflow
 func (rule *EnvVarInjectionRule) VisitWorkflowPre(node *ast.Workflow) error {
 	rule.workflow = node
-	rule.workflowTriggers = nil
-
-	for _, event := range node.On {
-		switch e := event.(type) {
-		case *ast.WebhookEvent:
-			if e.Hook != nil {
-				rule.workflowTriggers = append(rule.workflowTriggers, e.Hook.Value)
-			}
-		case *ast.WorkflowCallEvent:
-			rule.workflowTriggers = append(rule.workflowTriggers, "workflow_call")
-		}
-	}
 
 	if rule.workflowTaintMap != nil {
 		rule.workflowTaintMap.Reset()
@@ -164,7 +150,7 @@ func (rule *EnvVarInjectionRule) VisitJobPre(node *ast.Job) error {
 
 				untrustedPaths := rule.checkUntrustedInput(expr)
 				if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
-					rule.addPendingEnvVarCrossJobCheck(expr, s, line)
+					rule.addPendingEnvVarCrossJobCheck(expr, s)
 				}
 				if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, s.Env) {
 					if stepUntrusted == nil {
@@ -534,7 +520,7 @@ func (rule *EnvVarInjectionRule) isDefinedInEnv(expr parsedExpression, env *ast.
 }
 
 // addPendingEnvVarCrossJobCheck parses expr for needs.X.outputs.Y and stores it for retry in VisitWorkflowPost.
-func (rule *EnvVarInjectionRule) addPendingEnvVarCrossJobCheck(expr parsedExpression, step *ast.Step, line string) {
+func (rule *EnvVarInjectionRule) addPendingEnvVarCrossJobCheck(expr parsedExpression, step *ast.Step) {
 	exprStr := exprNodeToString(expr.node)
 	lower := strings.ToLower(exprStr)
 	parts := strings.Split(lower, ".")

--- a/pkg/core/envvarinjection.go
+++ b/pkg/core/envvarinjection.go
@@ -19,6 +19,15 @@ type EnvVarInjectionRule struct {
 	checkPrivileged    bool   // true = check privileged triggers, false = check normal triggers
 	stepsWithUntrusted []*stepWithEnvVarInjection
 	workflow           *ast.Workflow
+	// workflowTaintMap is shared between Critical and Medium rule instances.
+	// Nil if cross-job taint propagation is disabled (e.g., in unit tests).
+	workflowTaintMap *WorkflowTaintMap
+	// taintTracker tracks intra-job taint; used only for RegisterJobOutputs.
+	taintTracker *TaintTracker
+	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
+	pendingCrossJobChecks []pendingCrossJobCheck
+	// workflowTriggers stores all trigger names from the workflow
+	workflowTriggers []string
 }
 
 // stepWithEnvVarInjection tracks steps that need auto-fixing for environment variable injection
@@ -48,7 +57,7 @@ type envVarUntrustedExprInfo struct {
 var githubEnvPattern = regexp.MustCompile(`>>\s*["']?\$\{?GITHUB_ENV\}?["']?`)
 
 // newEnvVarInjectionRule creates a new environment variable injection rule with the specified severity level
-func newEnvVarInjectionRule(severityLevel string, checkPrivileged bool) *EnvVarInjectionRule {
+func newEnvVarInjectionRule(severityLevel string, checkPrivileged bool, wfTaintMap *WorkflowTaintMap) *EnvVarInjectionRule {
 	var desc string
 
 	if checkPrivileged {
@@ -65,16 +74,46 @@ func newEnvVarInjectionRule(severityLevel string, checkPrivileged bool) *EnvVarI
 		severityLevel:      severityLevel,
 		checkPrivileged:    checkPrivileged,
 		stepsWithUntrusted: make([]*stepWithEnvVarInjection, 0),
+		workflowTaintMap:   wfTaintMap,
 	}
 }
 
 // VisitWorkflowPre is called before visiting a workflow
 func (rule *EnvVarInjectionRule) VisitWorkflowPre(node *ast.Workflow) error {
 	rule.workflow = node
+	rule.workflowTriggers = nil
+
+	for _, event := range node.On {
+		switch e := event.(type) {
+		case *ast.WebhookEvent:
+			if e.Hook != nil {
+				rule.workflowTriggers = append(rule.workflowTriggers, e.Hook.Value)
+			}
+		case *ast.WorkflowCallEvent:
+			rule.workflowTriggers = append(rule.workflowTriggers, "workflow_call")
+		}
+	}
+
+	if rule.workflowTaintMap != nil {
+		rule.workflowTaintMap.Reset()
+		rule.pendingCrossJobChecks = nil
+	}
+
 	return nil
 }
 
 func (rule *EnvVarInjectionRule) VisitJobPre(node *ast.Job) error {
+	// Initialize taint tracker per job for cross-job output registration.
+	rule.taintTracker = NewTaintTracker()
+	for _, s := range node.Steps {
+		rule.taintTracker.AnalyzeStep(s)
+	}
+
+	// Register this job's outputs into WorkflowTaintMap for downstream jobs.
+	if rule.workflowTaintMap != nil && node.ID != nil {
+		rule.workflowTaintMap.RegisterJobOutputs(node.ID.Value, rule.taintTracker, node.Outputs)
+	}
+
 	// Check if workflow trigger matches what we're looking for
 	isPrivileged := rule.hasPrivilegedTriggers()
 
@@ -124,6 +163,9 @@ func (rule *EnvVarInjectionRule) VisitJobPre(node *ast.Job) error {
 				}
 
 				untrustedPaths := rule.checkUntrustedInput(expr)
+				if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
+					rule.addPendingEnvVarCrossJobCheck(expr, s, line)
+				}
 				if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, s.Env) {
 					if stepUntrusted == nil {
 						stepUntrusted = &stepWithEnvVarInjection{step: s}
@@ -489,4 +531,59 @@ func (rule *EnvVarInjectionRule) isDefinedInEnv(expr parsedExpression, env *ast.
 	}
 
 	return false
+}
+
+// addPendingEnvVarCrossJobCheck parses expr for needs.X.outputs.Y and stores it for retry in VisitWorkflowPost.
+func (rule *EnvVarInjectionRule) addPendingEnvVarCrossJobCheck(expr parsedExpression, step *ast.Step, line string) {
+	exprStr := exprNodeToString(expr.node)
+	lower := strings.ToLower(exprStr)
+	parts := strings.Split(lower, ".")
+	if len(parts) < 4 || parts[0] != "needs" || parts[2] != "outputs" {
+		return
+	}
+	rule.pendingCrossJobChecks = append(rule.pendingCrossJobChecks, pendingCrossJobCheck{
+		expr:       expr,
+		needsJobID: parts[1],
+		outputName: strings.Join(parts[3:], "."),
+		step:       step,
+	})
+}
+
+// VisitWorkflowPost is called after all jobs have been visited.
+// It flushes pending cross-job taint checks that couldn't be resolved during VisitJobPre
+// (e.g., when a downstream job appears before its upstream job in the yaml file).
+func (rule *EnvVarInjectionRule) VisitWorkflowPost(node *ast.Workflow) error {
+	if rule.workflowTaintMap == nil || len(rule.pendingCrossJobChecks) == 0 {
+		return nil
+	}
+
+	for _, pending := range rule.pendingCrossJobChecks {
+		sources, stillPending := rule.workflowTaintMap.ResolveFromExprNode(pending.expr.node)
+		if stillPending || len(sources) == 0 {
+			continue
+		}
+
+		if pending.step != nil && rule.isDefinedInEnv(pending.expr, pending.step.Env) {
+			continue
+		}
+
+		taintPath := fmt.Sprintf("%s (tainted via %s)", pending.expr.raw, strings.Join(sources, ", "))
+
+		if rule.checkPrivileged {
+			rule.Errorf(
+				pending.expr.pos,
+				"environment variable injection (critical): \"%s\" is potentially untrusted and written to $GITHUB_ENV in a workflow with privileged triggers. This can allow attackers to inject additional environment variables. Use heredoc syntax with unique delimiters or sanitize the input with 'tr -d '\\n''. See https://sisaku-security.github.io/lint/docs/rules/envvarinjectioncritical/",
+				taintPath,
+			)
+		} else {
+			rule.Errorf(
+				pending.expr.pos,
+				"environment variable injection (medium): \"%s\" is potentially untrusted and written to $GITHUB_ENV. This can allow attackers to inject additional environment variables. Use heredoc syntax with unique delimiters or sanitize the input with 'tr -d '\\n''. See https://sisaku-security.github.io/lint/docs/rules/envvarinjectionmedium/",
+				taintPath,
+			)
+		}
+	}
+
+	rule.pendingCrossJobChecks = nil
+	return nil
 }

--- a/pkg/core/envvarinjectioncritical.go
+++ b/pkg/core/envvarinjectioncritical.go
@@ -7,6 +7,6 @@ type EnvVarInjectionCritical = EnvVarInjectionRule
 // EnvVarInjectionCriticalRule creates a rule for detecting environment variable injection in privileged workflow contexts
 // Privileged contexts include: pull_request_target, workflow_run, issue_comment, issues, discussion_comment
 // These triggers have write access or run with secrets, making envvar injection critical severity
-func EnvVarInjectionCriticalRule() *EnvVarInjectionRule {
-	return newEnvVarInjectionRule("critical", true)
+func EnvVarInjectionCriticalRule(wfTaintMap *WorkflowTaintMap) *EnvVarInjectionRule {
+	return newEnvVarInjectionRule("critical", true, wfTaintMap)
 }

--- a/pkg/core/envvarinjectioncritical_test.go
+++ b/pkg/core/envvarinjectioncritical_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestEnvVarInjectionCriticalRule(t *testing.T) {
-	rule := EnvVarInjectionCriticalRule()
+	rule := EnvVarInjectionCriticalRule(nil)
 	if rule.RuleName != "envvar-injection-critical" {
 		t.Errorf("RuleName = %q, want %q", rule.RuleName, "envvar-injection-critical")
 	}
@@ -72,7 +72,7 @@ echo "EOF_$EOF" >> "$GITHUB_ENV"`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := EnvVarInjectionCriticalRule()
+			rule := EnvVarInjectionCriticalRule(nil)
 
 			// Create workflow with specified trigger
 			workflow := &ast.Workflow{
@@ -122,7 +122,7 @@ echo "EOF_$EOF" >> "$GITHUB_ENV"`,
 }
 
 func TestEnvVarInjectionCritical_AutoFix(t *testing.T) {
-	rule := EnvVarInjectionCriticalRule()
+	rule := EnvVarInjectionCriticalRule(nil)
 
 	// Create workflow with privileged trigger
 	workflow := &ast.Workflow{

--- a/pkg/core/envvarinjectionmedium.go
+++ b/pkg/core/envvarinjectionmedium.go
@@ -7,6 +7,6 @@ type EnvVarInjectionMedium = EnvVarInjectionRule
 // EnvVarInjectionMediumRule creates a rule for detecting environment variable injection in normal workflow contexts
 // Normal contexts include: pull_request, push, schedule, workflow_dispatch
 // These triggers have limited permissions, making envvar injection medium severity
-func EnvVarInjectionMediumRule() *EnvVarInjectionRule {
-	return newEnvVarInjectionRule("medium", false)
+func EnvVarInjectionMediumRule(wfTaintMap *WorkflowTaintMap) *EnvVarInjectionRule {
+	return newEnvVarInjectionRule("medium", false, wfTaintMap)
 }

--- a/pkg/core/envvarinjectionmedium_test.go
+++ b/pkg/core/envvarinjectionmedium_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestEnvVarInjectionMediumRule(t *testing.T) {
-	rule := EnvVarInjectionMediumRule()
+	rule := EnvVarInjectionMediumRule(nil)
 	if rule.RuleName != "envvar-injection-medium" {
 		t.Errorf("RuleName = %q, want %q", rule.RuleName, "envvar-injection-medium")
 	}
@@ -76,7 +76,7 @@ echo "BODY=${{ github.event.pull_request.body }}" >> "$GITHUB_ENV"`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := EnvVarInjectionMediumRule()
+			rule := EnvVarInjectionMediumRule(nil)
 
 			// Create workflow with specified trigger
 			workflow := &ast.Workflow{
@@ -126,7 +126,7 @@ echo "BODY=${{ github.event.pull_request.body }}" >> "$GITHUB_ENV"`,
 }
 
 func TestEnvVarInjectionMedium_AutoFix(t *testing.T) {
-	rule := EnvVarInjectionMediumRule()
+	rule := EnvVarInjectionMediumRule(nil)
 
 	// Create workflow with normal trigger
 	workflow := &ast.Workflow{

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -560,8 +560,8 @@ func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadat
 		NewSecretsInheritRuleWithCache(localReusableWorkflow),         // Detects excessive secret inheritance using 'secrets: inherit'
 		ArgumentInjectionCriticalRule(wfTaintMap),
 		ArgumentInjectionMediumRule(wfTaintMap),
-		RequestForgeryCriticalRule(),         // Detects SSRF vulnerabilities in privileged triggers
-		RequestForgeryMediumRule(),           // Detects SSRF vulnerabilities in normal triggers
+		RequestForgeryCriticalRule(wfTaintMap), // Detects SSRF vulnerabilities in privileged triggers
+		RequestForgeryMediumRule(wfTaintMap),  // Detects SSRF vulnerabilities in normal triggers
 		NewCacheBloatRule(),                  // Detects cache bloat risk with cache/restore and cache/save
 		NewAIActionUnrestrictedTriggerRule(), // Detects AI actions with unrestricted user access (Clinejection attack pattern)
 		NewAIActionExcessiveToolsRule(),      // Detects AI actions with dangerous tools in untrusted triggers (Clinejection attack pattern)

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -558,8 +558,8 @@ func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadat
 		NewDangerousTriggersCriticalRule(),                            // Detects dangerous triggers without any mitigations
 		NewDangerousTriggersMediumRule(),                              // Detects dangerous triggers with partial mitigations
 		NewSecretsInheritRuleWithCache(localReusableWorkflow),         // Detects excessive secret inheritance using 'secrets: inherit'
-		ArgumentInjectionCriticalRule(),
-		ArgumentInjectionMediumRule(),
+		ArgumentInjectionCriticalRule(wfTaintMap),
+		ArgumentInjectionMediumRule(wfTaintMap),
 		RequestForgeryCriticalRule(),         // Detects SSRF vulnerabilities in privileged triggers
 		RequestForgeryMediumRule(),           // Detects SSRF vulnerabilities in normal triggers
 		NewCacheBloatRule(),                  // Detects cache bloat risk with cache/restore and cache/save

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -503,8 +503,9 @@ func (l *Linter) Lint(filepath string, content []byte, project *Project) (*Valid
 }
 
 func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadataCache, localReusableWorkflow *LocalReusableWorkflowCache) []Rule {
-	// WorkflowTaintMap is shared between Critical and Medium rules to enable
-	// cross-job taint propagation tracking via needs.*.outputs.*
+	// WorkflowTaintMap is shared between Critical and Medium variants of
+	// CodeInjection, EnvVarInjection, ArgumentInjection, and RequestForgery rules
+	// to enable cross-job taint propagation tracking via needs.*.outputs.*
 	wfTaintMap := NewWorkflowTaintMap()
 
 	return []Rule{

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -523,8 +523,8 @@ func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadat
 		TimeoutMinuteRule(),
 		CodeInjectionCriticalRule(wfTaintMap), // Detects untrusted input in privileged workflow triggers
 		CodeInjectionMediumRule(wfTaintMap),   // Detects untrusted input in normal workflow triggers
-		EnvVarInjectionCriticalRule(),  // Detects envvar injection in privileged workflow triggers
-		EnvVarInjectionMediumRule(),    // Detects envvar injection in normal workflow triggers
+		EnvVarInjectionCriticalRule(wfTaintMap),  // Detects envvar injection in privileged workflow triggers
+		EnvVarInjectionMediumRule(wfTaintMap),    // Detects envvar injection in normal workflow triggers
 		EnvPathInjectionCriticalRule(), // Detects PATH injection in privileged workflow triggers
 		EnvPathInjectionMediumRule(),   // Detects PATH injection in normal workflow triggers
 		OutputClobberingCriticalRule(), // Detects output clobbering in privileged workflow triggers

--- a/pkg/core/requestforgery.go
+++ b/pkg/core/requestforgery.go
@@ -17,6 +17,14 @@ type RequestForgeryRule struct {
 	checkPrivileged    bool   // true = check privileged triggers, false = check normal triggers
 	stepsWithUntrusted []*stepWithRequestForgery
 	workflow           *ast.Workflow
+	// workflowTaintMap is shared between Critical and Medium rule instances.
+	workflowTaintMap *WorkflowTaintMap
+	// taintTracker tracks intra-job taint; used only for RegisterJobOutputs.
+	taintTracker *TaintTracker
+	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
+	pendingCrossJobChecks []pendingCrossJobCheck
+	// workflowTriggers stores all trigger names from the workflow
+	workflowTriggers []string
 }
 
 type stepWithRequestForgery struct {
@@ -69,7 +77,7 @@ var networkCommandPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?:^|[\s|&;(])(netcat)\b`),
 }
 
-func newRequestForgeryRule(severityLevel string, checkPrivileged bool) *RequestForgeryRule {
+func newRequestForgeryRule(severityLevel string, checkPrivileged bool, wfTaintMap *WorkflowTaintMap) *RequestForgeryRule {
 	var desc string
 
 	if checkPrivileged {
@@ -86,15 +94,45 @@ func newRequestForgeryRule(severityLevel string, checkPrivileged bool) *RequestF
 		severityLevel:      severityLevel,
 		checkPrivileged:    checkPrivileged,
 		stepsWithUntrusted: make([]*stepWithRequestForgery, 0),
+		workflowTaintMap:   wfTaintMap,
 	}
 }
 
 func (rule *RequestForgeryRule) VisitWorkflowPre(node *ast.Workflow) error {
 	rule.workflow = node
+	rule.workflowTriggers = nil
+
+	for _, event := range node.On {
+		switch e := event.(type) {
+		case *ast.WebhookEvent:
+			if e.Hook != nil {
+				rule.workflowTriggers = append(rule.workflowTriggers, e.Hook.Value)
+			}
+		case *ast.WorkflowCallEvent:
+			rule.workflowTriggers = append(rule.workflowTriggers, "workflow_call")
+		}
+	}
+
+	if rule.workflowTaintMap != nil {
+		rule.workflowTaintMap.Reset()
+		rule.pendingCrossJobChecks = nil
+	}
+
 	return nil
 }
 
 func (rule *RequestForgeryRule) VisitJobPre(node *ast.Job) error {
+	// Initialize taint tracker per job for cross-job output registration.
+	rule.taintTracker = NewTaintTracker()
+	for _, s := range node.Steps {
+		rule.taintTracker.AnalyzeStep(s)
+	}
+
+	// Register this job's outputs into WorkflowTaintMap for downstream jobs.
+	if rule.workflowTaintMap != nil && node.ID != nil {
+		rule.workflowTaintMap.RegisterJobOutputs(node.ID.Value, rule.taintTracker, node.Outputs)
+	}
+
 	isPrivileged := rule.hasPrivilegedTriggers()
 	if rule.checkPrivileged != isPrivileged {
 		return nil
@@ -169,6 +207,11 @@ func (rule *RequestForgeryRule) checkScriptWithAST(cmdCalls []shell.NetworkComma
 					}
 
 					untrustedPaths := rule.checkUntrustedInput(expr)
+
+					if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
+						rule.addPendingReqForgeryCrossJobCheck(expr, step)
+					}
+
 					if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, step.Env) {
 						if stepUntrusted == nil {
 							stepUntrusted = &stepWithRequestForgery{step: step}
@@ -216,6 +259,11 @@ func (rule *RequestForgeryRule) checkScriptWithLines(script string, exprs []pars
 			}
 
 			untrustedPaths := rule.checkUntrustedInput(expr)
+
+			if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
+				rule.addPendingReqForgeryCrossJobCheck(expr, step)
+			}
+
 			if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, step.Env) {
 				if stepUntrusted == nil {
 					stepUntrusted = &stepWithRequestForgery{step: step}
@@ -374,6 +422,45 @@ func (rule *RequestForgeryRule) reportError(pos *ast.Position, untrustedPaths []
 			command,
 		)
 	}
+}
+
+func (rule *RequestForgeryRule) addPendingReqForgeryCrossJobCheck(expr parsedExpression, step *ast.Step) {
+	exprStr := exprNodeToString(expr.node)
+	lower := strings.ToLower(exprStr)
+	parts := strings.Split(lower, ".")
+	if len(parts) < 4 || parts[0] != "needs" || parts[2] != "outputs" {
+		return
+	}
+	rule.pendingCrossJobChecks = append(rule.pendingCrossJobChecks, pendingCrossJobCheck{
+		expr:       expr,
+		needsJobID: parts[1],
+		outputName: strings.Join(parts[3:], "."),
+		step:       step,
+	})
+}
+
+func (rule *RequestForgeryRule) VisitWorkflowPost(node *ast.Workflow) error {
+	if rule.workflowTaintMap == nil || len(rule.pendingCrossJobChecks) == 0 {
+		return nil
+	}
+
+	for _, pending := range rule.pendingCrossJobChecks {
+		sources, stillPending := rule.workflowTaintMap.ResolveFromExprNode(pending.expr.node)
+		if stillPending || len(sources) == 0 {
+			continue
+		}
+
+		if pending.step != nil && rule.isDefinedInEnv(pending.expr, pending.step.Env) {
+			continue
+		}
+
+		taintPath := fmt.Sprintf("%s (tainted via %s)", pending.expr.raw, strings.Join(sources, ", "))
+
+		rule.reportError(pending.expr.pos, []string{taintPath}, "network command", RequestForgerySeverityURL)
+	}
+
+	rule.pendingCrossJobChecks = nil
+	return nil
 }
 
 func (rule *RequestForgeryRule) hasPrivilegedTriggers() bool {

--- a/pkg/core/requestforgery.go
+++ b/pkg/core/requestforgery.go
@@ -23,6 +23,8 @@ type RequestForgeryRule struct {
 	taintTracker *TaintTracker
 	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
 	pendingCrossJobChecks []pendingCrossJobCheck
+	// pendingCrossJobSet deduplicates pending checks by expr.raw + step pointer.
+	pendingCrossJobSet map[string]bool
 }
 
 type stepWithRequestForgery struct {
@@ -102,6 +104,7 @@ func (rule *RequestForgeryRule) VisitWorkflowPre(node *ast.Workflow) error {
 	if rule.workflowTaintMap != nil {
 		rule.workflowTaintMap.Reset()
 		rule.pendingCrossJobChecks = nil
+		rule.pendingCrossJobSet = nil
 	}
 
 	return nil
@@ -194,16 +197,16 @@ func (rule *RequestForgeryRule) checkScriptWithAST(cmdCalls []shell.NetworkComma
 
 					untrustedPaths := rule.checkUntrustedInput(expr)
 
+					severity := rule.determineSeverityFromArg(arg)
+
 					if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
-						rule.addPendingReqForgeryCrossJobCheck(expr, step)
+						rule.addPendingReqForgeryCrossJobCheck(expr, step, cmdCall.CommandName, severity)
 					}
 
 					if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, step.Env) {
 						if stepUntrusted == nil {
 							stepUntrusted = &stepWithRequestForgery{step: step}
 						}
-
-						severity := rule.determineSeverityFromArg(arg)
 
 						stepUntrusted.untrustedExprs = append(stepUntrusted.untrustedExprs, requestForgeryExprInfo{
 							expr:     expr,
@@ -246,16 +249,16 @@ func (rule *RequestForgeryRule) checkScriptWithLines(script string, exprs []pars
 
 			untrustedPaths := rule.checkUntrustedInput(expr)
 
+			severity := rule.determineSeverity(line, expr)
+
 			if rule.workflowTaintMap != nil && isNeedsOutputExpr(expr) {
-				rule.addPendingReqForgeryCrossJobCheck(expr, step)
+				rule.addPendingReqForgeryCrossJobCheck(expr, step, networkCmd, severity)
 			}
 
 			if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, step.Env) {
 				if stepUntrusted == nil {
 					stepUntrusted = &stepWithRequestForgery{step: step}
 				}
-
-				severity := rule.determineSeverity(line, expr)
 
 				stepUntrusted.untrustedExprs = append(stepUntrusted.untrustedExprs, requestForgeryExprInfo{
 					expr:     expr,
@@ -410,18 +413,31 @@ func (rule *RequestForgeryRule) reportError(pos *ast.Position, untrustedPaths []
 	}
 }
 
-func (rule *RequestForgeryRule) addPendingReqForgeryCrossJobCheck(expr parsedExpression, step *ast.Step) {
+func (rule *RequestForgeryRule) addPendingReqForgeryCrossJobCheck(expr parsedExpression, step *ast.Step, command string, severity RequestForgerySeverity) {
 	exprStr := exprNodeToString(expr.node)
 	lower := strings.ToLower(exprStr)
 	parts := strings.Split(lower, ".")
 	if len(parts) < 4 || parts[0] != "needs" || parts[2] != "outputs" {
 		return
 	}
+
+	// Deduplicate by expression text + step pointer
+	key := fmt.Sprintf("%s@%p", expr.raw, step)
+	if rule.pendingCrossJobSet == nil {
+		rule.pendingCrossJobSet = make(map[string]bool)
+	}
+	if rule.pendingCrossJobSet[key] {
+		return
+	}
+	rule.pendingCrossJobSet[key] = true
+
 	rule.pendingCrossJobChecks = append(rule.pendingCrossJobChecks, pendingCrossJobCheck{
-		expr:       expr,
-		needsJobID: parts[1],
-		outputName: strings.Join(parts[3:], "."),
-		step:       step,
+		expr:               expr,
+		needsJobID:         parts[1],
+		outputName:         strings.Join(parts[3:], "."),
+		step:               step,
+		commandName:        command,
+		reqForgerySeverity: severity,
 	})
 }
 
@@ -442,10 +458,15 @@ func (rule *RequestForgeryRule) VisitWorkflowPost(node *ast.Workflow) error {
 
 		taintPath := fmt.Sprintf("%s (tainted via %s)", pending.expr.raw, strings.Join(sources, ", "))
 
-		rule.reportError(pending.expr.pos, []string{taintPath}, "network command", RequestForgerySeverityURL)
+		cmdDesc := pending.commandName
+		if cmdDesc == "" {
+			cmdDesc = "network command"
+		}
+		rule.reportError(pending.expr.pos, []string{taintPath}, cmdDesc, pending.reqForgerySeverity)
 	}
 
 	rule.pendingCrossJobChecks = nil
+	rule.pendingCrossJobSet = nil
 	return nil
 }
 

--- a/pkg/core/requestforgery.go
+++ b/pkg/core/requestforgery.go
@@ -23,8 +23,6 @@ type RequestForgeryRule struct {
 	taintTracker *TaintTracker
 	// pendingCrossJobChecks holds needs.*.outputs.* checks deferred to VisitWorkflowPost.
 	pendingCrossJobChecks []pendingCrossJobCheck
-	// workflowTriggers stores all trigger names from the workflow
-	workflowTriggers []string
 }
 
 type stepWithRequestForgery struct {
@@ -100,18 +98,6 @@ func newRequestForgeryRule(severityLevel string, checkPrivileged bool, wfTaintMa
 
 func (rule *RequestForgeryRule) VisitWorkflowPre(node *ast.Workflow) error {
 	rule.workflow = node
-	rule.workflowTriggers = nil
-
-	for _, event := range node.On {
-		switch e := event.(type) {
-		case *ast.WebhookEvent:
-			if e.Hook != nil {
-				rule.workflowTriggers = append(rule.workflowTriggers, e.Hook.Value)
-			}
-		case *ast.WorkflowCallEvent:
-			rule.workflowTriggers = append(rule.workflowTriggers, "workflow_call")
-		}
-	}
 
 	if rule.workflowTaintMap != nil {
 		rule.workflowTaintMap.Reset()

--- a/pkg/core/requestforgery_test.go
+++ b/pkg/core/requestforgery_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestRequestForgeryCriticalRule(t *testing.T) {
-	rule := RequestForgeryCriticalRule()
+	rule := RequestForgeryCriticalRule(nil)
 	if rule.RuleName != "request-forgery-critical" {
 		t.Errorf("RuleName = %q, want %q", rule.RuleName, "request-forgery-critical")
 	}
 }
 
 func TestRequestForgeryMediumRule(t *testing.T) {
-	rule := RequestForgeryMediumRule()
+	rule := RequestForgeryMediumRule(nil)
 	if rule.RuleName != "request-forgery-medium" {
 		t.Errorf("RuleName = %q, want %q", rule.RuleName, "request-forgery-medium")
 	}
@@ -67,7 +67,7 @@ func TestRequestForgeryCritical_PrivilegedTriggers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := RequestForgeryCriticalRule()
+			rule := RequestForgeryCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -166,7 +166,7 @@ func TestRequestForgery_NetworkCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := RequestForgeryCriticalRule()
+			rule := RequestForgeryCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -234,7 +234,7 @@ func TestRequestForgery_CloudMetadataDetection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := RequestForgeryCriticalRule()
+			rule := RequestForgeryCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -300,7 +300,7 @@ func TestRequestForgery_GitHubScript(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := RequestForgeryCriticalRule()
+			rule := RequestForgeryCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -380,7 +380,7 @@ func TestRequestForgeryMedium_NormalTriggers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := RequestForgeryMediumRule()
+			rule := RequestForgeryMediumRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -447,7 +447,7 @@ func TestRequestForgery_SeverityDetermination(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := RequestForgeryCriticalRule()
+			rule := RequestForgeryCriticalRule(nil)
 
 			workflow := &ast.Workflow{
 				On: []ast.Event{
@@ -489,7 +489,7 @@ func TestRequestForgery_SeverityDetermination(t *testing.T) {
 }
 
 func TestRequestForgery_EnvVarName(t *testing.T) {
-	rule := RequestForgeryCriticalRule()
+	rule := RequestForgeryCriticalRule(nil)
 
 	tests := []struct {
 		path     string
@@ -513,7 +513,7 @@ func TestRequestForgery_EnvVarName(t *testing.T) {
 }
 
 func TestRequestForgery_DetectNetworkCommand(t *testing.T) {
-	rule := RequestForgeryCriticalRule()
+	rule := RequestForgeryCriticalRule(nil)
 
 	tests := []struct {
 		line     string
@@ -544,7 +544,7 @@ func TestRequestForgery_DetectNetworkCommand(t *testing.T) {
 
 // TestRequestForgery_MultipleUntrustedInputs tests detection of multiple untrusted inputs
 func TestRequestForgery_MultipleUntrustedInputs(t *testing.T) {
-	rule := RequestForgeryCriticalRule()
+	rule := RequestForgeryCriticalRule(nil)
 
 	workflow := &ast.Workflow{
 		On: []ast.Event{

--- a/pkg/core/requestforgerycritical.go
+++ b/pkg/core/requestforgerycritical.go
@@ -3,6 +3,6 @@ package core
 // RequestForgeryCriticalRule creates a critical severity request forgery rule
 // that checks for SSRF vulnerabilities in workflows with privileged triggers
 // (pull_request_target, workflow_run, issue_comment)
-func RequestForgeryCriticalRule() *RequestForgeryRule {
-	return newRequestForgeryRule("critical", true)
+func RequestForgeryCriticalRule(wfTaintMap *WorkflowTaintMap) *RequestForgeryRule {
+	return newRequestForgeryRule("critical", true, wfTaintMap)
 }

--- a/pkg/core/requestforgerymedium.go
+++ b/pkg/core/requestforgerymedium.go
@@ -3,6 +3,6 @@ package core
 // RequestForgeryMediumRule creates a medium severity request forgery rule
 // that checks for SSRF vulnerabilities in workflows with normal triggers
 // (pull_request, push, schedule, etc.)
-func RequestForgeryMediumRule() *RequestForgeryRule {
-	return newRequestForgeryRule("medium", false)
+func RequestForgeryMediumRule(wfTaintMap *WorkflowTaintMap) *RequestForgeryRule {
+	return newRequestForgeryRule("medium", false, wfTaintMap)
 }

--- a/pkg/core/taint_integration_test.go
+++ b/pkg/core/taint_integration_test.go
@@ -371,3 +371,279 @@ jobs:
 		}
 	}
 }
+
+func TestCrossJobTaintPropagation_EnvVarInjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		workflow       string
+		expectError    bool
+		expectContains string
+	}{
+		{
+			name: "needs output の汚染値を GITHUB_ENV に書き込み - critical",
+			workflow: `name: Test
+on: pull_request_target
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_title: ${{ steps.meta.outputs.title }}
+    steps:
+      - id: meta
+        run: echo "title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+
+  process:
+    needs: extract
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "TITLE=${{ needs.extract.outputs.pr_title }}" >> $GITHUB_ENV
+`,
+			expectError:    true,
+			expectContains: "environment variable injection",
+		},
+		{
+			name: "定数値 needs output は GITHUB_ENV に書いても安全",
+			workflow: `name: Test
+on: pull_request_target
+
+jobs:
+  safe-job:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        run: echo "version=1.0.0" >> $GITHUB_OUTPUT
+
+  consumer:
+    needs: safe-job
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "VER=${{ needs.safe-job.outputs.version }}" >> $GITHUB_ENV
+`,
+			expectError:    false,
+			expectContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			linter, err := NewLinter(io.Discard, &LinterOptions{})
+			if err != nil {
+				t.Fatalf("failed to create linter: %v", err)
+			}
+
+			result, err := linter.Lint("<test>", []byte(tt.workflow), nil)
+			if err != nil {
+				t.Fatalf("failed to lint: %v", err)
+			}
+
+			var matchingErrors []string
+			for _, e := range result.Errors {
+				if strings.Contains(e.Description, "tainted via") && strings.Contains(e.Description, "environment variable injection") {
+					matchingErrors = append(matchingErrors, e.Description)
+				}
+			}
+
+			if tt.expectError && len(matchingErrors) == 0 {
+				t.Errorf("expected error containing %q, but got none", tt.expectContains)
+				for _, e := range result.Errors {
+					t.Logf("Error: %s", e.Description)
+				}
+			}
+
+			if !tt.expectError && len(matchingErrors) > 0 {
+				t.Errorf("expected no matching errors, but got: %v", matchingErrors)
+			}
+		})
+	}
+}
+
+func TestCrossJobTaintPropagation_ArgumentInjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		workflow       string
+		expectError    bool
+		expectContains string
+	}{
+		{
+			name: "needs output の汚染値をコマンド引数に展開 - critical",
+			workflow: `name: Test
+on: pull_request_target
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.meta.outputs.branch }}
+    steps:
+      - id: meta
+        run: echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+
+  process:
+    needs: extract
+    runs-on: ubuntu-latest
+    steps:
+      - run: git checkout ${{ needs.extract.outputs.branch }}
+`,
+			expectError:    true,
+			expectContains: "argument injection",
+		},
+		{
+			name: "定数値 needs output をコマンド引数に使っても安全",
+			workflow: `name: Test
+on: pull_request_target
+
+jobs:
+  safe-job:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - id: v
+        run: echo "tag=v1.0.0" >> $GITHUB_OUTPUT
+
+  consumer:
+    needs: safe-job
+    runs-on: ubuntu-latest
+    steps:
+      - run: git checkout ${{ needs.safe-job.outputs.tag }}
+`,
+			expectError:    false,
+			expectContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			linter, err := NewLinter(io.Discard, &LinterOptions{})
+			if err != nil {
+				t.Fatalf("failed to create linter: %v", err)
+			}
+
+			result, err := linter.Lint("<test>", []byte(tt.workflow), nil)
+			if err != nil {
+				t.Fatalf("failed to lint: %v", err)
+			}
+
+			var matchingErrors []string
+			for _, e := range result.Errors {
+				if strings.Contains(e.Description, "tainted via") && strings.Contains(e.Description, "argument injection") {
+					matchingErrors = append(matchingErrors, e.Description)
+				}
+			}
+
+			if tt.expectError && len(matchingErrors) == 0 {
+				t.Errorf("expected error containing %q, but got none", tt.expectContains)
+				for _, e := range result.Errors {
+					t.Logf("Error: %s", e.Description)
+				}
+			}
+
+			if !tt.expectError && len(matchingErrors) > 0 {
+				t.Errorf("expected no matching errors, but got: %v", matchingErrors)
+			}
+		})
+	}
+}
+
+func TestCrossJobTaintPropagation_RequestForgery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		workflow       string
+		expectError    bool
+		expectContains string
+	}{
+		{
+			name: "needs output の汚染値を curl URL に使用 - critical",
+			workflow: `name: Test
+on: pull_request_target
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      api_url: ${{ steps.meta.outputs.url }}
+    steps:
+      - id: meta
+        run: echo "url=${{ github.event.pull_request.body }}" >> $GITHUB_OUTPUT
+
+  process:
+    needs: extract
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl ${{ needs.extract.outputs.api_url }}
+`,
+			expectError:    true,
+			expectContains: "request forgery",
+		},
+		{
+			name: "定数値 needs output を curl に使っても安全",
+			workflow: `name: Test
+on: pull_request_target
+
+jobs:
+  safe-job:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.v.outputs.url }}
+    steps:
+      - id: v
+        run: echo "url=https://api.github.com" >> $GITHUB_OUTPUT
+
+  consumer:
+    needs: safe-job
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl ${{ needs.safe-job.outputs.url }}
+`,
+			expectError:    false,
+			expectContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			linter, err := NewLinter(io.Discard, &LinterOptions{})
+			if err != nil {
+				t.Fatalf("failed to create linter: %v", err)
+			}
+
+			result, err := linter.Lint("<test>", []byte(tt.workflow), nil)
+			if err != nil {
+				t.Fatalf("failed to lint: %v", err)
+			}
+
+			var matchingErrors []string
+			for _, e := range result.Errors {
+				if strings.Contains(e.Description, "tainted via") && strings.Contains(e.Description, "request forgery") {
+					matchingErrors = append(matchingErrors, e.Description)
+				}
+			}
+
+			if tt.expectError && len(matchingErrors) == 0 {
+				t.Errorf("expected error containing %q, but got none", tt.expectContains)
+				for _, e := range result.Errors {
+					t.Logf("Error: %s", e.Description)
+				}
+			}
+
+			if !tt.expectError && len(matchingErrors) > 0 {
+				t.Errorf("expected no matching errors, but got: %v", matchingErrors)
+			}
+		})
+	}
+}

--- a/pkg/core/taint_integration_test.go
+++ b/pkg/core/taint_integration_test.go
@@ -427,6 +427,29 @@ jobs:
 			expectError:    false,
 			expectContains: "",
 		},
+		{
+			name: "needs output の汚染値を GITHUB_ENV に書き込み - medium (pull_request)",
+			workflow: `name: Test
+on: pull_request
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_title: ${{ steps.meta.outputs.title }}
+    steps:
+      - id: meta
+        run: echo "title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+
+  process:
+    needs: extract
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "TITLE=${{ needs.extract.outputs.pr_title }}" >> $GITHUB_ENV
+`,
+			expectError:    true,
+			expectContains: "environment variable injection",
+		},
 	}
 
 	for _, tt := range tests {
@@ -519,6 +542,29 @@ jobs:
 			expectError:    false,
 			expectContains: "",
 		},
+		{
+			name: "needs output の汚染値をコマンド引数に展開 - medium (pull_request)",
+			workflow: `name: Test
+on: pull_request
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.meta.outputs.branch }}
+    steps:
+      - id: meta
+        run: echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+
+  process:
+    needs: extract
+    runs-on: ubuntu-latest
+    steps:
+      - run: git checkout ${{ needs.extract.outputs.branch }}
+`,
+			expectError:    true,
+			expectContains: "argument injection",
+		},
 	}
 
 	for _, tt := range tests {
@@ -610,6 +656,29 @@ jobs:
 `,
 			expectError:    false,
 			expectContains: "",
+		},
+		{
+			name: "needs output の汚染値を curl URL に使用 - medium (pull_request)",
+			workflow: `name: Test
+on: pull_request
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      api_url: ${{ steps.meta.outputs.url }}
+    steps:
+      - id: meta
+        run: echo "url=${{ github.event.pull_request.body }}" >> $GITHUB_OUTPUT
+
+  process:
+    needs: extract
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl ${{ needs.extract.outputs.api_url }}
+`,
+			expectError:    true,
+			expectContains: "request forgery",
 		},
 	}
 

--- a/pkg/core/taint_integration_test.go
+++ b/pkg/core/taint_integration_test.go
@@ -450,8 +450,8 @@ jobs:
 				}
 			}
 
-			if tt.expectError && len(matchingErrors) == 0 {
-				t.Errorf("expected error containing %q, but got none", tt.expectContains)
+			if tt.expectError && len(matchingErrors) != 1 {
+				t.Errorf("expected exactly 1 error containing %q, but got %d: %v", tt.expectContains, len(matchingErrors), matchingErrors)
 				for _, e := range result.Errors {
 					t.Logf("Error: %s", e.Description)
 				}
@@ -542,8 +542,8 @@ jobs:
 				}
 			}
 
-			if tt.expectError && len(matchingErrors) == 0 {
-				t.Errorf("expected error containing %q, but got none", tt.expectContains)
+			if tt.expectError && len(matchingErrors) != 1 {
+				t.Errorf("expected exactly 1 error containing %q, but got %d: %v", tt.expectContains, len(matchingErrors), matchingErrors)
 				for _, e := range result.Errors {
 					t.Logf("Error: %s", e.Description)
 				}
@@ -634,8 +634,8 @@ jobs:
 				}
 			}
 
-			if tt.expectError && len(matchingErrors) == 0 {
-				t.Errorf("expected error containing %q, but got none", tt.expectContains)
+			if tt.expectError && len(matchingErrors) != 1 {
+				t.Errorf("expected exactly 1 error containing %q, but got %d: %v", tt.expectContains, len(matchingErrors), matchingErrors)
 				for _, e := range result.Errors {
 					t.Logf("Error: %s", e.Description)
 				}


### PR DESCRIPTION
## Summary

- `EnvVarInjectionRule` (Critical/Medium): `needs.*.outputs.*` の汚染値を `$GITHUB_ENV` に無加工で書き込むパターンを検出
- `ArgumentInjectionRule` (Critical/Medium): `needs.*.outputs.*` の汚染値をコマンド引数に直接展開するパターンを検出
- `RequestForgeryRule` (Critical/Medium): `needs.*.outputs.*` の汚染値を curl/wget の URL に使うパターンを検出
- `isNeedsOutputExpr` を CodeInjectionRule のメソッドからパッケージレベル関数に抽出し、全ルールで再利用

## Implementation

`pkg/core/linter.go` の `makeRules()` で既に作成している `WorkflowTaintMap` インスタンスのポインタを、上記6つのファクトリ関数にも渡す。各ルールは CodeInjectionRule と同じ遅延解決パターン (`pendingCrossJobChecks` + `VisitWorkflowPost`) を実装。

## Test plan

- [x] 既存テスト全通過 (`go test ./... -count=1`)
- [x] EnvVarInjection クロスジョブテイント検出テスト (positive + negative)
- [x] ArgumentInjection クロスジョブテイント検出テスト (positive + negative)
- [x] RequestForgery クロスジョブテイント検出テスト (positive + negative)
- [x] 定数値の needs output は false positive にならないことを確認

Closes #419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ワークフロー内のジョブ間出力（needs.*.outputs.*）に対する追跡を導入し、別ジョブで使用された値による環境変数注入、コマンド引数注入、外部リクエストの危険をワークフロー全体で検出する精度を向上。

* **Tests**
  * 環境変数注入、引数注入、リクエスト偽造に関するジョブ間汚染（taint）伝播の統合テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->