### PR TITLE
feat(taint): add tj-actions/changed-files to known tainted actions database

### DIFF
--- a/docs/goat/case10-code-injection-output.md
+++ b/docs/goat/case10-code-injection-output.md
@@ -28,19 +28,18 @@ The output of `tj-actions/changed-files` (`steps.changed-files.outputs.all_chang
 
 ## sisakulint Detection Status
 
-### Indirect Detection
+### Direct Detection (code-injection rule via Phase 3 Known Tainted Actions)
 
-The `known-vulnerable-actions` rule detected the known vulnerabilities in `tj-actions/changed-files@v40` and `@v35` (see Case 03).
+The `code-injection` rule detects this pattern via the Phase 3 Known Tainted Actions database. `tj-actions/changed-files` is registered as a known tainted action because its file-list outputs (`all_changed_files`, `modified_files`, etc.) reflect PR filenames, which are attacker-controlled.
 
-### Why Not Directly Detected
+```
+code injection (medium): "steps.changed-files.outputs.all_changed_files (tainted via PR filenames
+(attacker-controlled via pull request))" is potentially untrusted. Avoid using it directly in
+inline scripts. Instead, pass it through an environment variable.
+```
 
-sisakulint's `code-injection` rule tracks known untrusted input contexts such as `github.event.pull_request.title`, `github.event.issue.body`, etc. However, it does not track indirect taint propagation from third-party action outputs (`steps.*.outputs.*`).
+### Additional Detection
 
-This is a fundamental limitation of static analysis — determining whether an action's output is derived from untrusted input requires analyzing the action's internal implementation, which is beyond workflow-level YAML analysis.
+The `known-vulnerable-actions` rule also detects known CVEs in `tj-actions/changed-files@v40` and `@v35` (GHSA-mrrh-fwg8-r2c3, GHSA-mcph-m25j-8j63).
 
-## Future Improvement Ideas
-
-- Build a database of known dangerous action outputs
-- Add a warning rule for `steps.*.outputs.*` usage in `${{ }}` within `run` steps
-
-## Verdict: NOT DETECTED (indirectly detected via known-vulnerable-actions)
+## Verdict: DETECTED

--- a/pkg/core/taint.go
+++ b/pkg/core/taint.go
@@ -112,6 +112,22 @@ func (t *TaintTracker) initKnownTaintedActions() {
 	t.knownTaintedActions["andstor/file-reader-action"] = []KnownTaintedOutput{
 		{OutputName: "contents", TaintSource: "file content (potentially from artifact)"},
 	}
+
+	// tj-actions/changed-files - exposes PR-controlled filenames as outputs
+	// GHSL-2023-271: attacker creates PR with crafted filenames containing shell metacharacters
+	// All file-list outputs reflect filenames from the PR, making them untrusted input
+	t.knownTaintedActions["tj-actions/changed-files"] = []KnownTaintedOutput{
+		{OutputName: "all_changed_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "modified_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "added_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "deleted_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "renamed_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "all_changed_and_modified_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "all_modified_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "other_changed_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "other_modified_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+		{OutputName: "other_deleted_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
+	}
 }
 
 // AnalyzeStep analyzes a step for $GITHUB_OUTPUT writes with tainted values.

--- a/pkg/core/taint_test.go
+++ b/pkg/core/taint_test.go
@@ -714,6 +714,73 @@ func TestTaintTracker_KnownTaintedActionIntegration(t *testing.T) {
 	t.Logf("Taint sources for head_ref: %v", sources)
 }
 
+func TestTaintTracker_KnownTaintedAction_TjActionsChangedFiles(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewTaintTracker()
+
+	// Test tj-actions/changed-files action (GHSL-2023-271, Case 10)
+	step := &ast.Step{
+		ID: &ast.String{Value: "changed-files"},
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "tj-actions/changed-files@v40"},
+		},
+	}
+	tracker.AnalyzeStep(step)
+
+	// Verify outputs are marked as tainted
+	outputs, exists := tracker.taintedOutputs["changed-files"]
+	if !exists {
+		t.Fatal("tj-actions/changed-files should have tainted outputs")
+	}
+
+	// Check for expected tainted outputs
+	expectedOutputs := []string{
+		"all_changed_files",
+		"modified_files",
+		"added_files",
+		"deleted_files",
+		"renamed_files",
+		"all_changed_and_modified_files",
+		"all_modified_files",
+		"other_changed_files",
+		"other_modified_files",
+		"other_deleted_files",
+	}
+	for _, outputName := range expectedOutputs {
+		if _, outputExists := outputs[outputName]; !outputExists {
+			t.Errorf("output %s should be tainted for tj-actions/changed-files", outputName)
+		}
+	}
+}
+
+func TestTaintTracker_KnownTaintedAction_TjActionsChangedFilesIntegration(t *testing.T) {
+	t.Parallel()
+
+	// Full integration test: tj-actions/changed-files -> run step with output in ${{ }}
+	// This is the Case 10 pattern from github-actions-goat
+	tracker := NewTaintTracker()
+
+	// Step 1: Use tj-actions/changed-files
+	step1 := &ast.Step{
+		ID: &ast.String{Value: "changed-files"},
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "tj-actions/changed-files@v40"},
+		},
+	}
+	tracker.AnalyzeStep(step1)
+
+	// Verify the action's output is detected as tainted
+	tainted, sources := tracker.IsTaintedExpr("steps.changed-files.outputs.all_changed_files")
+	if !tainted {
+		t.Fatal("steps.changed-files.outputs.all_changed_files should be tainted")
+	}
+	if len(sources) == 0 {
+		t.Fatal("taint sources should not be empty")
+	}
+	t.Logf("Taint sources for all_changed_files: %v", sources)
+}
+
 func TestTaintTracker_VariableAssignmentWithKeywordPrefix(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `tj-actions/changed-files` のファイルリスト系output（`all_changed_files`, `modified_files` 等10個）を Phase 3 Known Tainted Actions データベースに追加
- github-actions-goat Case 10 の code injection パターンを直接検出可能に
- Case 10 ドキュメントを "NOT DETECTED" から "DETECTED" に更新

## 背景

Closes #387

`tj-actions/changed-files` のoutputはPRファイル名を反映しており、攻撃者が細工したファイル名（シェルメタ文字を含む）でコード注入が可能（GHSL-2023-271）。既存のPhase 3 Known Tainted Actions の仕組みを活用し、データベースにエントリを追加するだけで検出を実現。

未知のアクションに対する汎用的な警告ルール（Approach 2）は #429 として別issueに切り出し済み。

## Test plan

- [x] `TestTaintTracker_KnownTaintedAction_TjActionsChangedFiles` -- 10個のoutputがtaint登録されることを確認
- [x] `TestTaintTracker_KnownTaintedAction_TjActionsChangedFilesIntegration` -- IsTaintedExprでtaint判定されることを確認
- [x] `sisakulint script/actions/goat-changed-files-vulnerability-without-hr.yml` でcode-injection-medium検出確認
- [x] 既存TaintTrackerテスト全通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `tj-actions/changed-files` アクションの出力（`all_changed_files`、`modified_files` など）がPRファイル名由来の攻撃者制御可能な値として検出されるようになりました。

* **ドキュメント**
  * コード注入脆弱性の検出ステータスに関する説明を更新し、より明確な検出フレームワークを提供しました。

* **テスト**
  * 既知の危険なアクションの検出を検証する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->