### PR TITLE
feat(secret-in-log): sink 拡張 — cat/tee/dd の here-string と heredoc を検出

### DIFF
--- a/docs/secretinlogrule.md
+++ b/docs/secretinlogrule.md
@@ -80,7 +80,11 @@ The rule performs taint propagation within a single `run` step:
 
 1. **Taint sources** — environment variables whose value contains `${{ secrets.* }}` declared at the workflow-level, job-level, or step-level `env` (all three scopes are merged, with step-level entries overriding the outer scopes on name conflict).
 2. **Taint propagation** — shell assignments that reference a tainted variable, including command substitutions (`VAR=$(cmd $TAINTED)`).
-3. **Sink detection** — `echo` or `printf` calls that reference a tainted variable without a preceding `::add-mask::` for that variable. Masks that appear *after* the sink are not considered protective, since GitHub Actions applies masking only to subsequent log output.
+3. **Sink detection** — the following commands are treated as sinks when they reference a tainted variable without a preceding `::add-mask::` for that variable:
+   - `echo` / `printf` with a tainted argument
+   - `cat` / `tee` / `dd` receiving tainted data via here-string (`<<<`) or heredoc (`<<EOF ... EOF`)
+
+   Masks that appear *after* the sink are not considered protective, since GitHub Actions applies masking only to subsequent log output.
 
 #### Non-detection cases (not reported as leaks)
 
@@ -118,10 +122,9 @@ If an assignment and a sink share the same physical line as a compound statement
 
 ### Scope Limitations (MVP)
 
