### PR TITLE
feat(secret-in-log): cross-step taint — $GITHUB_ENV 経由の

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ sisakulint includes the following security rules (as of pkg/core/linter.go:500-5
 - **ArgumentInjectionMediumRule** - Detects argument injection in command-line args with normal triggers (auto-fix supported)
 - **RequestForgeryCriticalRule** - Detects SSRF vulnerabilities when untrusted input is used in network requests with privileged triggers (auto-fix supported)
 - **RequestForgeryMediumRule** - Detects SSRF vulnerabilities when untrusted input is used in network requests with normal triggers (auto-fix supported)
-- **SecretInLogRule** - Detects secret values printed to build logs via `echo`/`printf` of shell variables derived from secret-sourced environment variables (e.g., `jq`-derived values) (auto-fix supported)
+- **SecretInLogRule** - Detects secret values printed to build logs via `echo`/`printf` of shell variables derived from secret-sourced environment variables (e.g., `jq`-derived values); taint is also propagated across steps within the same job through `$GITHUB_ENV` (auto-fix supported)
 - **CacheBloatRule** - Detects cache bloat risk with actions/cache/restore and actions/cache/save without proper conditions (auto-fix supported)
 - **AIActionUnrestrictedTriggerRule** - Detects AI agent actions (claude-code-action, etc.) configured with `allowed_non_write_users: "*"` allowing any GitHub user to trigger AI execution (Clinejection attack pattern)
 - **AIActionExcessiveToolsRule** - Detects AI agent actions with dangerous tools (Bash/Write/Edit) enabled in workflows triggered by untrusted users (issues, issue_comment, discussion) (Clinejection attack pattern)

--- a/docs/secretinlogrule.md
+++ b/docs/secretinlogrule.md
@@ -76,11 +76,13 @@ Derived values flow through standard shell variable assignment and GitHub Action
 
 ### Detection Logic
 
-The rule performs taint propagation within a single `run` step:
+The rule performs taint propagation within a single `run` step, and additionally propagates
+taint across steps that belong to the same job via `$GITHUB_ENV`:
 
-1. **Taint sources** — environment variables whose value contains `${{ secrets.* }}` declared at the workflow-level, job-level, or step-level `env` (all three scopes are merged, with step-level entries overriding the outer scopes on name conflict).
+1. **Taint sources** — environment variables whose value contains `${{ secrets.* }}` declared at the workflow-level, job-level, or step-level `env` (all four scopes — workflow / job / cross-step / step — are merged, with step-level entries overriding the others on name conflict).
 2. **Taint propagation** — shell assignments that reference a tainted variable, including command substitutions (`VAR=$(cmd $TAINTED)`).
-3. **Sink detection** — the following commands are treated as sinks when they reference a tainted variable without a preceding `::add-mask::` for that variable:
+3. **Cross-step propagation via `$GITHUB_ENV`** — if a tainted shell variable is written to `$GITHUB_ENV` (via `echo "NAME=$VAR" >> $GITHUB_ENV`, `echo "NAME=$VAR" > $GITHUB_ENV`, or `cat <<EOF >> $GITHUB_ENV ... EOF`), the environment variable `NAME` becomes tainted for subsequent steps in the same job. Cross-*job* propagation (`needs.*.outputs.*`) and reusable-workflow propagation are separate follow-up items.
+4. **Sink detection** — the following commands are treated as sinks when they reference a tainted variable without a preceding `::add-mask::` for that variable:
    - `echo` / `printf` with a tainted argument
    - `cat` / `tee` / `dd` receiving tainted data via here-string (`<<<`) or heredoc (`<<EOF ... EOF`)
 
@@ -120,9 +122,31 @@ run: |
 
 If an assignment and a sink share the same physical line as a compound statement (e.g., `KEY=$(...); echo "$KEY"`), the rule cannot safely locate an insertion point between them from the shell AST alone. In that case the rule reports the warning **but leaves the script unchanged**; the user is expected to split the compound onto multiple lines and rerun `-fix on`, or add `::add-mask::` manually.
 
+### Cross-step propagation example
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+    steps:
+      - name: Derive and export via GITHUB_ENV
+        run: |
+          DERIVED=$(echo "$GCP_SERVICE_ACCOUNT_KEY" | jq -r '.access_token')
+          echo "TOKEN=$DERIVED" >> $GITHUB_ENV
+      - name: Leak propagated token
+        run: |
+          echo "got token: $TOKEN"   # flagged (origin: shellvar:GCP_SERVICE_ACCOUNT_KEY)
+```
+
+The first step's derivation (`DERIVED`) is tainted, and writing `TOKEN=$DERIVED` to `$GITHUB_ENV`
+marks `TOKEN` as a tainted environment variable for the next step. The next step's `echo "$TOKEN"`
+is therefore flagged even though neither the step nor the job declares `TOKEN` in `env:`.
+
 ### Scope Limitations (MVP)
 
-- **Single-step scope only** — taint does not cross step boundaries or job outputs (`needs.*.outputs.*`); cross-job propagation is a planned follow-up (see #432 / #437).
+- **Same-job scope only** — cross-step taint is tracked within a single job via `$GITHUB_ENV`. Taint does not cross *job* boundaries (`needs.*.outputs.*`); cross-job propagation is a planned follow-up (see #432).
 - **`logger` and pipe-consuming commands not yet covered** — `logger`, `xargs`, and similar sinks are not yet detected. Pipes (`cmd1 | cmd2`) flag the upstream source if it is `echo`/`printf`, but the downstream command is not individually analyzed.
 - **Reusable workflow boundaries** — taint does not cross `workflow_call` boundaries; that is a planned follow-up (see #433).
 

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -666,11 +666,6 @@ func shellVarRefRegex(varName string) *regexp.Regexp {
 	return actual.(*regexp.Regexp)
 }
 
-// containsShellVarRef は文字列中に `$NAME` または `${NAME}` 形式で varName が参照されていれば true。
-func containsShellVarRef(s, varName string) bool {
-	return shellVarRefRegex(varName).MatchString(s)
-}
-
 // wordIsEnvVarRef は Word が単一の env 変数参照（$NAME / ${NAME} / "$NAME" / "${NAME}"）の場合に
 // その変数名を返し、それ以外は "" を返す。`$GITHUB_ENV` のリダイレクト先判定に使用する。
 func wordIsEnvVarRef(w *syntax.Word) string {
@@ -775,7 +770,11 @@ func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
 		switch cmdName {
 		case "echo", "printf":
 			rule.collectEchoEnvWrites(call, tainted, result)
-		case "cat":
+		case "cat", "tee", "dd":
+			// heredoc 経由で `>> $GITHUB_ENV` に流し込むパターン。
+			// tee/dd も stdin を受け取って stdout（もしくは file 引数）に流すので
+			// `cmd <<EOF >> $GITHUB_ENV ... EOF` 形式で taint を書き込みうる。
+			// sink 検出側 (collectRedirectSinkLeaks) との対称性を保つ。
 			rule.collectHeredocEnvWrites(stmt, tainted, script, result)
 		}
 		return true
@@ -786,9 +785,12 @@ func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
 // collectEchoEnvWrites は `echo "NAME=$VAL" >> $GITHUB_ENV` 形式の引数から
 // NAME と origin を抽出して result に追加する。
 //
-// MVP: 第 1 引数の先頭 Lit から NAME を取り出し、全引数を走査して最初に見つかった
-// tainted 変数の origin を引き継ぐ。複数 NAME=... が 1 行に並ぶケース（GitHub Actions が
-// スペース含みの値として解釈するため実質 1 assignment）は第 1 引数の NAME のみを記録する。
+// 先頭が `-n`/`-e`/`-E` などの echo オプションまたは `printf` のフォーマット指定子
+// (`%s\n` 等) で始まる場合はそれらをスキップし、最初に `NAME=` 形式と一致する Word
+// を NAME 候補として扱う。
+//
+// 複数 NAME=... が 1 行に並ぶケース（GitHub Actions がスペース含みの値として解釈する
+// ため実質 1 assignment）は最初に一致した NAME のみを記録する。
 func (rule *SecretInLogRule) collectEchoEnvWrites(
 	call *syntax.CallExpr,
 	tainted map[string]taintEntry,
@@ -797,12 +799,32 @@ func (rule *SecretInLogRule) collectEchoEnvWrites(
 	if len(call.Args) < 2 {
 		return
 	}
-	name := firstNameEqualsPrefix(call.Args[1])
-	if name == "" {
+	nameArgIdx := -1
+	var name string
+	for i := 1; i < len(call.Args); i++ {
+		lit := firstWordLiteral(call.Args[i])
+		// `-` 単独 (stdin 指定) は NAME= にはなり得ないが、スキップせずに探索を進める。
+		if strings.HasPrefix(lit, "-") && lit != "-" {
+			// 短いオプション群 (`-n`, `-e`, `-nE` 等) または long option を飛ばして次へ。
+			continue
+		}
+		if n := firstNameEqualsPrefix(call.Args[i]); n != "" {
+			name = n
+			nameArgIdx = i
+			break
+		}
+		// printf のフォーマット指定子 (`%s\n` など) は Lit としてリテラル値を持つ。
+		// NAME= 形式でなければ次の引数で NAME= を探す。
+		if strings.Contains(lit, "%") {
+			continue
+		}
+		// それ以外の Lit (例: `--`) は option 終端とみなし、次の arg を NAME 候補にする。
+	}
+	if name == "" || nameArgIdx < 0 {
 		return
 	}
 	var firstVar string
-	for _, arg := range call.Args[1:] {
+	for _, arg := range call.Args[nameArgIdx:] {
 		if v := rule.firstTaintedVarIn(arg, tainted); v != "" {
 			firstVar = v
 			break

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -34,6 +34,11 @@ type SecretInLogRule struct {
 	BaseRule
 	workflowEnvSecrets map[string]string // populated in VisitWorkflowPre from workflow-level env:
 	jobEnvSecrets      map[string]string // populated in VisitJobPre from job-level env:
+	// crossStepEnv は同一 Job 内で前 step が `$GITHUB_ENV` 経由で書き出した tainted な
+	// 環境変数を、後続 step の初期 taint source として引き継ぐためのマップ。
+	// VisitJobPre の冒頭でリセットされ、各 step 処理後に $GITHUB_ENV 書き込みから
+	// 追加される。クロスジョブ伝播は範囲外（follow-up issue）。
+	crossStepEnv map[string]string
 }
 
 // NewSecretInLogRule は新規ルールインスタンスを返す。
@@ -419,8 +424,11 @@ func (rule *SecretInLogRule) VisitWorkflowPre(node *ast.Workflow) error {
 }
 
 // VisitJobPre は Job 内の各 Step を走査して secret 漏洩を検出する。
+// Job 開始時に crossStepEnv をリセットし、ステップを順次処理することで
+// 前 step の `$GITHUB_ENV` 書き込みを後続 step の taint source として引き継ぐ。
 func (rule *SecretInLogRule) VisitJobPre(node *ast.Job) error {
 	rule.jobEnvSecrets = rule.collectSecretEnvVars(node.Env)
+	rule.crossStepEnv = make(map[string]string)
 	for _, step := range node.Steps {
 		rule.checkStep(step)
 	}
@@ -448,6 +456,11 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 	for k, v := range rule.jobEnvSecrets {
 		initialTainted[k] = v
 	}
+	// crossStepEnv（前 step の $GITHUB_ENV 経由で伝播した taint）を merge。
+	// step-level env より前に入れ、同名の場合は step-level が勝つようにする。
+	for k, v := range rule.crossStepEnv {
+		initialTainted[k] = v
+	}
 	for k, v := range rule.collectSecretEnvVars(step.Env) {
 		initialTainted[k] = v
 	}
@@ -467,6 +480,12 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 	for _, leak := range leaks {
 		rule.reportLeak(leak)
 		rule.addAutoFixerForLeak(step, leak)
+	}
+
+	// この step の $GITHUB_ENV 書き込みから tainted な env var を抽出し、
+	// 後続 step の crossStepEnv に伝播させる。
+	for name, origin := range rule.collectGitHubEnvTaintWrites(file, tainted, script) {
+		rule.crossStepEnv[name] = origin
 	}
 }
 
@@ -626,6 +645,238 @@ func insertAfterAssignment(script, varName, addMaskLine string) (string, bool) {
 
 	updated := script[:insertPos] + indent + addMaskLine + "\n" + script[insertPos:]
 	return updated, true
+}
+
+// envAssignRe は `NAME=...` 形式の行先頭マッチ（heredoc 内 1 行用）。
+var envAssignRe = regexp.MustCompile(`^\s*([A-Za-z_][A-Za-z0-9_]*)=`)
+
+// envAssignPrefixRe は Lit の先頭から NAME= 部分を切り出す（heredoc 以外、echo/printf 引数用）。
+var envAssignPrefixRe = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*)=`)
+
+// shellVarRefCache は 変数名 → `$NAME` / `${NAME}` の境界つき検出用 Regexp のキャッシュ。
+var shellVarRefCache sync.Map // map[string]*regexp.Regexp
+
+func shellVarRefRegex(varName string) *regexp.Regexp {
+	if v, ok := shellVarRefCache.Load(varName); ok {
+		return v.(*regexp.Regexp)
+	}
+	// $NAME（識別子境界）または ${NAME}（閉じブレース必須）
+	re := regexp.MustCompile(`\$\{` + regexp.QuoteMeta(varName) + `\}|\$` + regexp.QuoteMeta(varName) + `($|[^A-Za-z0-9_])`)
+	actual, _ := shellVarRefCache.LoadOrStore(varName, re)
+	return actual.(*regexp.Regexp)
+}
+
+// containsShellVarRef は文字列中に `$NAME` または `${NAME}` 形式で varName が参照されていれば true。
+func containsShellVarRef(s, varName string) bool {
+	return shellVarRefRegex(varName).MatchString(s)
+}
+
+// wordIsEnvVarRef は Word が単一の env 変数参照（$NAME / ${NAME} / "$NAME" / "${NAME}"）の場合に
+// その変数名を返し、それ以外は "" を返す。`$GITHUB_ENV` のリダイレクト先判定に使用する。
+func wordIsEnvVarRef(w *syntax.Word) string {
+	if w == nil || len(w.Parts) != 1 {
+		return ""
+	}
+	switch p := w.Parts[0].(type) {
+	case *syntax.ParamExp:
+		if p.Param != nil {
+			return p.Param.Value
+		}
+	case *syntax.DblQuoted:
+		if len(p.Parts) != 1 {
+			return ""
+		}
+		if pe, ok := p.Parts[0].(*syntax.ParamExp); ok && pe.Param != nil {
+			return pe.Param.Value
+		}
+	}
+	return ""
+}
+
+// stmtRedirectsToGitHubEnv は Stmt の Redirs に `> $GITHUB_ENV` / `>> $GITHUB_ENV` 系が
+// 含まれていれば true。書き込み先の Word が $GITHUB_ENV の参照であるかを AST で判定する。
+func stmtRedirectsToGitHubEnv(stmt *syntax.Stmt) bool {
+	if stmt == nil {
+		return false
+	}
+	for _, r := range stmt.Redirs {
+		if r == nil {
+			continue
+		}
+		switch r.Op {
+		case syntax.RdrOut, syntax.AppOut, syntax.RdrClob:
+		default:
+			continue
+		}
+		if r.N != nil && r.N.Value != "" && r.N.Value != "1" {
+			continue
+		}
+		if wordIsEnvVarRef(r.Word) == "GITHUB_ENV" {
+			return true
+		}
+	}
+	return false
+}
+
+// firstNameEqualsPrefix は Word の先頭 Lit 部分から `NAME=` 形式の NAME を取り出す。
+// 形式に一致しなければ "" を返す。DblQuoted / SglQuoted 内の先頭 Lit も対象とする。
+func firstNameEqualsPrefix(word *syntax.Word) string {
+	if word == nil || len(word.Parts) == 0 {
+		return ""
+	}
+	var s string
+	switch p := word.Parts[0].(type) {
+	case *syntax.Lit:
+		s = p.Value
+	case *syntax.DblQuoted:
+		if len(p.Parts) > 0 {
+			if lit, ok := p.Parts[0].(*syntax.Lit); ok {
+				s = lit.Value
+			}
+		}
+	case *syntax.SglQuoted:
+		s = p.Value
+	}
+	m := envAssignPrefixRe.FindStringSubmatch(s)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// collectGitHubEnvTaintWrites は `>> $GITHUB_ENV` / `> $GITHUB_ENV` へ書き込む statement を
+// 検索し、その中で tainted なシェル変数を参照して構築された `NAME=...` の NAME を抽出し、
+// `NAME -> origin` のマップを返す。対象コマンドは echo / printf / cat（heredoc）。
+//
+// 戻り値は後続 step の crossStepEnv に merge される。origin は後続 step での
+// 漏洩メッセージに表示される識別子（`secrets.X` or `shellvar:Y`）。
+func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
+	file *syntax.File,
+	tainted map[string]taintEntry,
+	script string,
+) map[string]string {
+	result := make(map[string]string)
+	if file == nil {
+		return result
+	}
+	syntax.Walk(file, func(node syntax.Node) bool {
+		stmt, ok := node.(*syntax.Stmt)
+		if !ok {
+			return true
+		}
+		if !stmtRedirectsToGitHubEnv(stmt) {
+			return true
+		}
+		call, ok := stmt.Cmd.(*syntax.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		cmdName := firstWordLiteral(call.Args[0])
+		switch cmdName {
+		case "echo", "printf":
+			rule.collectEchoEnvWrites(call, tainted, result)
+		case "cat":
+			rule.collectHeredocEnvWrites(stmt, tainted, script, result)
+		}
+		return true
+	})
+	return result
+}
+
+// collectEchoEnvWrites は `echo "NAME=$VAL" >> $GITHUB_ENV` 形式の引数から
+// NAME と origin を抽出して result に追加する。
+//
+// MVP: 第 1 引数の先頭 Lit から NAME を取り出し、全引数を走査して最初に見つかった
+// tainted 変数の origin を引き継ぐ。複数 NAME=... が 1 行に並ぶケース（GitHub Actions が
+// スペース含みの値として解釈するため実質 1 assignment）は第 1 引数の NAME のみを記録する。
+func (rule *SecretInLogRule) collectEchoEnvWrites(
+	call *syntax.CallExpr,
+	tainted map[string]taintEntry,
+	result map[string]string,
+) {
+	if len(call.Args) < 2 {
+		return
+	}
+	name := firstNameEqualsPrefix(call.Args[1])
+	if name == "" {
+		return
+	}
+	var firstVar string
+	for _, arg := range call.Args[1:] {
+		if v := rule.firstTaintedVarIn(arg, tainted); v != "" {
+			firstVar = v
+			break
+		}
+	}
+	if firstVar == "" {
+		return
+	}
+	// origin は「起点の secret 名」を保持する。tainted[firstVar].origin は
+	// 既に "secrets.X" または "shellvar:Y" の形を持つため、そのまま引き継ぐ。
+	result[name] = tainted[firstVar].origin
+}
+
+// collectHeredocEnvWrites は `cat <<EOF >> $GITHUB_ENV ... EOF` 形式の heredoc 本文を
+// 行単位で走査し、`NAME=...` 行のうち `...` 内で tainted 変数が参照されているものを
+// result に追加する。heredoc 本文の取得は script のバイトオフセットから行う。
+func (rule *SecretInLogRule) collectHeredocEnvWrites(
+	stmt *syntax.Stmt,
+	tainted map[string]taintEntry,
+	script string,
+	result map[string]string,
+) {
+	for _, r := range stmt.Redirs {
+		if r == nil {
+			continue
+		}
+		if r.Op != syntax.Hdoc && r.Op != syntax.DashHdoc {
+			continue
+		}
+		if r.Hdoc == nil {
+			continue
+		}
+		start := int(r.Hdoc.Pos().Offset())
+		end := int(r.Hdoc.End().Offset())
+		if start < 0 || end > len(script) || start >= end {
+			continue
+		}
+		body := script[start:end]
+		// 変数名の走査順を決定的にしたいので、tainted のキーを sort する意味は薄い
+		// （「いずれかの tainted 参照があれば 1 件記録」が仕様のため任意で良い）。
+		// ただし map iteration の非決定性でテストが不安定にならないよう、
+		// 明示的に tainted 集合からの探索順は body 上で「最初に現れた $REF」優先にする。
+		for _, line := range strings.Split(body, "\n") {
+			m := envAssignRe.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			name := m[1]
+			origin := rule.firstTaintedRefOrigin(line, tainted)
+			if origin == "" {
+				continue
+			}
+			result[name] = origin
+		}
+	}
+}
+
+// firstTaintedRefOrigin は行内に現れる最初の tainted 変数参照の origin を返す。
+// 現れる位置（バイトオフセット）が最小のものを選ぶことで map iteration の
+// 非決定性を回避する。
+func (rule *SecretInLogRule) firstTaintedRefOrigin(line string, tainted map[string]taintEntry) string {
+	minPos := -1
+	var origin string
+	for name, entry := range tainted {
+		loc := shellVarRefRegex(name).FindStringIndex(line)
+		if loc == nil {
+			continue
+		}
+		if minPos < 0 || loc[0] < minPos {
+			minPos = loc[0]
+			origin = entry.origin
+		}
+	}
+	return origin
 }
 
 func (rule *SecretInLogRule) collectSecretEnvVars(env *ast.Env) map[string]string {

--- a/pkg/core/secretinlog_test.go
+++ b/pkg/core/secretinlog_test.go
@@ -1262,3 +1262,84 @@ func TestSecretInLog_CrossStep_StepEnvOverridesCrossStep(t *testing.T) {
 		t.Errorf("expected step-env origin (secrets.STEP_LEVEL) to win over cross-step origin, got: %s", errs[0].Description)
 	}
 }
+
+// tee / dd の heredoc 経由で $GITHUB_ENV に書き込むケースでも cross-step 伝播する。
+func TestSecretInLog_CrossStep_TeeHeredocEnvWrite(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		script string
+	}{
+		{
+			name:   "tee heredoc with append redirect",
+			script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\ntee <<EOF >> $GITHUB_ENV\nTOKEN=$DERIVED\nEOF",
+		},
+		{
+			name:   "dd heredoc with append redirect",
+			script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\ndd <<EOF >> $GITHUB_ENV\nTOKEN=$DERIVED\nEOF",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step1 := mkRunStepForTest(t,
+				map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+				tc.script,
+			)
+			step2 := mkRunStepForTest(t, nil, "echo \"$TOKEN\"")
+			job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+			rule := NewSecretInLogRule()
+			if err := rule.VisitJobPre(job); err != nil {
+				t.Fatalf("VisitJobPre: %v", err)
+			}
+			if got := len(rule.Errors()); got != 1 {
+				t.Errorf("%s: expected 1 cross-step leak via %s heredoc, got %d: %v", tc.name, tc.name, got, rule.Errors())
+			}
+		})
+	}
+}
+
+// echo の短いオプション (`-n`, `-e`, `-E`) が先頭にある場合でも cross-step 伝播を検出する。
+// printf のフォーマット指定子 (`%s\n`) 先頭も対象。
+func TestSecretInLog_CrossStep_LeadingOptionBeforeNameEquals(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		script string
+	}{
+		{
+			name:   "echo -n",
+			script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\necho -n \"TOKEN=$DERIVED\" >> $GITHUB_ENV",
+		},
+		{
+			name:   "echo -e",
+			script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\necho -e \"TOKEN=$DERIVED\" >> $GITHUB_ENV",
+		},
+		{
+			name:   "echo -nE combined",
+			script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\necho -nE \"TOKEN=$DERIVED\" >> $GITHUB_ENV",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step1 := mkRunStepForTest(t,
+				map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+				tc.script,
+			)
+			step2 := mkRunStepForTest(t, nil, "echo \"$TOKEN\"")
+			job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+			rule := NewSecretInLogRule()
+			if err := rule.VisitJobPre(job); err != nil {
+				t.Fatalf("VisitJobPre: %v", err)
+			}
+			if got := len(rule.Errors()); got != 1 {
+				t.Errorf("%s: expected 1 cross-step leak, got %d: %v", tc.name, got, rule.Errors())
+			}
+		})
+	}
+}

