### PR TITLE
feat: add sandbox validation and execution order rules for AI actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,8 @@ sisakulint includes the following security rules (as of pkg/core/linter.go:500-5
 - **AIActionUnrestrictedTriggerRule** - Detects AI agent actions (claude-code-action, etc.) configured with `allowed_non_write_users: "*"` allowing any GitHub user to trigger AI execution (Clinejection attack pattern)
 - **AIActionExcessiveToolsRule** - Detects AI agent actions with dangerous tools (Bash/Write/Edit) enabled in workflows triggered by untrusted users (issues, issue_comment, discussion) (Clinejection attack pattern)
 - **AIActionPromptInjectionRule** - Detects untrusted user input (github.event.issue.title, github.event.comment.body, etc.) directly interpolated into AI agent prompt parameters, enabling prompt injection attacks (Clinejection attack pattern)
+- **AIActionUnsafeSandboxRule** - Detects unsafe sandbox or safety-strategy settings (e.g., `safety-strategy: unsafe`, `--dangerouslySkipPermissions`) in AI agent actions that disable sandbox protections
+- **AIActionExecutionOrderRule** - Detects AI agent actions that are not the last step in a job, risking subsequent steps inheriting compromised state
 
 ## Key Files
 

--- a/docs/aiactionexecutionorder.md
+++ b/docs/aiactionexecutionorder.md
@@ -3,7 +3,7 @@ title: "AI Action Execution Order Rule"
 weight: 1
 ---
 
-### AI Action Execution Order Rule Overview
+## AI Action Execution Order Rule Overview
 
 This rule detects **AI agent actions that are not the last step in a job**. The OpenAI Codex security checklist recommends running AI agent actions as the final step to prevent subsequent steps from inheriting potentially compromised state.
 
@@ -64,7 +64,7 @@ The rule operates at the job level:
 
 ### Attack Scenario
 
-```
+```text
 1. A workflow checks out code and runs an AI agent
 2. The AI agent, potentially manipulated via prompt injection, modifies source files
 3. A subsequent step (npm publish, docker build, terraform apply) executes

--- a/docs/aiactionexecutionorder.md
+++ b/docs/aiactionexecutionorder.md
@@ -1,0 +1,142 @@
+---
+title: "AI Action Execution Order Rule"
+weight: 1
+---
+
+### AI Action Execution Order Rule Overview
+
+This rule detects **AI agent actions that are not the last step in a job**. The OpenAI Codex security checklist recommends running AI agent actions as the final step to prevent subsequent steps from inheriting potentially compromised state.
+
+**Affected Actions:**
+- `anthropics/claude-code-action`
+- `github/copilot-swe-agent`
+- `openai/openai-actions`
+- `openai/codex-action`
+
+### Security Impact
+
+**Severity: Medium**
+
+Running steps after an AI agent action creates risk because the agent may have modified:
+
+1. **Source Code**: Files in the workspace may have been altered by the agent
+2. **Environment Variables**: The agent may have set or modified environment variables
+3. **Build Artifacts**: Generated files may contain malicious content
+4. **Configuration Files**: CI/CD configuration or package manifests may have been tampered with
+
+If subsequent steps rely on any of these (e.g., `npm publish`, `docker push`, `terraform apply`), they may execute against compromised state.
+
+This vulnerability aligns with **CWE-829: Inclusion of Functionality from Untrusted Control Sphere** and **OWASP CI/CD Security Risk CICD-SEC-4: Poisoned Pipeline Execution**.
+
+**Vulnerable Example:**
+
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: drop-sudo
+      - run: npm publish    # DANGEROUS: publishes potentially modified code
+```
+
+**Detection Output:**
+
+```bash
+vulnerable.yaml:8:9: action "openai/codex-action@v1" is not the last step in this job. The OpenAI/Anthropic security checklist recommends running AI agent actions as the last step to prevent subsequent steps from inheriting potentially compromised state. [ai-action-execution-order]
+      8 |       - uses: openai/codex-action@v1
+```
+
+### Detection Logic
+
+The rule operates at the job level:
+
+1. Iterates through all steps in a job
+2. Identifies steps using a known AI agent action (by prefix match)
+3. If an AI action step is found and it is not the last step, emits a warning
+
+### Attack Scenario
+
+```
+1. A workflow checks out code and runs an AI agent
+2. The AI agent, potentially manipulated via prompt injection, modifies source files
+3. A subsequent step (npm publish, docker build, terraform apply) executes
+4. The modified code/config is deployed to production
+5. Attacker achieves supply chain compromise through the AI agent
+```
+
+### Remediation Steps
+
+1. **Move AI actions to the last step** (recommended)
+
+   ```yaml
+   steps:
+     - uses: actions/checkout@v4
+     - run: npm test            # Run tests BEFORE the AI agent
+     - run: npm run build       # Build BEFORE the AI agent
+     - uses: openai/codex-action@v1
+       with:
+         safety-strategy: drop-sudo
+   ```
+
+2. **Separate AI and deployment into different jobs**
+
+   ```yaml
+   jobs:
+     ai-review:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: openai/codex-action@v1
+           with:
+             safety-strategy: read-only
+
+     deploy:
+       needs: ai-review
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4   # Fresh checkout, not affected by AI
+         - run: npm publish
+   ```
+
+3. **Use read-only sandbox when followed by other steps**
+
+   If you must have steps after the AI action, at minimum use `read-only` sandbox to prevent file modifications:
+
+   ```yaml
+   steps:
+     - uses: openai/codex-action@v1
+       with:
+         safety-strategy: read-only   # Cannot modify files
+     - run: npm publish               # Less risky with read-only sandbox
+   ```
+
+### Best Practices
+
+1. **AI agent as last step**: Always place AI agent actions at the end of the job step list.
+
+2. **Separate concerns**: Use different jobs for AI analysis and deployment/publishing.
+
+3. **Fresh checkout for deployment**: If deploying after AI analysis, do a fresh `actions/checkout` in a separate job.
+
+4. **Combine with sandbox restrictions**: Use `read-only` or `unprivileged-user` sandbox strategies when the AI agent doesn't need write access (see [AI Action Unsafe Sandbox]({{< ref "aiactionunsafesandbox.md" >}})).
+
+### Complementary Rules
+
+- [AI Action Unsafe Sandbox]({{< ref "aiactionunsafesandbox.md" >}}): Detects unsafe sandbox/safety-strategy settings
+- [AI Action Excessive Tools]({{< ref "aiactionexcessivetools.md" >}}): Detects dangerous tool grants in untrusted triggers
+- [AI Action Prompt Injection]({{< ref "aiactionpromptinjection.md" >}}): Detects untrusted input in AI prompts
+
+### References
+
+- [OpenAI Codex GitHub Action Security Checklist](https://developers.openai.com/codex/github-action#security-checklist)
+- [Anthropic: claude-code-action security](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md)
+- [OWASP: CI/CD Security Risk CICD-SEC-4](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
+- [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

--- a/docs/aiactionunsafesandbox.md
+++ b/docs/aiactionunsafesandbox.md
@@ -3,7 +3,7 @@ title: "AI Action Unsafe Sandbox Rule"
 weight: 1
 ---
 
-### AI Action Unsafe Sandbox Rule Overview
+## AI Action Unsafe Sandbox Rule Overview
 
 This rule detects **AI agent actions configured with unsafe sandbox or safety-strategy settings**, which disable sandbox protections and allow the AI agent to execute with unrestricted system access.
 

--- a/docs/aiactionunsafesandbox.md
+++ b/docs/aiactionunsafesandbox.md
@@ -1,0 +1,132 @@
+---
+title: "AI Action Unsafe Sandbox Rule"
+weight: 1
+---
+
+### AI Action Unsafe Sandbox Rule Overview
+
+This rule detects **AI agent actions configured with unsafe sandbox or safety-strategy settings**, which disable sandbox protections and allow the AI agent to execute with unrestricted system access.
+
+**Affected Actions:**
+- `anthropics/claude-code-action`
+- `github/copilot-swe-agent`
+- `openai/openai-actions`
+- `openai/codex-action`
+
+### Security Impact
+
+**Severity: High**
+
+Disabling sandbox protections on AI agent actions creates severe risk:
+
+1. **Unrestricted System Access**: The AI agent can modify any file, install packages, and run arbitrary system commands without restrictions
+2. **Privilege Escalation**: With `unsafe` or `danger-full-access`, the agent runs with full user privileges
+3. **Secret Exfiltration**: No sandbox boundary prevents the agent from accessing and transmitting sensitive data
+4. **Supply Chain Compromise**: Unrestricted agents can modify build artifacts, dependencies, or CI/CD configuration
+
+This vulnerability aligns with **CWE-250: Execution with Unnecessary Privileges** and **OWASP CI/CD Security Risk CICD-SEC-6: Insufficient Credential Hygiene**.
+
+### Detected Patterns
+
+#### 1. Unsafe safety-strategy (Codex)
+
+```yaml
+name: Vulnerable Agent
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: unsafe   # DANGEROUS: disables all sandbox protections
+```
+
+#### 2. Full access mode (Codex)
+
+```yaml
+steps:
+  - uses: openai/codex-action@v1
+    with:
+      safety-strategy: danger-full-access   # DANGEROUS: maximum privileges
+```
+
+#### 3. Skip permissions (Claude Code Action)
+
+```yaml
+steps:
+  - uses: anthropics/claude-code-action@v1
+    with:
+      claude_args: --dangerouslySkipPermissions   # DANGEROUS: bypasses all permission checks
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+### Detection Logic
+
+The rule checks each AI agent action step for:
+
+1. `safety-strategy` or `safety_strategy` input with values `unsafe` or `danger-full-access`
+2. `claude_args` input containing the `--dangerouslySkipPermissions` flag
+
+### Remediation Steps
+
+1. **Use a safe sandbox strategy** (recommended)
+
+   ```yaml
+   - uses: openai/codex-action@v1
+     with:
+       safety-strategy: drop-sudo   # Default, drops sudo privileges
+   ```
+
+2. **Use stricter sandbox modes for sensitive operations**
+
+   ```yaml
+   - uses: openai/codex-action@v1
+     with:
+       safety-strategy: read-only   # Most restrictive: read-only filesystem
+   ```
+
+3. **Remove --dangerouslySkipPermissions from Claude Code Action**
+
+   ```yaml
+   - uses: anthropics/claude-code-action@v1
+     with:
+       claude_args: --allowedTools "Read,Glob,Grep"   # Explicit tool list instead
+       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+   ```
+
+### Available Safety Strategies
+
+| Strategy | Description | Risk |
+|----------|-------------|------|
+| `drop-sudo` | Drops sudo privileges (default) | Low |
+| `unprivileged-user` | Runs as unprivileged user | Low |
+| `read-only` | Read-only filesystem access | Minimal |
+| `unsafe` | No sandbox restrictions | **Critical** |
+| `danger-full-access` | Full unrestricted access | **Critical** |
+
+### Best Practices
+
+1. **Default to `drop-sudo`**: Use the default sandbox strategy unless you have a specific reason to change it.
+
+2. **Use `read-only` for analysis tasks**: If the agent only needs to read and analyze code, use the most restrictive sandbox.
+
+3. **Never use `unsafe` or `danger-full-access` in production**: These modes should only be used in development environments with full awareness of the risks.
+
+4. **Combine with tool restrictions**: Even with sandbox protections, limit the tools available to the agent (see [AI Action Excessive Tools]({{< ref "aiactionexcessivetools.md" >}})).
+
+### Complementary Rules
+
+- [AI Action Excessive Tools]({{< ref "aiactionexcessivetools.md" >}}): Detects dangerous tool grants (Bash/Write/Edit) with untrusted triggers
+- [AI Action Unrestricted Trigger]({{< ref "aiactionunrestrictedtrigger.md" >}}): Detects open access (`allowed_non_write_users: "*"`)
+- [AI Action Prompt Injection]({{< ref "aiactionpromptinjection.md" >}}): Detects untrusted input in AI prompts
+
+### References
+
+- [OpenAI Codex GitHub Action Security Checklist](https://developers.openai.com/codex/github-action#security-checklist)
+- [Anthropic: claude-code-action security](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md)
+- [OWASP: CI/CD Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
+- [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

--- a/pkg/core/aiaction_execution_order.go
+++ b/pkg/core/aiaction_execution_order.go
@@ -1,0 +1,75 @@
+package core
+
+import (
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// AIActionExecutionOrderRule は AI エージェントアクションがジョブの最後のステップでない場合を検出するルール。
+//
+// OpenAI Codex セキュリティチェックリストでは "Run Codex as the last step in a job" を推奨している。
+// AI エージェントの後に他のステップが続くと、エージェントによる状態変更（ファイル変更、環境変数など）を
+// 後続ステップが継承するリスクがある。
+//
+// 脆弱なパターン:
+//
+//	steps:
+//	  - uses: actions/checkout@v4
+//	  - uses: openai/codex-action@v1
+//	    with:
+//	      safety-strategy: drop-sudo
+//	  - run: npm publish    # AI エージェントの後のステップ — 改変されたコードを公開する可能性
+//
+// 安全なパターン:
+//
+//	steps:
+//	  - uses: actions/checkout@v4
+//	  - uses: openai/codex-action@v1
+//	    with:
+//	      safety-strategy: drop-sudo
+type AIActionExecutionOrderRule struct {
+	BaseRule
+}
+
+// NewAIActionExecutionOrderRule は新しいルールインスタンスを返す。
+func NewAIActionExecutionOrderRule() *AIActionExecutionOrderRule {
+	return &AIActionExecutionOrderRule{
+		BaseRule: BaseRule{
+			RuleName: "ai-action-execution-order",
+			RuleDesc: "AI action is not the last step in the job",
+		},
+	}
+}
+
+// VisitJobPre はジョブを訪問し、AI エージェントアクションの後に他のステップが続いていないかを検査する。
+func (r *AIActionExecutionOrderRule) VisitJobPre(node *ast.Job) error {
+	if node.Steps == nil {
+		return nil
+	}
+
+	steps := node.Steps
+	for i, step := range steps {
+		action, ok := step.Exec.(*ast.ExecAction)
+		if !ok {
+			continue
+		}
+
+		if action.Uses == nil {
+			continue
+		}
+
+		if !isKnownAIActionPrefix(action.Uses.Value) {
+			continue
+		}
+
+		// AI アクションの後にステップが存在するかチェック
+		if i < len(steps)-1 {
+			r.Errorf(
+				step.Pos,
+				`action %q is not the last step in this job. The OpenAI/Anthropic security checklist recommends running AI agent actions as the last step to prevent subsequent steps from inheriting potentially compromised state.`,
+				action.Uses.Value,
+			)
+		}
+	}
+
+	return nil
+}

--- a/pkg/core/aiaction_execution_order_test.go
+++ b/pkg/core/aiaction_execution_order_test.go
@@ -1,0 +1,182 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAIActionExecutionOrder_DetectsNotLastStep(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionExecutionOrderRule()
+
+	workflow := `
+on:
+  push:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: drop-sudo
+      - run: npm publish
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) == 0 {
+		t.Fatal("expected error for AI action not being last step, got none")
+	}
+	if !strings.Contains(ruleErrors[0].Description, "not the last step") {
+		t.Errorf("expected error to mention 'not the last step', got: %s", ruleErrors[0].Description)
+	}
+	if ruleErrors[0].Type != "ai-action-execution-order" {
+		t.Errorf("expected error type ai-action-execution-order, got: %s", ruleErrors[0].Type)
+	}
+}
+
+func TestAIActionExecutionOrder_AllowsLastStep(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionExecutionOrderRule()
+
+	workflow := `
+on:
+  push:
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: drop-sudo
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) != 0 {
+		t.Fatalf("expected no errors when AI action is last step, got %d: %v", len(ruleErrors), ruleErrors)
+	}
+}
+
+func TestAIActionExecutionOrder_IgnoresNonAIAction(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionExecutionOrderRule()
+
+	workflow := `
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm test
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) != 0 {
+		t.Fatalf("expected no errors for non-AI actions, got %d", len(ruleErrors))
+	}
+}
+
+func TestAIActionExecutionOrder_DetectsMultipleAIActions(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionExecutionOrderRule()
+
+	workflow := `
+on:
+  push:
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: drop-sudo
+      - run: echo "done"
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) < 2 {
+		t.Fatalf("expected at least 2 errors for multiple AI actions not being last, got %d", len(ruleErrors))
+	}
+}
+
+func TestAIActionExecutionOrder_ClaudeCodeAction(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionExecutionOrderRule()
+
+	workflow := `
+on:
+  issues:
+    types: [opened]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      - run: echo "post-processing"
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) == 0 {
+		t.Fatal("expected error for claude-code-action not being last step, got none")
+	}
+}

--- a/pkg/core/aiaction_unrestricted_trigger.go
+++ b/pkg/core/aiaction_unrestricted_trigger.go
@@ -77,11 +77,18 @@ func (r *AIActionUnrestrictedTriggerRule) VisitStep(node *ast.Step) error {
 }
 
 // isKnownAIActionPrefix は uses の値が既知の AI アクションプレフィックスに一致するかを確認する。
+// プレフィックスの直後が '@'、'/'、または文字列終端であることを確認し、
+// "openai/codex-action-malicious@v1" のような誤検知を防ぐ。
 func isKnownAIActionPrefix(uses string) bool {
 	usesLower := strings.ToLower(uses)
 	for _, prefix := range knownAIActionPrefixes {
 		if strings.HasPrefix(usesLower, prefix) {
-			return true
+			// Exact match or followed by '@' or '/' (version or sub-path)
+			if len(usesLower) == len(prefix) ||
+				usesLower[len(prefix)] == '@' ||
+				usesLower[len(prefix)] == '/' {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/core/aiaction_unrestricted_trigger.go
+++ b/pkg/core/aiaction_unrestricted_trigger.go
@@ -11,6 +11,7 @@ var knownAIActionPrefixes = []string{
 	"anthropics/claude-code-action",
 	"github/copilot-swe-agent",
 	"openai/openai-actions",
+	"openai/codex-action",
 }
 
 // AIActionUnrestrictedTriggerRule は allowed_non_write_users: "*" を検出するルール。

--- a/pkg/core/aiaction_unrestricted_trigger_test.go
+++ b/pkg/core/aiaction_unrestricted_trigger_test.go
@@ -78,6 +78,40 @@ jobs:
 	}
 }
 
+func TestAIActionUnrestrictedTrigger_IgnoresSimilarActionName(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionUnrestrictedTriggerRule()
+
+	// "openai/codex-action-malicious" should NOT match prefix "openai/codex-action"
+	workflow := `
+on:
+  issues:
+    types: [opened]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action-malicious@v1
+        with:
+          allowed_non_write_users: "*"
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) != 0 {
+		t.Fatalf("expected no errors for similar-but-different action name, got %d: %v", len(ruleErrors), ruleErrors)
+	}
+}
+
 func TestAIActionUnrestrictedTrigger_IgnoresNonAIAction(t *testing.T) {
 	t.Parallel()
 	rule := NewAIActionUnrestrictedTriggerRule()

--- a/pkg/core/aiaction_unsafe_sandbox.go
+++ b/pkg/core/aiaction_unsafe_sandbox.go
@@ -1,0 +1,118 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// unsafeSandboxValues はサンドボックス保護を無効化する危険な safety-strategy の値。
+var unsafeSandboxValues = []string{
+	"unsafe",
+	"danger-full-access",
+}
+
+// sandboxStrategyInputKeys は safety-strategy を指定する入力キー名の候補。
+// GitHub Actions の with セクションではハイフン区切りとアンダースコア区切りの両方が使われうる。
+var sandboxStrategyInputKeys = []string{
+	"safety-strategy",
+	"safety_strategy",
+}
+
+// AIActionUnsafeSandboxRule は AI エージェントアクションの安全でないサンドボックス設定を検出するルール。
+//
+// 脆弱なパターン:
+//
+//	steps:
+//	  - uses: openai/codex-action@v1
+//	    with:
+//	      safety-strategy: unsafe
+//
+//	steps:
+//	  - uses: anthropics/claude-code-action@v1
+//	    with:
+//	      claude_args: --dangerouslySkipPermissions
+//
+// OpenAI Codex セキュリティチェックリストでは safety-strategy に "drop-sudo"（デフォルト）、
+// "unprivileged-user"、"read-only" を推奨し、"unsafe" や "danger-full-access" の使用を警告している。
+// claude-code-action では --dangerouslySkipPermissions フラグが同等のサンドボックスバイパスに該当する。
+//
+// 安全なパターン:
+//
+//	steps:
+//	  - uses: openai/codex-action@v1
+//	    with:
+//	      safety-strategy: drop-sudo
+type AIActionUnsafeSandboxRule struct {
+	BaseRule
+}
+
+// NewAIActionUnsafeSandboxRule は新しいルールインスタンスを返す。
+func NewAIActionUnsafeSandboxRule() *AIActionUnsafeSandboxRule {
+	return &AIActionUnsafeSandboxRule{
+		BaseRule: BaseRule{
+			RuleName: "ai-action-unsafe-sandbox",
+			RuleDesc: "AI action has unsafe sandbox or safety-strategy configuration",
+		},
+	}
+}
+
+// VisitStep は各ステップを訪問し、AI エージェントアクションの安全でないサンドボックス設定を検出する。
+func (r *AIActionUnsafeSandboxRule) VisitStep(node *ast.Step) error {
+	action, ok := node.Exec.(*ast.ExecAction)
+	if !ok {
+		return nil
+	}
+
+	if action.Uses == nil {
+		return nil
+	}
+
+	if !isKnownAIActionPrefix(action.Uses.Value) {
+		return nil
+	}
+
+	r.checkSafetyStrategy(node, action)
+	r.checkDangerouslySkipPermissions(node, action)
+
+	return nil
+}
+
+// checkSafetyStrategy は safety-strategy 入力の値を検査する。
+func (r *AIActionUnsafeSandboxRule) checkSafetyStrategy(node *ast.Step, action *ast.ExecAction) {
+	for _, key := range sandboxStrategyInputKeys {
+		input, exists := action.Inputs[key]
+		if !exists || input == nil || input.Value == nil {
+			continue
+		}
+
+		val := strings.TrimSpace(strings.ToLower(input.Value.Value))
+		for _, unsafeVal := range unsafeSandboxValues {
+			if val == unsafeVal {
+				r.Errorf(
+					node.Pos,
+					`action %q has safety-strategy set to %q which disables sandbox protections. Use "drop-sudo", "unprivileged-user", or "read-only" instead.`,
+					action.Uses.Value,
+					input.Value.Value,
+				)
+				return
+			}
+		}
+	}
+}
+
+// checkDangerouslySkipPermissions は claude_args に --dangerouslySkipPermissions が含まれているかを検査する。
+func (r *AIActionUnsafeSandboxRule) checkDangerouslySkipPermissions(node *ast.Step, action *ast.ExecAction) {
+	claudeArgsInput, exists := action.Inputs["claude_args"]
+	if !exists || claudeArgsInput == nil || claudeArgsInput.Value == nil {
+		return
+	}
+
+	if strings.Contains(claudeArgsInput.Value.Value, "--dangerouslySkipPermissions") {
+		r.Errorf(
+			node.Pos,
+			`action %q uses --dangerouslySkipPermissions in claude_args which bypasses all permission checks. Remove this flag and configure specific tool permissions instead.`,
+			action.Uses.Value,
+		)
+	}
+}

--- a/pkg/core/aiaction_unsafe_sandbox.go
+++ b/pkg/core/aiaction_unsafe_sandbox.go
@@ -79,6 +79,7 @@ func (r *AIActionUnsafeSandboxRule) VisitStep(node *ast.Step) error {
 }
 
 // checkSafetyStrategy は safety-strategy 入力の値を検査する。
+// safety-strategy が未設定の場合、デフォルト値は "drop-sudo"（安全）のため警告不要。
 func (r *AIActionUnsafeSandboxRule) checkSafetyStrategy(node *ast.Step, action *ast.ExecAction) {
 	for _, key := range sandboxStrategyInputKeys {
 		input, exists := action.Inputs[key]

--- a/pkg/core/aiaction_unsafe_sandbox_test.go
+++ b/pkg/core/aiaction_unsafe_sandbox_test.go
@@ -1,0 +1,220 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAIActionUnsafeSandbox_DetectsUnsafeStrategy(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionUnsafeSandboxRule()
+
+	workflow := `
+on:
+  issues:
+    types: [opened]
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: unsafe
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) == 0 {
+		t.Fatal("expected error for safety-strategy: unsafe, got none")
+	}
+	if !strings.Contains(ruleErrors[0].Description, "safety-strategy") {
+		t.Errorf("expected error to mention safety-strategy, got: %s", ruleErrors[0].Description)
+	}
+	if ruleErrors[0].Type != "ai-action-unsafe-sandbox" {
+		t.Errorf("expected error type ai-action-unsafe-sandbox, got: %s", ruleErrors[0].Type)
+	}
+}
+
+func TestAIActionUnsafeSandbox_DetectsDangerFullAccess(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionUnsafeSandboxRule()
+
+	workflow := `
+on:
+  push:
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: danger-full-access
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) == 0 {
+		t.Fatal("expected error for safety-strategy: danger-full-access, got none")
+	}
+	if !strings.Contains(ruleErrors[0].Description, "danger-full-access") {
+		t.Errorf("expected error to mention danger-full-access, got: %s", ruleErrors[0].Description)
+	}
+}
+
+func TestAIActionUnsafeSandbox_DetectsDangerouslySkipPermissions(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionUnsafeSandboxRule()
+
+	workflow := `
+on:
+  issues:
+    types: [opened]
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_args: --dangerouslySkipPermissions --allowedTools "Bash,Read"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) == 0 {
+		t.Fatal("expected error for --dangerouslySkipPermissions, got none")
+	}
+	if !strings.Contains(ruleErrors[0].Description, "dangerouslySkipPermissions") {
+		t.Errorf("expected error to mention dangerouslySkipPermissions, got: %s", ruleErrors[0].Description)
+	}
+}
+
+func TestAIActionUnsafeSandbox_AllowsSafeStrategies(t *testing.T) {
+	t.Parallel()
+
+	safeValues := []string{"drop-sudo", "unprivileged-user", "read-only"}
+	for _, val := range safeValues {
+		t.Run(val, func(t *testing.T) {
+			t.Parallel()
+			rule := NewAIActionUnsafeSandboxRule()
+
+			workflow := `
+on:
+  push:
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: ` + val + `
+`
+			parsed, errs := Parse([]byte(workflow))
+			if len(errs) > 0 {
+				t.Fatalf("failed to parse workflow: %v", errs)
+			}
+
+			v := NewSyntaxTreeVisitor()
+			v.AddVisitor(rule)
+			if err := v.VisitTree(parsed); err != nil {
+				t.Fatalf("failed to visit tree: %v", err)
+			}
+
+			ruleErrors := rule.Errors()
+			if len(ruleErrors) != 0 {
+				t.Fatalf("expected no errors for safe strategy %q, got %d: %v", val, len(ruleErrors), ruleErrors)
+			}
+		})
+	}
+}
+
+func TestAIActionUnsafeSandbox_IgnoresNonAIAction(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionUnsafeSandboxRule()
+
+	workflow := `
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          safety-strategy: unsafe
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) != 0 {
+		t.Fatalf("expected no errors for non-AI action, got %d", len(ruleErrors))
+	}
+}
+
+func TestAIActionUnsafeSandbox_NoSandboxInputIsOK(t *testing.T) {
+	t.Parallel()
+	rule := NewAIActionUnsafeSandboxRule()
+
+	workflow := `
+on:
+  push:
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action@v1
+        with:
+          model: o3-mini
+`
+	parsed, errs := Parse([]byte(workflow))
+	if len(errs) > 0 {
+		t.Fatalf("failed to parse workflow: %v", errs)
+	}
+
+	v := NewSyntaxTreeVisitor()
+	v.AddVisitor(rule)
+	if err := v.VisitTree(parsed); err != nil {
+		t.Fatalf("failed to visit tree: %v", err)
+	}
+
+	ruleErrors := rule.Errors()
+	if len(ruleErrors) != 0 {
+		t.Fatalf("expected no errors when safety-strategy is not set, got %d: %v", len(ruleErrors), ruleErrors)
+	}
+}

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -567,6 +567,8 @@ func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadat
 		NewAIActionUnrestrictedTriggerRule(), // Detects AI actions with unrestricted user access (Clinejection attack pattern)
 		NewAIActionExcessiveToolsRule(),      // Detects AI actions with dangerous tools in untrusted triggers (Clinejection attack pattern)
 		NewAIActionPromptInjectionRule(),     // Detects untrusted input in AI agent prompt parameters (prompt injection, Clinejection attack pattern)
+		NewAIActionUnsafeSandboxRule(),       // Detects unsafe sandbox settings in AI agent actions
+		NewAIActionExecutionOrderRule(),      // Detects AI agent actions that are not the last step in a job
 	}
 }
 

--- a/script/README.md
+++ b/script/README.md
@@ -36,6 +36,10 @@ Contains example GitHub Actions workflow files that demonstrate various security
 | `test-actionlist-blacklist.yaml` | Blacklist validation testing |
 | `cross-job-taint.yaml` | Cross-job taint propagation via `needs.*.outputs.*` (code-injection-critical) |
 | `cross-job-taint-safe.yaml` | Safe pattern: untrusted needs output moved to `env:` and referenced with double quotes (e.g. `echo "$PR_TITLE"` not `echo $PR_TITLE`) to avoid shell expansion; see `pkg/core/codeinjection_shell_test.go` for unquoted env detection |
+| `ai-action-unsafe-sandbox-vulnerable.yaml` | AI action with unsafe sandbox settings (`safety-strategy: unsafe`) |
+| `ai-action-unsafe-sandbox-safe.yaml` | Safe AI action sandbox configuration (`safety-strategy: drop-sudo`) |
+| `ai-action-execution-order-vulnerable.yaml` | AI action followed by additional steps (compromised state risk) |
+| `ai-action-execution-order-safe.yaml` | AI action as the last step in the job (recommended pattern) |
 
 ### Usage
 

--- a/script/actions/ai-action-execution-order-safe.yaml
+++ b/script/actions/ai-action-execution-order-safe.yaml
@@ -1,0 +1,13 @@
+name: Safe AI Execution Order
+
+on:
+  push:
+
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: drop-sudo

--- a/script/actions/ai-action-execution-order-vulnerable.yaml
+++ b/script/actions/ai-action-execution-order-vulnerable.yaml
@@ -1,0 +1,14 @@
+name: Vulnerable AI Execution Order
+
+on:
+  push:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: drop-sudo
+      - run: npm publish

--- a/script/actions/ai-action-unsafe-sandbox-safe.yaml
+++ b/script/actions/ai-action-unsafe-sandbox-safe.yaml
@@ -1,0 +1,12 @@
+name: Safe AI Sandbox
+
+on:
+  push:
+
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: drop-sudo

--- a/script/actions/ai-action-unsafe-sandbox-vulnerable.yaml
+++ b/script/actions/ai-action-unsafe-sandbox-vulnerable.yaml
@@ -1,0 +1,13 @@
+name: Vulnerable AI Sandbox
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/codex-action@v1
+        with:
+          safety-strategy: unsafe


### PR DESCRIPTION
## Summary

Closes #406 (items 1, 3, 4)

Adds two new rules to close gaps between sisakulint's existing AI action checks and the [OpenAI Codex GitHub Action security checklist](https://developers.openai.com/codex/github-action#security-checklist):

- **`ai-action-unsafe-sandbox`** — Detects unsafe sandbox/safety-strategy configurations on AI agent actions:
  - `safety-strategy: unsafe` and `safety-strategy: danger-full-access` (Codex)
  - `--dangerouslySkipPermissions` in `claude_args` (Claude Code Action)
- **`ai-action-execution-order`** — Warns when AI agent actions are not the last step in a job, preventing subsequent steps from inheriting potentially compromised state
- Adds `openai/codex-action` to the known AI action prefixes shared by all AI action rules

### Not included (deferred)

- Item 2 (excessive secrets exposure to AI): Overlaps with existing `SecretsInheritRule`/`SecretExposureRule`; needs design discussion to define "excessive"
- Item 5 (HTML comment prompt injection): Acknowledged as out of scope in the issue itself

## New files

| File | Purpose |
|------|---------|
| `pkg/core/aiaction_unsafe_sandbox.go` | Sandbox validation rule |
| `pkg/core/aiaction_unsafe_sandbox_test.go` | Tests (6 test cases) |
| `pkg/core/aiaction_execution_order.go` | Execution order rule |
| `pkg/core/aiaction_execution_order_test.go` | Tests (5 test cases) |
| `docs/aiactionunsafesandbox.md` | Rule documentation |
| `docs/aiactionexecutionorder.md` | Rule documentation |
| `script/actions/ai-action-unsafe-sandbox-{vulnerable,safe}.yaml` | Example workflows |
| `script/actions/ai-action-execution-order-{vulnerable,safe}.yaml` | Example workflows |

## Test plan

- [x] All 17 AI action tests pass (`go test ./pkg/core/... -run TestAIAction`)
- [x] Full test suite passes (`go test ./...`)
- [x] Vulnerable example workflows produce expected rule violations
- [x] Safe example workflows do not produce false positives
- [x] Existing AI action rules (`unrestricted-trigger`, `excessive-tools`, `prompt-injection`) unaffected

https://claude.ai/code/session_01KzWzwMzcDCEPMaZmTkoabL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * AIエージェント向けセキュリティ検出ルールを2件追加：サンドボックス無効化の検出と、AIアクションがジョブの最後でない配置の検出。

* **ドキュメント**
  * 各ルールの検出パターン、脅威シナリオ、緩和策、ベストプラクティスを詳細に追加。

* **テスト**
  * 新ルールを検証する並列化された網羅的なテスト群を追加。

* **例・ワークフロー**
  * 安全／脆弱なAIワークフロー例を複数追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->