-- **Single-step scope only** — taint does not cross step boundaries or job outputs (`needs.*.outputs.*`); cross-job propagation is a planned follow-up.
-- **`echo` and `printf` only** — commands such as `tee`, `cat`, and `logger` are not yet detected.
-- **Reusable workflow boundaries** — taint does not cross `workflow_call` boundaries; that is a planned follow-up.
-- **Whole-script taint** — taint is currently computed as a set over the entire script, so a sink that syntactically precedes its variable's assignment may still be reported as a leak. Making the analysis order-aware is a planned follow-up (see `sisakulint-a5s`).
+- **Single-step scope only** — taint does not cross step boundaries or job outputs (`needs.*.outputs.*`); cross-job propagation is a planned follow-up (see #432 / #437).
+- **`logger` and pipe-consuming commands not yet covered** — `logger`, `xargs`, and similar sinks are not yet detected. Pipes (`cmd1 | cmd2`) flag the upstream source if it is `echo`/`printf`, but the downstream command is not individually analyzed.
+- **Reusable workflow boundaries** — taint does not cross `workflow_call` boundaries; that is a planned follow-up (see #433).
 
 ### Related Rules
 

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -156,9 +156,15 @@ func (rule *SecretInLogRule) findEchoLeaks(file *syntax.File, tainted map[string
 		if _, isCmdSubst := node.(*syntax.CmdSubst); isCmdSubst {
 			return false
 		}
-		// stdout を「ログに出ない先」へリダイレクトしている Stmt は子ノードごとスキップ。
-		if stmt, isStmt := node.(*syntax.Stmt); isStmt && stmtRedirectsStdoutAwayFromLog(stmt) {
-			return false
+		if stmt, isStmt := node.(*syntax.Stmt); isStmt {
+			// stdout を「ログに出ない先」へリダイレクトしている Stmt は子ノードごとスキップ。
+			if stmtRedirectsStdoutAwayFromLog(stmt) {
+				return false
+			}
+			// cat / tee / dd の here-string (<<<) や heredoc (<<) を経由した
+			// 漏洩は Stmt の Redirs 側に taint があるため、ここで検査する。
+			rule.collectRedirectSinkLeaks(stmt, tainted, script, runStr, &leaks)
+			return true
 		}
 		call, ok := node.(*syntax.CallExpr)
 		if !ok || len(call.Args) == 0 {
@@ -178,6 +184,61 @@ func (rule *SecretInLogRule) findEchoLeaks(file *syntax.File, tainted map[string
 		return true
 	})
 	return leaks
+}
+
+// collectRedirectSinkLeaks は cat / tee / dd のように stdin をそのまま stdout に
+// 出力するコマンドに対し、here-string (<<<) や heredoc (<<) で渡される本文内の
+// tainted 変数参照を漏洩として収集する。
+//
+// 例:
+//
+//	cat <<< "$TOKEN"
+//	tee /dev/stderr <<< "$TOKEN"
+//	cat <<EOF
+//	key=$TOKEN
+//	EOF
+//
+// stdout をファイルにリダイレクトしている場合は呼び出し元の
+// stmtRedirectsStdoutAwayFromLog で既に除外済み。tee のように常に stdout へも書く
+// コマンドは file 引数があっても引き続きログに出るため flag する。
+func (rule *SecretInLogRule) collectRedirectSinkLeaks(
+	stmt *syntax.Stmt,
+	tainted map[string]taintEntry,
+	script string,
+	runStr *ast.String,
+	leaks *[]echoLeakOccurrence,
+) {
+	if stmt == nil || stmt.Cmd == nil {
+		return
+	}
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Args) == 0 {
+		return
+	}
+	cmdName := firstWordLiteral(call.Args[0])
+	switch cmdName {
+	case "cat", "tee", "dd":
+		// proceed
+	default:
+		return
+	}
+	for _, r := range stmt.Redirs {
+		if r == nil {
+			continue
+		}
+		switch r.Op {
+		case syntax.WordHdoc:
+			// here-string: コマンド <<< word — Word に taint があればログに出る
+			if r.Word != nil {
+				rule.collectLeakedVars(r.Word, tainted, script, runStr, cmdName, leaks)
+			}
+		case syntax.Hdoc, syntax.DashHdoc:
+			// heredoc: コマンド << EOF ... EOF — 本文は Hdoc に格納される
+			if r.Hdoc != nil {
+				rule.collectLeakedVars(r.Hdoc, tainted, script, runStr, cmdName, leaks)
+			}
+		}
+	}
 }
 
 // stmtRedirectsStdoutAwayFromLog は Stmt の Redirs に stdout をファイルへ送るものが

--- a/pkg/core/secretinlog_test.go
+++ b/pkg/core/secretinlog_test.go
@@ -894,6 +894,87 @@ func TestSecretInLog_StderrRedirect_StillFlagged(t *testing.T) {
 	}
 }
 
+// Issue #436: sink 拡張 — tee / cat / dd / here-string / heredoc / >&2 を追加検出対象にする。
+func TestSecretInLog_SinkExpansion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		runScript  string
+		wantErrors int
+	}{
+		// >&2 (DplOut) — stderr はログに出力されるため検出対象。
+		{
+			name:       "echo redirect to stderr via DplOut",
+			runScript:  "echo \"$TOKEN\" >&2",
+			wantErrors: 1,
+		},
+		{
+			name:       "printf redirect to stderr via DplOut",
+			runScript:  "printf '%s' \"$TOKEN\" >&2",
+			wantErrors: 1,
+		},
+		// here-string — cat/tee/dd が受け取り stdout に出すため検出対象。
+		{
+			name:       "cat with here-string",
+			runScript:  "cat <<< \"$TOKEN\"",
+			wantErrors: 1,
+		},
+		{
+			name:       "tee with here-string to /dev/stderr",
+			runScript:  "tee /dev/stderr <<< \"$TOKEN\"",
+			wantErrors: 1,
+		},
+		{
+			name:       "dd with here-string",
+			runScript:  "dd <<< \"$TOKEN\"",
+			wantErrors: 1,
+		},
+		// heredoc — 本文内で taint 変数参照がある場合は stdout に出るため検出対象。
+		{
+			name:       "cat with heredoc referencing tainted var",
+			runScript:  "cat <<EOF\nkey=$TOKEN\nEOF",
+			wantErrors: 1,
+		},
+		// 安全: stdout をファイルに逸らしている場合は検出しない。
+		{
+			name:       "cat here-string with stdout redirected to file",
+			runScript:  "cat <<< \"$TOKEN\" > out.txt",
+			wantErrors: 0,
+		},
+		{
+			name:       "tee with here-string into file only (goes to stdout too, still flagged)",
+			runScript:  "tee file.txt <<< \"$TOKEN\"",
+			wantErrors: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step := &ast.Step{
+				Env: &ast.Env{Vars: map[string]*ast.EnvVar{
+					"token": {
+						Name:  &ast.String{Value: "TOKEN"},
+						Value: &ast.String{Value: "${{ secrets.API }}"},
+					},
+				}},
+				Exec: &ast.ExecRun{
+					Run: &ast.String{Value: tc.runScript, Pos: &ast.Position{Line: 1, Col: 1}},
+				},
+			}
+			rule := NewSecretInLogRule()
+			if err := rule.VisitJobPre(&ast.Job{Steps: []*ast.Step{step}}); err != nil {
+				t.Fatalf("VisitJobPre: %v", err)
+			}
+			if got := len(rule.Errors()); got != tc.wantErrors {
+				t.Errorf("script %q: got %d errors, want %d. details=%v",
+					tc.runScript, got, tc.wantErrors, rule.Errors())
+			}
+		})
+	}
+}
+
 // Finding 6: `printf -v VAR ...` は stdout を出さず指定変数に格納するため検出対象外。
 func TestSecretInLog_PrintfDashV_NotFlagged(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

`secret-in-log` ルールの検出対象 sink を拡張し、`cat` / `tee` / `dd` コマンドが here-string (`<<<`) や heredoc (`<<EOF ... EOF`) で受け取るタインテッド変数を検出できるようにした。

Closes #436

## 背景

従来 `secret-in-log` は `echo` / `printf` のみを sink として扱っていたため、以下のパターンは未検出（FN）だった。

```bash
cat <<< "$TOKEN"
tee /dev/stderr <<< "$TOKEN"
cat <<EOF
key=$TOKEN
EOF
```

これらはいずれも stdin をそのまま stdout に出力するためビルドログに漏洩する。

## 実装

- `findEchoLeaks` の Stmt 走査時に `collectRedirectSinkLeaks` を呼び出し、`cat`/`tee`/`dd` の `Stmt.Redirs` を検査
- `WordHdoc` (here-string `<<<`) — `Word` を走査して taint を検出
- `Hdoc` / `DashHdoc` (heredoc `<<` / `<<-`) — `Hdoc` 本文を走査して taint を検出
- stdout を別ファイルにリダイレクトしている Stmt は既存の `stmtRedirectsStdoutAwayFromLog` で除外済み

## 検証

`TestSecretInLog_SinkExpansion` で以下 8 ケースを検証:

| ケース | 期待 |
|---|---|
| `echo "$TOKEN" >&2` (DplOut) | 検出（既存挙動の確認） |
| `printf '%s' "$TOKEN" >&2` | 検出（既存挙動の確認） |
| `cat <<< "$TOKEN"` | 検出（新規） |
| `tee /dev/stderr <<< "$TOKEN"` | 検出（新規） |
| `dd <<< "$TOKEN"` | 検出（新規） |
| `cat <<EOF\nkey=$TOKEN\nEOF` | 検出（新規） |
| `cat <<< "$TOKEN" > out.txt` | 検出しない（stdout をファイルに逸らしている） |
| `tee file.txt <<< "$TOKEN"` | 検出（tee は常に stdout にも書く） |

## Test plan

- [x] `go test ./...` 全件 PASS
- [x] 新規テスト `TestSecretInLog_SinkExpansion` の 8 ケース PASS
- [x] 既存 `TestSecretInLog_*` テスト全件 PASS（回帰なし）

## Related

- #432 — cross-job taint propagation (follow-up)
- #433 — reusable workflow taint (follow-up)
- #435 — order-aware taint (マージ済み)
- #437 — cross-step taint propagation (follow-up)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ヒアドキュメント（`<<EOF`）およびヒアストリング（`<<<`）経由で `cat`、`tee`、`dd` コマンドを使用する際の機密情報リーク検出の範囲を拡張しました。従来の `echo` と `printf` に加えて、これらのコマンドでのタイントデータ流出を検出できるようになります。

* **ドキュメント**
  * シンク検出の動作を詳細に説明し、検出対象外のコマンドを明確化しました。機能の制限事項も更新されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->