--- a/pkg/core/secretinlog_test.go
+++ b/pkg/core/secretinlog_test.go
@@ -1036,3 +1036,229 @@ func TestSecretInLog_AutoFix_ShebangOnlyScript(t *testing.T) {
 		t.Errorf("shebang-only auto-fix: got %q, want %q", got, want)
 	}
 }
+
+// Issue #437: cross-step taint — $GITHUB_ENV 経由で前 step からの taint を後続 step が引き継ぐ。
+// 以降のテストは "前 step で tainted な値を $GITHUB_ENV に書き込み、後続 step で echo する"
+// ケースが検出されることを保証するためのもの。
+
+// mkRunStepForTest は env/run を受け取って最小の *ast.Step を組み立てるテストヘルパ。
+// envVars の key は小文字化された map key（ast 仕様どおり）、Name.Value に実際の env var 名を入れる。
+func mkRunStepForTest(t *testing.T, envVars map[string]string, script string) *ast.Step {
+	t.Helper()
+	var env *ast.Env
+	if len(envVars) > 0 {
+		vars := map[string]*ast.EnvVar{}
+		for name, val := range envVars {
+			vars[strings.ToLower(name)] = &ast.EnvVar{
+				Name:  &ast.String{Value: name},
+				Value: &ast.String{Value: val},
+			}
+		}
+		env = &ast.Env{Vars: vars}
+	}
+	return &ast.Step{
+		Env: env,
+		Exec: &ast.ExecRun{
+			Run: &ast.String{Value: script, Pos: &ast.Position{Line: 1, Col: 1}},
+		},
+	}
+}
+
+func TestSecretInLog_CrossStep_BasicEnvWrite(t *testing.T) {
+	t.Parallel()
+
+	// step1: tainted な derived 値を $GITHUB_ENV へ書き込む
+	// step2: 引き継がれた env var $TOKEN を echo → leak として検出されるべき
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.key')\necho \"TOKEN=$DERIVED\" >> $GITHUB_ENV",
+	)
+	step2 := mkRunStepForTest(t, nil, "echo \"$TOKEN\"")
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 cross-step leak, got %d: %v", got, rule.Errors())
+	}
+	// 検出メッセージは後続 step 側の sink 位置に対して出るはず。
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "TOKEN") {
+		t.Errorf("leak message should mention $TOKEN, got: %s", msg)
+	}
+}
+
+func TestSecretInLog_CrossStep_QuotedGithubEnvVariants(t *testing.T) {
+	t.Parallel()
+
+	// `$GITHUB_ENV` の書き方ブレ (`"$GITHUB_ENV"`, `${GITHUB_ENV}`) に対応する。
+	cases := []struct {
+		name   string
+		script string
+	}{
+		{name: "quoted", script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\necho \"TOKEN=$DERIVED\" >> \"$GITHUB_ENV\""},
+		{name: "braced", script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\necho \"TOKEN=$DERIVED\" >> ${GITHUB_ENV}"},
+		{name: "quoted-braced", script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\necho \"TOKEN=$DERIVED\" >> \"${GITHUB_ENV}\""},
+		{name: "overwrite single >", script: "DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\necho \"TOKEN=$DERIVED\" > $GITHUB_ENV"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step1 := mkRunStepForTest(t,
+				map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+				tc.script,
+			)
+			step2 := mkRunStepForTest(t, nil, "echo \"$TOKEN\"")
+			job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+			rule := NewSecretInLogRule()
+			if err := rule.VisitJobPre(job); err != nil {
+				t.Fatalf("VisitJobPre: %v", err)
+			}
+			if got := len(rule.Errors()); got != 1 {
+				t.Errorf("%s: expected 1 cross-step leak, got %d: %v", tc.name, got, rule.Errors())
+			}
+		})
+	}
+}
+
+func TestSecretInLog_CrossStep_HeredocEnvWrite(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"DERIVED=$(echo \"$SECRET_JSON\" | jq -r '.k')\ncat <<EOF >> $GITHUB_ENV\nTOKEN=$DERIVED\nEOF",
+	)
+	step2 := mkRunStepForTest(t, nil, "echo \"$TOKEN\"")
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Errorf("heredoc cross-step: expected 1 leak, got %d: %v", got, rule.Errors())
+	}
+}
+
+func TestSecretInLog_CrossStep_EnvWriteWithoutTaintIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	// $GITHUB_ENV に書き込んでいるが値が tainted でないため、後続 step の echo は leak ではない。
+	step1 := mkRunStepForTest(t, nil,
+		"VALUE=\"hello\"\necho \"GREETING=$VALUE\" >> $GITHUB_ENV",
+	)
+	step2 := mkRunStepForTest(t, nil, "echo \"$GREETING\"")
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 0 {
+		t.Errorf("non-tainted env write must not propagate; got %d errors: %v", got, rule.Errors())
+	}
+}
+
+func TestSecretInLog_CrossStep_ChainedSteps(t *testing.T) {
+	t.Parallel()
+
+	// step1 で TOKEN に書き出し、step2 でさらに DERIVED2 を作り $GITHUB_ENV へ、step3 で echo。
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"TOKEN=$D\" >> $GITHUB_ENV",
+	)
+	step2 := mkRunStepForTest(t, nil,
+		"D2=\"$TOKEN-suffix\"\necho \"TOKEN2=$D2\" >> $GITHUB_ENV",
+	)
+	step3 := mkRunStepForTest(t, nil, "echo \"$TOKEN2\"")
+	job := &ast.Job{Steps: []*ast.Step{step1, step2, step3}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	// step3 で $TOKEN2 が leak 1 件として検出されるはず。
+	if got := len(rule.Errors()); got != 1 {
+		t.Errorf("chained cross-step: expected 1 leak on step3, got %d: %v", got, rule.Errors())
+	}
+}
+
+func TestSecretInLog_CrossStep_TaintDoesNotCrossJob(t *testing.T) {
+	t.Parallel()
+
+	// job A で $GITHUB_ENV に書き込まれた taint は job B には伝播しない。
+	// （実装上は VisitJobPre 呼び出しごとに crossStepEnv がリセットされる前提）。
+	stepA := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"TOKEN=$D\" >> $GITHUB_ENV",
+	)
+	stepB := mkRunStepForTest(t, nil, "echo \"$TOKEN\"")
+	jobA := &ast.Job{Steps: []*ast.Step{stepA}}
+	jobB := &ast.Job{Steps: []*ast.Step{stepB}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(jobA); err != nil {
+		t.Fatalf("VisitJobPre(A): %v", err)
+	}
+	if err := rule.VisitJobPre(jobB); err != nil {
+		t.Fatalf("VisitJobPre(B): %v", err)
+	}
+	// jobB 側では未知変数なので leak は発生しないはず。
+	// jobA 側は $GITHUB_ENV への書き込みのみで echo sink は無いので leak 0。
+	if got := len(rule.Errors()); got != 0 {
+		t.Errorf("cross-job propagation must not happen; got %d leaks: %v", got, rule.Errors())
+	}
+}
+
+func TestSecretInLog_CrossStep_GithubOutputDoesNotPropagate(t *testing.T) {
+	t.Parallel()
+
+	// $GITHUB_OUTPUT は後続 step の env var にはならないため、cross-step taint の対象外。
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step2 := mkRunStepForTest(t, nil, "echo \"$TOKEN\"")
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 0 {
+		t.Errorf("GITHUB_OUTPUT write must not propagate as env taint; got %d: %v", got, rule.Errors())
+	}
+}
+
+func TestSecretInLog_CrossStep_StepEnvOverridesCrossStep(t *testing.T) {
+	t.Parallel()
+
+	// step1 で TOKEN=tainted を GITHUB_ENV に書く。
+	// step2 は step-level env で TOKEN を untrusted ではない値に上書きする想定なので、
+	// step2 の origin は step env 側が使われる。ここでは step2 env 自身も secrets 参照を含むため
+	// leak は発生するが、origin が step env 側の secret 名であることを確認する。
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.UPSTREAM }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"TOKEN=$D\" >> $GITHUB_ENV",
+	)
+	step2 := mkRunStepForTest(t,
+		map[string]string{"TOKEN": "${{ secrets.STEP_LEVEL }}"},
+		"echo \"$TOKEN\"",
+	)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	errs := rule.Errors()
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly 1 leak in step2, got %d: %v", len(errs), errs)
+	}
+	if !strings.Contains(errs[0].Description, "secrets.STEP_LEVEL") {
+		t.Errorf("expected step-env origin (secrets.STEP_LEVEL) to win over cross-step origin, got: %s", errs[0].Description)
+	}
+}

--- a/plan/2026-04-23-secret-in-log-cross-step-taint.md
+++ b/plan/2026-04-23-secret-in-log-cross-step-taint.md
@@ -1,0 +1,106 @@
+# secret-in-log cross-step taint 実装計画 (Issue #437)
+
+## Goal
+
+`secret-in-log` ルールの taint 伝播を、単一 run ステップから **同一 Job 内の step 間** へ拡張する。
+`echo "VAR=$DERIVED" >> $GITHUB_ENV` のような `$GITHUB_ENV` 経由の伝播を taint source として
+後続 step に引き継ぎ、これまで未検出だった FN を検出する。
+
+## 検出対象（未検出だったパターン）
+
+```yaml
+steps:
+  - run: |
+      DERIVED=$(echo $SECRET_JSON | jq -r '.key')
+      echo "TOKEN=$DERIVED" >> $GITHUB_ENV
+  - run: |
+      echo "$TOKEN"   # ← 検出対象
+```
+
+## 対応範囲
+
+### In scope
+- `echo "NAME=$VAL" >> $GITHUB_ENV` / `echo NAME=$VAL >> "$GITHUB_ENV"`（クォート有無）
+- `echo "NAME=$VAL" > $GITHUB_ENV`（overwrite）
+- `printf '%s\n' "NAME=$VAL" >> $GITHUB_ENV`（第 1 引数が NAME=VAL 形式）
+- `cat <<EOF >> $GITHUB_ENV\nNAME=$VAL\nEOF`（heredoc、本文内で tainted 参照）
+- 同一 job 内で step1 → step2 → step3 と連鎖する伝播
+
+### Out of scope（follow-up として別 issue）
+- クロス job 伝播 (`needs.*.outputs.*`)（#432）
+- reusable workflow 跨ぎ (#433)
+- `${NAME}` / bash-specific な変数展開拡張のコーナーケース
+- `$GITHUB_ENV` に書く際の **add-mask** 補助 auto-fix（MVP では当面、sink 側 step の既存 auto-fix で対処）
+
+## 実装方針
+
+### データフロー
+
+```
+prev step の script
+  └─ taint source (workflow/job/step env + crossStepEnv)
+       └─ propagateTaint → tainted vars
+            ├─ findEchoLeaks → leaks（既存）
+            └─ collectGitHubEnvTaintWrites → crossStepEnv に追加 ★新規
+```
+
+### 変更箇所
+
+- `SecretInLogRule` に `crossStepEnv map[string]string` フィールド追加。
+- `VisitJobPre` 冒頭で `crossStepEnv` を空 map に初期化。
+- `checkStep` 内の初期 tainted に `crossStepEnv` を merge。
+- `checkStep` 終端で `collectGitHubEnvTaintWrites` を呼び、検出した env var を `crossStepEnv` に蓄積。
+- `$GITHUB_ENV` への書き込みを AST ベースで検出する補助関数群を追加:
+  - `stmtWritesToGitHubEnv(stmt) bool`
+  - `collectGitHubEnvTaintWrites(file, tainted) map[string]string`
+  - `parseEnvAssignmentName(word) string`（`NAME=` 先頭 Lit のパース）
+
+### 境界条件
+- `$GITHUB_OUTPUT` は **対象外**（env とは別で、後続 step の環境変数にはならない）。
+- `>&2` 等で stderr に書いても `$GITHUB_ENV` ファイルに書かれるわけではないのでスキップ。
+- 書き込み先が `$GITHUB_ENV` 以外 (`file.txt` 等) ならスキップ。
+- `printf` は第一引数の Word が `NAME=` から始まる場合のみ対応（シンプル実装）。
+- 同じ名前の env var が step env と crossStepEnv 両方にある場合、step env 側の origin で上書き（原 secret が明確な方を優先）。
+
+## TDD タスク
+
+### Task 1: RED - step 間伝播テスト追加
+- `TestSecretInLog_CrossStep_BasicEnvWrite`
+- `TestSecretInLog_CrossStep_HeredocEnvWrite`
+- `TestSecretInLog_CrossStep_TaintDoesNotCrossJob`
+- `TestSecretInLog_CrossStep_EnvWriteWithoutTaintIsIgnored`
+- `TestSecretInLog_CrossStep_ChainedSteps`（step1→step2→step3）
+- `TestSecretInLog_CrossStep_GitHubOutputDoesNotPropagate`
+- `TestSecretInLog_CrossStep_OverwriteByStepEnv`
+
+### Task 2: GREEN - 最小実装
+- `crossStepEnv` フィールドを追加
+- `VisitJobPre` で reset
+- `checkStep` で merge + 書き込み収集
+- `collectGitHubEnvTaintWrites` と補助関数を実装
+
+### Task 3: REFACTOR
+- 重複コード整理
+- コメント整備
+
+### Task 4: docs/example
+- `docs/secretinlogrule.md` の "Single-step scope only" 節を更新
+- `script/actions/secret-in-log-vulnerable.yaml` に cross-step パターンを追加
+- `script/actions/secret-in-log-safe.yaml` にも対応 safe パターン
+
+### Task 5: CLAUDE.md 更新
+- 変更の要点を記載（cross-step 対応）
+
+### Task 6: lint / test / commit
+- `go test ./pkg/core -run TestSecretInLog`
+- `golangci-lint run --fix pkg/core/secretinlog.go pkg/core/secretinlog_test.go`
+- commit 粒度: (1) テスト+実装 (2) docs (3) example
+
+## 進捗
+
+- [x] Task 1 (RED)
+- [x] Task 2 (GREEN)
+- [x] Task 3 (REFACTOR)
+- [x] Task 4 (docs/example)
+- [x] Task 5 (CLAUDE.md)
+- [ ] Task 6 (lint/test/commit)

--- a/plan/2026-04-23-secret-in-log-cross-step-taint.md
+++ b/plan/2026-04-23-secret-in-log-cross-step-taint.md
@@ -103,4 +103,4 @@ prev step の script
 - [x] Task 3 (REFACTOR)
 - [x] Task 4 (docs/example)
 - [x] Task 5 (CLAUDE.md)
-- [ ] Task 6 (lint/test/commit)
+- [x] Task 6 (lint/test/commit)

--- a/script/actions/secret-in-log-safe.yaml
+++ b/script/actions/secret-in-log-safe.yaml
@@ -57,3 +57,20 @@ jobs:
           TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           curl -H "Authorization: Bearer $TOKEN" https://api.github.com/user
+
+  # Safe 4: cross-step propagation with add-mask applied before sink (Issue #437)
+  # 前 step で $GITHUB_ENV 経由で派生値を渡す場合も、後続 step で最初に ::add-mask:: を
+  # 発行しておけばログに平文出力されない。
+  safe-cross-step-with-add-mask:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive and export via GITHUB_ENV
+        env:
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        run: |
+          DERIVED=$(echo "$GCP_SERVICE_ACCOUNT_KEY" | jq -r '.access_token')
+          echo "TOKEN=$DERIVED" >> $GITHUB_ENV
+      - name: Consume with masking
+        run: |
+          echo "::add-mask::$TOKEN"
+          curl -H "Authorization: Bearer $TOKEN" https://example.com/api

--- a/script/actions/secret-in-log-vulnerable.yaml
+++ b/script/actions/secret-in-log-vulnerable.yaml
@@ -29,3 +29,19 @@ jobs:
           SECRET: ${{ secrets.PLAIN_SECRET }}
         run: |
           echo "The value is $SECRET"
+
+  # Case C: cross-step taint via $GITHUB_ENV (Issue #437)
+  # 前 step で derivation した値を $GITHUB_ENV に書き込み、後続 step で echo する。
+  # taint は step 境界を越えて伝播する。
+  leak-cross-step-github-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive and export via GITHUB_ENV
+        env:
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        run: |
+          DERIVED=$(echo "$GCP_SERVICE_ACCOUNT_KEY" | jq -r '.access_token')
+          echo "TOKEN=$DERIVED" >> $GITHUB_ENV
+      - name: Leak the propagated token
+        run: |
+          echo "got token: $TOKEN"


### PR DESCRIPTION
## Summary

Issue #437 対応。`secret-in-log` ルールの taint 解析を単一 run ステップから **同一 Job 内のステップ間** へ拡張する。`$GITHUB_ENV` への書き込み経由で引き継がれる secret 派生値を後続 step の sink で検出できるようにした。

### 未検出だった FN（解決）

```yaml
steps:
  - run: |
      DERIVED=\$(echo \$SECRET_JSON | jq -r '.key')
      echo "TOKEN=\$DERIVED" >> \$GITHUB_ENV
  - run: |
      echo "\$TOKEN"   # これが検出されるようになる
```

### 実装ポイント

- `SecretInLogRule` に `crossStepEnv map[string]string` を追加。`VisitJobPre` 冒頭でリセットし、各 step 処理後に書き込みを回収して次 step に引き継ぐ。
- 書き込み検出 (`collectGitHubEnvTaintWrites`) は echo / printf / cat(heredoc) の 3 形態に対応。
  - `echo "NAME=\$VAR" >> \$GITHUB_ENV` / `echo NAME=\$VAR >> "\$GITHUB_ENV"` / `> \$GITHUB_ENV`（上書き）
  - `cat <<EOF >> \$GITHUB_ENV ... EOF`
- `\$GITHUB_OUTPUT` は後続 step の env にはならないため対象外。
- step-level env は crossStepEnv を override する優先順序で merge（origin は step env 側が勝つ）。
- cross-*job* / reusable workflow 跨ぎは follow-up（#432 / #433）。

### 変更ファイル

- `pkg/core/secretinlog.go`: crossStepEnv + helper 関数群を追加
- `pkg/core/secretinlog_test.go`: 7 テストケース追加
- `docs/secretinlogrule.md`: detection logic と Scope Limitations を更新
- `script/actions/secret-in-log-{vulnerable,safe}.yaml`: cross-step 例を追加
- `CLAUDE.md`: ルール説明を更新
- `plan/2026-04-23-secret-in-log-cross-step-taint.md`: 実装計画

## Test plan

- [x] 新規テスト（7 件）: 基本 / quote バリアント / heredoc / 連鎖 / ジョブ境界 / \$GITHUB_OUTPUT 非伝播 / step env 上書き
- [x] 既存テストに回帰なし（`go test ./pkg/core`）
- [x] `script/actions/secret-in-log-vulnerable.yaml` の `leak-cross-step-github-env` が検出される（origin: shellvar:GCP_SERVICE_ACCOUNT_KEY）
- [x] `script/actions/secret-in-log-safe.yaml` の `safe-cross-step-with-add-mask` は検出されない

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 同一ジョブ内のステップ間での環境変数経由のシークレット伝播（$GITHUB_ENV）を検出するようになりました。

* **ドキュメント**
  * ルール仕様を拡張し、同一ジョブ内のクロスステップ伝播の振る舞いと制限を明記。検出順序や例を追加しました。

* **テスト**
  * クロスステップ伝播を網羅する統合系テスト群とケースを追加しました。

* **サンプル**
  * 安全／脆弱なワークフローの例ジョブを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->