### PR TITLE
feat(taint):TaintTracker をシェルスコープ対応に拡張

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,8 @@ Use AST/Tokenizer instead of string-based parsing:
   - `shell.WalkAssignments(file)` / `shell.WordReferencesEntry(word, tainted)` — AST-aware lookups (treats heredoc bodies and comments correctly)
   - `shell.WalkRedirectWrites(file, target)` — collects `>> $TARGET` writes (echo / printf format / heredoc, including `printf 'name=%s\n' "$VAR"` form)
   - GitHub Actions `${{ ... }}` substitutions are not valid bash syntax. `pkg/core/taint.go` sanitizes them via `sanitizeForShellParse` (length-non-preserving placeholder + `exprMap`) before parsing. `secretinlog.go` does not need this because its taint sources come from the YAML `env:` section, not script literals.
+- **Scope-aware propagation (#447)**: `shell.PropagateTaint` は scope frame stack ベースで walk し、`*syntax.Subshell` / `*syntax.CmdSubst` は entry 時に親 visible を snapshot copy して隔離、`*syntax.FuncDecl` 本体は parent への lookup chain で bash dynamic scoping を近似 (`local` / 装飾なし `declare` は本体ローカル、その他は簡略案 A により親に漏らさない)。戻り値は `*shell.ScopedTaint` で、`Final` (script 末尾の親スコープ) と `At(stmt)` (per-stmt visible) を持つ。`taint.go` は per-stmt 展開で `recordRedirWrite` に渡す。`secretinlog.go` は `shellvar:X` マーカーを autofix のため raw 保持する (展開しない)
+  - **Known limitation**: `seedTaintFromExpressions` (in `pkg/core/taint.go`) is NOT scope-aware — direct `${{ untrusted }}` assignment inside a subshell will still seed `t.taintedVars`/`Final` regardless of scope. Scope-awareness applies fully to shell-variable derivation paths (`X="$Y"`) but seed leaks via the direct expression path remain. Tracked as follow-up.
 
 ## Implemented Rules
 

--- a/docs/superpowers/plans/2026-04-27-447-tainttracker-shell-scope.md
+++ b/docs/superpowers/plans/2026-04-27-447-tainttracker-shell-scope.md
@@ -1,0 +1,1551 @@
+# #447 TaintTracker シェルスコープ対応 — 実装プラン
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `pkg/shell/taint.go::PropagateTaint` を scope-aware に拡張し、subshell / `$(...)` / function 本体の bash スコープ意味論を導入する。両 caller (`pkg/core/taint.go`, `pkg/core/secretinlog.go`) を per-stmt visible lookup に切り替え、FP 抑制と FN 修正を両立させる。
+
+**Architecture:** `PropagateTaint` の戻り値を `*ScopedTaint` (`Final` map + `visibleAt` per-Stmt snapshot) に変更。内部に `scopeFrame` のスタックを持ち、`syntax.Walk` で `*syntax.Subshell` / `*syntax.CmdSubst` / `*syntax.FuncDecl` の入退場で push/pop。Subshell/CmdSubst は親 visible を snapshot copy して隔離、FuncDecl は parent への lookup chain で bash dynamic scoping を近似。
+
+**Tech Stack:** Go 1.22+, `mvdan.cc/sh/v3/syntax` (bash AST)、`maps` 標準ライブラリ、既存 `pkg/shell` プリミティブ (`WalkAssignments`, `WordReferencesEntry` 等)。
+
+**Spec:** [docs/superpowers/specs/2026-04-27-447-tainttracker-shell-scope-design.md](../specs/2026-04-27-447-tainttracker-shell-scope-design.md)
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `pkg/shell/taint.go` | Modify | `ScopedTaint` 型追加、`PropagateTaint` をスコープ対応 walker に書き換え、`scopeFrame` 内部構造 |
+| `pkg/shell/taint_test.go` | Modify | 新規 13 ケース + API 検証 (NilFile, At fallback) |
+| `pkg/core/taint.go` | Modify | `recordRedirWrite` のシグネチャ更新、`AnalyzeStep` での per-stmt 展開 |
+| `pkg/core/taint_test.go` | Modify | `TestTaintTracker_RedirWriteInSubshell` 追加 |
+| `pkg/core/secretinlog.go` | Modify | `findEchoLeaks` と `collectGitHubEnvTaintWrites` を `*shell.ScopedTaint` 受け取りに変更 (per-stmt lookup) |
+| `pkg/core/secretinlog_test.go` | Modify | `TestSecretInLog_FunctionLocalScope_DetectsLeak`, `TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent` 追加 |
+| `script/actions/taint-scope-fp-safe.yaml` | Create | FP 抑制を示す fixture |
+| `script/actions/taint-scope-fn-vulnerable.yaml` | Create | 関数本体内 sink の正検出を示す fixture |
+| `script/README.md` | Modify | 新 fixture 追記 |
+| `CLAUDE.md` | Modify | TaintTracker 説明にスコープ対応の旨を追記、TODO コメント削除予定箇所メモ |
+
+---
+
+## Task 1: `ScopedTaint` 型と signature 変更 (scope 動作なし、互換のみ)
+
+**Files:**
+- Modify: `pkg/shell/taint.go:30-206`
+- Modify: `pkg/shell/taint_test.go` (全テスト)
+- Modify: `pkg/core/taint.go:226-240`
+- Modify: `pkg/core/secretinlog.go:398-409`
+
+### Step 1: 既存テスト名・呼び出し箇所を確認
+
+- [ ] Run: `grep -n 'PropagateTaint(' pkg/shell/taint_test.go pkg/core/taint.go pkg/core/secretinlog.go`
+- [ ] Expected: 4 箇所程度 (`taint.go:229`, `secretinlog.go:398`, `taint_test.go` 内のいくつか)
+
+### Step 2: `pkg/shell/taint.go` に `ScopedTaint` 型と新シグネチャを追加
+
+`PropagateTaint` 関数 (現 L182-206) を以下に置き換える。**スコープ動作はまだ実装しない** — 戻り値の `Final` は旧実装と同じ、`visibleAt` は空 map で互換性確保のみ目的。
+
+- [ ] Edit `pkg/shell/taint.go` — `Entry` 型の直後 (L42 あたり) に追加:
+
+```go
+// ScopedTaint は scope-aware な taint propagation の結果。
+//
+// Final はスクリプト末尾時点で親スコープから見える tainted vars。
+// 旧 PropagateTaint の戻り値と同じ形。cross-step 伝播 (taint.go の
+// $GITHUB_OUTPUT 記録、secretinlog.go の crossStepEnv 構築) で使う。
+//
+// visibleAt は AST 内の各 *syntax.Stmt 入口時点で「そのスコープから
+// 見える tainted vars の union」を保持。sink 検出で「この位置でこの
+// 変数は tainted か?」のクエリに使う。直接アクセスせず At() を経由する。
+type ScopedTaint struct {
+	Final     map[string]Entry
+	visibleAt map[*syntax.Stmt]map[string]Entry
+}
+
+// At は stmt の入口時点で見えている tainted set を返す。
+// stmt が nil または visibleAt に未登録の場合は Final を返す
+// (root scope sink のフォールバック)。
+func (s *ScopedTaint) At(stmt *syntax.Stmt) map[string]Entry {
+	if s == nil {
+		return nil
+	}
+	if stmt == nil {
+		return s.Final
+	}
+	if v, ok := s.visibleAt[stmt]; ok {
+		return v
+	}
+	return s.Final
+}
+```
+
+- [ ] Edit `pkg/shell/taint.go` — `PropagateTaint` 関数 (L172-206) を以下に書き換え:
+
+```go
+// PropagateTaint は initial を seed として AST を順方向 1 パス walk し、
+// scope-aware に taint を伝播する。
+//
+// セマンティクス:
+//   - 既に tainted な変数への再代入は origin/Offset を上書きしない（最初の taint を保持）
+//   - LHS 名は AST 順序で処理される（forward dataflow）
+//   - 代入の RHS が tainted を参照しない場合は LHS に何もしない（"untaint" はしない）
+//   - スコープ:
+//     - *syntax.Subshell `( ... )` と *syntax.CmdSubst `$(...)` は entry 時に
+//       親 visible を snapshot copy して隔離。内部代入は親に漏れない
+//     - *syntax.FuncDecl 本体は parent への lookup chain で bash dynamic scoping を
+//       近似。`local` / 装飾なし `declare` は本体ローカル、その他の代入は本 issue の
+//       簡略案 A により親に漏らさない (#448 で改善予定)
+//
+// 戻り値は initial を変更せず新しい *ScopedTaint を返す。
+func PropagateTaint(file *syntax.File, initial map[string]Entry) *ScopedTaint {
+	result := &ScopedTaint{
+		Final:     make(map[string]Entry, len(initial)),
+		visibleAt: make(map[*syntax.Stmt]map[string]Entry),
+	}
+	maps.Copy(result.Final, initial)
+	if file == nil {
+		return result
+	}
+
+	// 暫定実装: 旧フラット動作で Final を埋める。
+	// Task 2 以降でスコープ対応に置き換える。
+	for _, a := range WalkAssignments(file) {
+		if _, already := result.Final[a.Name]; already {
+			continue
+		}
+		if a.Value == nil {
+			continue
+		}
+		refName, found := WordReferencesEntry(a.Value, result.Final)
+		if !found {
+			continue
+		}
+		result.Final[a.Name] = Entry{
+			Sources: []string{"shellvar:" + refName},
+			Offset:  a.Offset,
+		}
+	}
+	return result
+}
+```
+
+### Step 3: `pkg/core/taint.go` の caller を最小修正
+
+- [ ] Edit `pkg/core/taint.go:228-241` — `t.taintedVars = shell.PropagateTaint(...)` を以下に変更:
+
+```go
+	scoped := shell.PropagateTaint(file, t.taintedVars)
+	t.taintedVars = scoped.Final
+	expandShellvarMarkers(t.taintedVars)
+
+	// shell.PropagateTaint marks derived variables with "shellvar:X" chain
+	// markers; taint.go callers expect transitive source lists for richer
+	// reporting (e.g. trace back to "github.event.issue.title"). Expand the
+	// markers in place. Bounded passes guard against pathological chains.
+	// (NOTE: scope-aware per-stmt expansion is added in Task 10)
+
+	// GITHUB_OUTPUT writes
+	for _, w := range shell.WalkRedirectWrites(file, "GITHUB_OUTPUT") {
+		t.recordRedirWrite(stepID, w, exprMap)
+	}
+```
+
+### Step 4: `pkg/core/secretinlog.go` の caller を最小修正
+
+- [ ] Edit `pkg/core/secretinlog.go:398-408` — `tainted := shell.PropagateTaint(...)` を以下に変更:
+
+```go
+	scoped := shell.PropagateTaint(file, initialTainted)
+	tainted := scoped.Final
+	leaks := rule.findEchoLeaks(file, tainted, script, execRun.Run)
+	for _, leak := range leaks {
+		rule.reportLeak(leak)
+		rule.addAutoFixerForLeak(step, leak)
+	}
+	// 後続 step の crossStepEnv に伝播させる。
+	for name, origin := range rule.collectGitHubEnvTaintWrites(file, tainted, script) {
+		rule.crossStepEnv[name] = origin
+	}
+```
+
+### Step 5: `pkg/shell/taint_test.go` の既存 `PropagateTaint` テストを更新
+
+- [ ] Run: `grep -n 'PropagateTaint(' pkg/shell/taint_test.go`
+- [ ] 各箇所で `result := PropagateTaint(...)` を `result := PropagateTaint(...).Final` に変更 (assertion 対象は同じく `map[string]Entry`)
+
+### Step 6: ビルド & 全テスト確認
+
+- [ ] Run: `go build ./...`
+- [ ] Expected: 成功 (compile error なし)
+- [ ] Run: `go test ./pkg/shell/... ./pkg/core/...`
+- [ ] Expected: 全テスト pass (旧挙動維持)
+
+### Step 7: Commit
+
+- [ ] Run:
+```bash
+git add pkg/shell/taint.go pkg/shell/taint_test.go pkg/core/taint.go pkg/core/secretinlog.go
+git commit -m "$(cat <<'EOF'
+refactor(taint): #447 PropagateTaint の戻り値を *ScopedTaint に変更
+
+スコープ動作の追加に向けた API 変更のみ。挙動は旧実装と同じ
+(Final は旧戻り値と同形、visibleAt は空)。callers (taint.go,
+secretinlog.go) を最小修正で追従。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Subshell スコープ隔離
+
+**Files:**
+- Modify: `pkg/shell/taint.go` — `PropagateTaint` 内部実装を walker ベースに置換
+- Modify: `pkg/shell/taint_test.go` — 新規 `TestPropagateTaint_Scoped` 追加
+
+### Step 1: 失敗するテストを追加
+
+- [ ] Edit `pkg/shell/taint_test.go` — ファイル末尾に追加:
+
+```go
+// TestPropagateTaint_Scoped は scope-aware な PropagateTaint の挙動を検証する。
+func TestPropagateTaint_Scoped(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		// finalHas は Final に含まれるべき変数名 → Sources の最初の値
+		finalHas map[string]string
+		// finalAbsent は Final に含まれてはいけない変数名
+		finalAbsent []string
+	}
+
+	cases := []struct {
+		name    string
+		script  string
+		initial map[string]Entry
+		want    want
+	}{
+		{
+			name:    "subshell_isolation_fp_suppressed",
+			script:  `X="$T"; ( X="safe"; cmd "$X" )`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				// 親 X は T 経由で tainted (subshell 内の X="safe" は親に漏れない)
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+					"X": "shellvar:T",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			file := parseScript(t, tc.script)
+			result := PropagateTaint(file, tc.initial)
+			for name, wantOrigin := range tc.want.finalHas {
+				entry, ok := result.Final[name]
+				if !ok {
+					t.Errorf("Final[%q] missing; want origin %q", name, wantOrigin)
+					continue
+				}
+				if entry.First() != wantOrigin {
+					t.Errorf("Final[%q].First() = %q; want %q", name, entry.First(), wantOrigin)
+				}
+			}
+			for _, name := range tc.want.finalAbsent {
+				if _, ok := result.Final[name]; ok {
+					t.Errorf("Final[%q] should be absent", name)
+				}
+			}
+		})
+	}
+}
+```
+
+### Step 2: テストが失敗することを確認
+
+- [ ] Run: `go test ./pkg/shell/ -run TestPropagateTaint_Scoped/subshell_isolation_fp_suppressed -v`
+- [ ] Expected: FAIL — `Final[X].First()` が `shellvar:T` ではなく `shellvar:X` (subshell 内の X="safe" を親も拾っている可能性) または別値になる
+
+### Step 3: `PropagateTaint` を walker ベースに書き換え
+
+- [ ] Edit `pkg/shell/taint.go` — `PropagateTaint` 関数全体 (現 L172 以降) を以下に置き換え:
+
+```go
+// scopeKind は scope frame の種別。
+type scopeKind int
+
+const (
+	scopeRoot     scopeKind = iota // スクリプトルート
+	scopeFunc                      // FuncDecl 本体
+	scopeSubshell                  // ( ... )
+	scopeCmdSubst                  // $(...)
+)
+
+// scopeFrame は scope-aware walker のスタック要素。
+//
+// local はこの frame で局所宣言された tainted vars。
+// parent は lookup chain (function 用) または nil (root)。
+// subshell/cmdsubst frame は entry 時に親の visible を local に snapshot copy
+// しているため、parent chain は使わない (kind の判定で分岐する)。
+type scopeFrame struct {
+	parent *scopeFrame
+	local  map[string]Entry
+	kind   scopeKind
+}
+
+// visible はこの frame から見える tainted vars の union を返す。
+// FuncDecl 本体: 自 frame.local + parent.visible() (再帰 chain)
+// Subshell/CmdSubst: 自 frame.local のみ (entry 時 snapshot 済み)
+// Root: 自 frame.local のみ
+func (f *scopeFrame) visible() map[string]Entry {
+	out := maps.Clone(f.local)
+	if out == nil {
+		out = make(map[string]Entry)
+	}
+	if f.kind == scopeFunc && f.parent != nil {
+		for k, v := range f.parent.visible() {
+			if _, ok := out[k]; !ok {
+				out[k] = v
+			}
+		}
+	}
+	return out
+}
+
+// PropagateTaint は initial を seed として AST を順方向 1 パス walk し、
+// scope-aware に taint を伝播する。
+//
+// セマンティクス:
+//   - 既に tainted な変数への再代入は origin/Offset を上書きしない
+//   - LHS 名は AST 順序で処理される（forward dataflow）
+//   - 代入の RHS が tainted を参照しない場合は LHS に何もしない（untaint しない）
+//   - スコープ:
+//     - *syntax.Subshell と *syntax.CmdSubst は entry 時に親 visible を
+//       snapshot copy して隔離。内部代入は親に漏れない
+//     - *syntax.FuncDecl 本体は parent への lookup chain で dynamic scoping を近似。
+//       `local` / 装飾なし `declare` は本体ローカル、その他の代入は簡略案 A により
+//       親に漏らさない (#448 で改善予定)
+//
+// 戻り値は initial を変更せず新しい *ScopedTaint を返す。
+func PropagateTaint(file *syntax.File, initial map[string]Entry) *ScopedTaint {
+	result := &ScopedTaint{
+		Final:     make(map[string]Entry, len(initial)),
+		visibleAt: make(map[*syntax.Stmt]map[string]Entry),
+	}
+	maps.Copy(result.Final, initial)
+	if file == nil {
+		return result
+	}
+
+	root := &scopeFrame{kind: scopeRoot, local: maps.Clone(initial)}
+	if root.local == nil {
+		root.local = make(map[string]Entry)
+	}
+	current := root
+	syntax.Walk(file, makeWalkFn(&current, result))
+
+	// Final は root frame の最終状態 (subshell/funcdecl frame は pop 済み)
+	maps.Copy(result.Final, root.local)
+	return result
+}
+
+// makeWalkFn は scope frame stack を維持しつつ walk するクロージャを返す。
+// `current` は現在の frame を指す pointer-to-pointer で、subshell/funcdecl 入退場時に
+// 書き換える。
+func makeWalkFn(current **scopeFrame, result *ScopedTaint) func(syntax.Node) bool {
+	return func(node syntax.Node) bool {
+		if node == nil {
+			return false
+		}
+		switch n := node.(type) {
+		case *syntax.Subshell:
+			child := &scopeFrame{kind: scopeSubshell, parent: *current, local: maps.Clone((*current).visible())}
+			*current = child
+			for _, stmt := range n.Stmts {
+				syntax.Walk(stmt, makeWalkFn(current, result))
+			}
+			*current = (*current).parent
+			return false
+		case *syntax.CmdSubst:
+			child := &scopeFrame{kind: scopeCmdSubst, parent: *current, local: maps.Clone((*current).visible())}
+			*current = child
+			for _, stmt := range n.Stmts {
+				syntax.Walk(stmt, makeWalkFn(current, result))
+			}
+			*current = (*current).parent
+			return false
+		case *syntax.FuncDecl:
+			// 関数本体の処理は Task 4 で実装
+			return false
+		case *syntax.Stmt:
+			// 各 Stmt 入口で visibleAt を記録
+			result.visibleAt[n] = (*current).visible()
+			return true
+		case *syntax.DeclClause:
+			processDeclClause(*current, n)
+			return false // children は処理済み (二重カウント防止)
+		case *syntax.Assign:
+			processAssign(*current, n, AssignNone)
+			return true
+		}
+		return true
+	}
+}
+
+// processAssign は単純代入 X=Y を current frame に書き込む。
+// 既に tainted な変数の上書きはしない (最初の taint を保持)。
+func processAssign(current *scopeFrame, a *syntax.Assign, kw AssignKeyword) {
+	if a == nil || a.Name == nil {
+		return
+	}
+	name := a.Name.Value
+	if _, already := current.local[name]; already {
+		return
+	}
+	if a.Value == nil {
+		return
+	}
+	visible := current.visible()
+	refName, found := WordReferencesEntry(a.Value, visible)
+	if !found {
+		return
+	}
+	current.local[name] = Entry{
+		Sources: []string{"shellvar:" + refName},
+		Offset:  int(a.Pos().Offset()), //nolint:gosec // file offsets fit in int
+	}
+}
+
+// processDeclClause は DeclClause (export X=Y / local X=Y / readonly X=Y / declare X=Y) を処理する。
+// keyword に応じた scope target は Task 6/7 で実装。本 Task では全部 current frame に書く
+// (Subshell/CmdSubst では結果同じ、FuncDecl 内は Task 5/6/7 で再分岐する)。
+func processDeclClause(current *scopeFrame, decl *syntax.DeclClause) {
+	if decl == nil {
+		return
+	}
+	kw := keywordFor(decl.Variant.Value)
+	for _, a := range decl.Args {
+		processAssign(current, a, kw)
+	}
+}
+```
+
+注意: `processAssign` の第 3 引数 `kw` は本 Task では使わないが、Task 5/6/7 で参照するため引数に残す。
+
+### Step 4: テストが pass することを確認
+
+- [ ] Run: `go test ./pkg/shell/ -run TestPropagateTaint_Scoped/subshell_isolation_fp_suppressed -v`
+- [ ] Expected: PASS
+
+### Step 5: 既存テスト群の回帰確認
+
+- [ ] Run: `go test ./pkg/shell/...`
+- [ ] Expected: 全 pass。失敗するなら walker のフォールスルー漏れ (Stmt の handler が return true を返さず children に降りていない等) を疑う
+
+### Step 6: Commit
+
+- [ ] Run:
+```bash
+git add pkg/shell/taint.go pkg/shell/taint_test.go
+git commit -m "$(cat <<'EOF'
+feat(taint): #447 Subshell スコープ隔離を実装
+
+PropagateTaint を scope frame stack ベースの walker に書き換え。
+*syntax.Subshell `( ... )` の内部代入が親に漏れないことを検証する
+ユニットテスト 1 件追加。CmdSubst / FuncDecl は後続タスクで実装。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: CmdSubst スコープ隔離 + visibleAt スナップショット検証
+
+**Files:**
+- Modify: `pkg/shell/taint_test.go`
+
+### Step 1: CmdSubst 隔離と visibleAt の失敗テストを追加
+
+- [ ] Edit `pkg/shell/taint_test.go` — `TestPropagateTaint_Scoped` の `cases` に追加:
+
+```go
+		{
+			name:   "subshell_inner_sees_parent_tainted",
+			script: `X="$T"; ( cmd "$X" )`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+					"X": "shellvar:T",
+				},
+			},
+		},
+		{
+			name:   "cmdsubst_isolation",
+			script: `R=$(X="leaked"; echo "$X"); cmd "$X"`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+				},
+				finalAbsent: []string{"X"}, // cmdsubst 内の X="leaked" は親に漏れない
+			},
+		},
+		{
+			name:   "nested_subshell",
+			script: `( X="$T"; ( cmd "$X" ) )`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+				},
+				finalAbsent: []string{"X"}, // 内側の X は外側 subshell に閉じる
+			},
+		},
+```
+
+加えて `visibleAt` を直接検証する新規テスト関数を追加:
+
+```go
+// TestScopedTaint_At は visibleAt の per-Stmt snapshot を検証する。
+func TestScopedTaint_At(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subshell_inner_stmt_sees_parent_tainted", func(t *testing.T) {
+		t.Parallel()
+		// X="$T" は親、( cmd "$X" ) の cmd は subshell 内
+		file := parseScript(t, `X="$T"; ( cmd "$X" )`)
+		initial := map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+
+		// AST から内側 cmd の Stmt を取り出して At を検証
+		var innerStmt *syntax.Stmt
+		syntax.Walk(file, func(n syntax.Node) bool {
+			if sub, ok := n.(*syntax.Subshell); ok {
+				if len(sub.Stmts) > 0 {
+					innerStmt = sub.Stmts[0]
+				}
+				return false
+			}
+			return true
+		})
+		if innerStmt == nil {
+			t.Fatal("inner subshell stmt not found")
+		}
+		visible := result.At(innerStmt)
+		if _, ok := visible["T"]; !ok {
+			t.Errorf("inner subshell visible should contain T, got %v", keysOf(visible))
+		}
+		if _, ok := visible["X"]; !ok {
+			t.Errorf("inner subshell visible should contain X (snapshotted from parent), got %v", keysOf(visible))
+		}
+	})
+
+	t.Run("at_nil_returns_final", func(t *testing.T) {
+		t.Parallel()
+		file := parseScript(t, `X=v`)
+		initial := map[string]Entry{"T": {Sources: []string{"x"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+		got := result.At(nil)
+		if _, ok := got["T"]; !ok {
+			t.Errorf("At(nil) should fall back to Final, got %v", keysOf(got))
+		}
+	})
+
+	t.Run("at_unknown_stmt_returns_final", func(t *testing.T) {
+		t.Parallel()
+		// 別ファイルの Stmt を渡してフォールバック確認
+		file := parseScript(t, `X=v`)
+		other := parseScript(t, `Y=z`)
+		initial := map[string]Entry{"T": {Sources: []string{"x"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+		var otherStmt *syntax.Stmt
+		if len(other.Stmts) > 0 {
+			otherStmt = other.Stmts[0]
+		}
+		got := result.At(otherStmt)
+		if _, ok := got["T"]; !ok {
+			t.Errorf("At(unknown stmt) should fall back to Final, got %v", keysOf(got))
+		}
+	})
+
+	t.Run("nil_scoped_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		var s *ScopedTaint
+		if got := s.At(nil); got != nil {
+			t.Errorf("nil ScopedTaint.At should return nil, got %v", got)
+		}
+	})
+}
+
+// keysOf is a test helper that returns sorted keys of a map for debug output.
+func keysOf(m map[string]Entry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+```
+
+### Step 2: 失敗確認
+
+- [ ] Run: `go test ./pkg/shell/ -run TestPropagateTaint_Scoped -v`
+- [ ] Expected: `cmdsubst_isolation` などが既に PASS している可能性が高い (Task 2 の walker が Subshell と CmdSubst の両 case を処理しているため)。FAIL したものだけ次 step で対処
+- [ ] Run: `go test ./pkg/shell/ -run TestScopedTaint_At -v`
+- [ ] Expected: 4 ケースとも PASS (Task 2 で visibleAt 自体は実装済み)
+
+### Step 3: もし失敗があれば原因調査・修正
+
+- [ ] FAIL があれば walker の `*syntax.CmdSubst` ハンドラまたは `*syntax.Stmt` の visibleAt 記録漏れを修正
+- [ ] 修正後 Step 2 を再実行
+
+### Step 4: Commit
+
+- [ ] Run:
+```bash
+git add pkg/shell/taint_test.go
+git commit -m "$(cat <<'EOF'
+test(taint): #447 CmdSubst 隔離と visibleAt スナップショット検証を追加
+
+cmdsubst_isolation / nested_subshell / subshell_inner_sees_parent ケース
+と TestScopedTaint_At (At(nil) / At(unknown) フォールバック含む) を追加。
+walker は Task 2 で実装済みのため挙動修正は不要。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: FuncDecl 本体スコープ + `local` ハンドリング
+
+**Files:**
+- Modify: `pkg/shell/taint.go` — walker に FuncDecl ハンドラ追加、`processDeclClause` で `local` を分岐
+- Modify: `pkg/shell/taint_test.go` — case 4, 12 追加
+
+### Step 1: 失敗テストを追加
+
+- [ ] Edit `pkg/shell/taint_test.go` — `TestPropagateTaint_Scoped` の `cases` に追加:
+
+```go
+		{
+			name:    "function_local_isolated",
+			script:  `foo() { local X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"}, // 関数内の local X は親に漏れない
+			},
+		},
+		{
+			name:    "root_local_treated_as_root_assign",
+			script:  `local X="$T"`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				// root scope の local は bash 実行時エラーだが、解析では root に書く (FN 抑制)
+				finalHas: map[string]string{
+					"T": "secrets.GH",
+					"X": "shellvar:T",
+				},
+			},
+		},
+```
+
+加えて `visibleAt` で関数内 sink を検証:
+
+```go
+	t.Run("function_body_inner_sees_local", func(t *testing.T) {
+		t.Parallel()
+		file := parseScript(t, `foo() { local X="$T"; cmd "$X"; }; foo`)
+		initial := map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+
+		// 関数本体内の `cmd "$X"` Stmt を取り出す
+		var cmdStmt *syntax.Stmt
+		syntax.Walk(file, func(n syntax.Node) bool {
+			fd, ok := n.(*syntax.FuncDecl)
+			if !ok || fd.Body == nil {
+				return true
+			}
+			body, ok := fd.Body.Cmd.(*syntax.Block)
+			if !ok {
+				return true
+			}
+			// body.Stmts: [0]=local X=, [1]=cmd "$X"
+			if len(body.Stmts) >= 2 {
+				cmdStmt = body.Stmts[1]
+			}
+			return false
+		})
+		if cmdStmt == nil {
+			t.Fatal("function body cmd stmt not found")
+		}
+		visible := result.At(cmdStmt)
+		if _, ok := visible["X"]; !ok {
+			t.Errorf("function body cmd visible should contain X (local), got %v", keysOf(visible))
+		}
+	})
+```
+
+→ この test は `TestScopedTaint_At` 関数内に追加する。
+
+### Step 2: 失敗確認
+
+- [ ] Run: `go test ./pkg/shell/ -run 'TestPropagateTaint_Scoped/function_local_isolated|TestPropagateTaint_Scoped/root_local_treated_as_root_assign|TestScopedTaint_At/function_body_inner_sees_local' -v`
+- [ ] Expected: 全部 FAIL (FuncDecl が walker でスキップされているため)
+
+### Step 3: walker に FuncDecl ハンドラを追加
+
+- [ ] Edit `pkg/shell/taint.go` — `makeWalkFn` 内 `case *syntax.FuncDecl:` を以下に置き換え:
+
+```go
+		case *syntax.FuncDecl:
+			if n.Body == nil {
+				return false
+			}
+			child := &scopeFrame{kind: scopeFunc, parent: *current, local: make(map[string]Entry)}
+			prev := *current
+			*current = child
+			syntax.Walk(n.Body, makeWalkFn(current, result))
+			*current = prev
+			return false
+```
+
+(Task 2 で walker は makeWalkFn 1 つに統一済み。修正箇所は 1 箇所のみ)
+
+### Step 4: `processDeclClause` で `local` を分岐
+
+- [ ] Edit `pkg/shell/taint.go` — `processDeclClause` を以下に置き換え:
+
+```go
+// processDeclClause は DeclClause を処理する。
+// セマンティクス (#447):
+//   - local: 常に current frame に書く (FuncDecl 内なら本体ローカル、root なら root ※bash エラーだが解析許容)
+//   - declare (装飾なし): FuncDecl 内なら current frame、それ以外なら current frame に書く (Task 6 で declare -g 対応)
+//   - export / readonly: FuncDecl 内では簡略案 A により無視 (親に漏らさない)、それ以外なら current frame に書く
+func processDeclClause(current *scopeFrame, decl *syntax.DeclClause) {
+	if decl == nil {
+		return
+	}
+	kw := keywordFor(decl.Variant.Value)
+
+	// FuncDecl 内で export / readonly は簡略案 A により無視 (親に漏らさない)
+	if current.kind == scopeFunc && (kw == AssignExport || kw == AssignReadonly) {
+		return
+	}
+	// declare -g の判定は Task 6 で追加。本 Task では declare は current frame に書く
+
+	for _, a := range decl.Args {
+		processAssign(current, a, kw)
+	}
+}
+```
+
+加えて、`AssignNone` (装飾なし `X=Y`) も FuncDecl 内では簡略案 A により親に漏らさない。`processAssign` 自体は current frame に書くので、FuncDecl 本体 walk の中なら自然と本体ローカルに閉じる (簡略案 A の「無視」は実質「FuncDecl 本体の local に書いて、関数を抜ける際に discard」と等価)。
+
+つまり Walker 上の FuncDecl pop で frame ごと捨てるため、FuncDecl 内の `X=Y` (AssignNone) は親に漏れない ← これで簡略案 A が成立する。**追加の特別処理は不要**。
+
+ただし `processAssign` 内で `current.visible()` を見ているので、関数本体の親 lookup chain が効く (関数内で親の T を参照できる)。
+
+### Step 5: テスト pass 確認
+
+- [ ] Run: `go test ./pkg/shell/ -run 'TestPropagateTaint_Scoped|TestScopedTaint_At' -v`
+- [ ] Expected: 全 pass
+- [ ] Run: `go test ./pkg/shell/...`
+- [ ] Expected: 全 pass (回帰なし)
+
+### Step 6: Commit
+
+- [ ] Run:
+```bash
+git add pkg/shell/taint.go pkg/shell/taint_test.go
+git commit -m "$(cat <<'EOF'
+feat(taint): #447 FuncDecl スコープと local キーワードを実装
+
+walker に FuncDecl ハンドラを追加。本体は scopeFunc frame で push し、
+parent への lookup chain で bash dynamic scoping を近似。local 宣言は
+本体ローカルに閉じる。関数内 export/readonly は簡略案 A により親に
+漏らさない。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `declare` / `declare -g` セマンティクス
+
+**Files:**
+- Modify: `pkg/shell/taint.go` — `processDeclClause` で `-g` フラグ判定
+- Modify: `pkg/shell/taint_test.go` — case 5, 6, 7, 8 追加
+
+### Step 1: 失敗テストを追加
+
+- [ ] Edit `pkg/shell/taint_test.go` — `TestPropagateTaint_Scoped` の `cases` に追加:
+
+```go
+		{
+			name:    "function_declare_local_by_default",
+			script:  `foo() { declare X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"}, // 関数内 declare はデフォルト local
+			},
+		},
+		{
+			name:    "function_declare_g_simplified_A_ignored",
+			script:  `foo() { declare -g X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				// 簡略案 A: 関数内の non-local 代入 (declare -g 含む) は親に漏らさない
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "function_export_simplified_A_ignored",
+			script:  `foo() { export X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "function_readonly_simplified_A_ignored",
+			script:  `foo() { readonly X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+```
+
+### Step 2: 失敗確認
+
+- [ ] Run: `go test ./pkg/shell/ -run 'TestPropagateTaint_Scoped/function_declare_local_by_default|TestPropagateTaint_Scoped/function_declare_g_simplified_A_ignored|TestPropagateTaint_Scoped/function_export_simplified_A_ignored|TestPropagateTaint_Scoped/function_readonly_simplified_A_ignored' -v`
+- [ ] Expected: `function_declare_local_by_default` は既に PASS している可能性あり。`function_declare_g_simplified_A_ignored` は FAIL する可能性あり (`declare -g` を「親に漏らす」と誤実装している場合)
+
+### Step 3: `processDeclClause` で `declare -g` を判定
+
+- [ ] Edit `pkg/shell/taint.go` — `processDeclClause` を以下に置き換え:
+
+```go
+// processDeclClause は DeclClause を処理する。
+// セマンティクス (#447):
+//   - local: 常に current frame に書く
+//   - declare / typeset (装飾なし): current frame に書く (FuncDecl 内なら本体ローカル)
+//   - declare -g (グローバル指定): FuncDecl 内では簡略案 A により無視
+//   - export / readonly: FuncDecl 内では簡略案 A により無視、それ以外なら current frame に書く
+func processDeclClause(current *scopeFrame, decl *syntax.DeclClause) {
+	if decl == nil {
+		return
+	}
+	kw := keywordFor(decl.Variant.Value)
+
+	if current.kind == scopeFunc {
+		// FuncDecl 内で export / readonly は簡略案 A により無視
+		if kw == AssignExport || kw == AssignReadonly {
+			return
+		}
+		// declare -g も簡略案 A により無視
+		if kw == AssignDeclare && declHasGlobalFlag(decl) {
+			return
+		}
+	}
+
+	for _, a := range decl.Args {
+		processAssign(current, a, kw)
+	}
+}
+
+// declHasGlobalFlag は DeclClause に -g (global) フラグが付いているか判定する。
+// `declare -g X=v` の場合 Args[0] が `-g` または `-Ag` 等のフラグ Word になる
+// ことがあるが、mvdan/sh では -g のような short option も Args の Lit として扱われる。
+// そのため Args の先頭から Lit を見て、`-` で始まり 'g' を含む文字列があれば true。
+func declHasGlobalFlag(decl *syntax.DeclClause) bool {
+	for _, a := range decl.Args {
+		if a == nil || a.Name == nil {
+			continue
+		}
+		// flag は Name.Value が `-` で始まる純粋な文字列
+		if strings.HasPrefix(a.Name.Value, "-") && strings.Contains(a.Name.Value, "g") && a.Value == nil {
+			return true
+		}
+	}
+	return false
+}
+```
+
+### Step 4: テスト pass 確認
+
+- [ ] Run: `go test ./pkg/shell/ -run TestPropagateTaint_Scoped -v`
+- [ ] Expected: 全 case pass
+- [ ] Run: `go test ./pkg/shell/...`
+- [ ] Expected: 回帰なし
+
+### Step 5: Commit
+
+- [ ] Run:
+```bash
+git add pkg/shell/taint.go pkg/shell/taint_test.go
+git commit -m "$(cat <<'EOF'
+feat(taint): #447 declare / declare -g / export / readonly のスコープ semantics
+
+関数内 declare はデフォルト local。declare -g / export / readonly は
+簡略案 A により親に漏らさない (#448 で改善)。テスト 4 ケース追加。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: ネストスコープと API edge ケース
+
+**Files:**
+- Modify: `pkg/shell/taint_test.go` — case 9-11, 13, NilFile
+
+### Step 1: テスト追加
+
+- [ ] Edit `pkg/shell/taint_test.go` — `TestPropagateTaint_Scoped` の `cases` に追加:
+
+```go
+		{
+			name:    "subshell_with_funcdecl_inside",
+			script:  `( foo() { local X="$T"; }; foo )`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "function_with_subshell_inside",
+			script:  `foo() { local X="$T"; ( cmd "$X" ); }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "regression_no_scope_constructs",
+			script:  `X="$T"; Y="$X"; cmd "$Y"`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "secrets.GH",
+					"X": "shellvar:T",
+					"Y": "shellvar:X",
+				},
+			},
+		},
+```
+
+加えて NilFile テストを `TestScopedTaint_At` に追加:
+
+```go
+	t.Run("nil_file", func(t *testing.T) {
+		t.Parallel()
+		initial := map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}}
+		result := PropagateTaint(nil, initial)
+		if result == nil {
+			t.Fatal("PropagateTaint(nil, ...) should return non-nil ScopedTaint")
+		}
+		if _, ok := result.Final["T"]; !ok {
+			t.Errorf("Final should contain initial T, got %v", keysOf(result.Final))
+		}
+	})
+```
+
+### Step 2: テスト pass 確認
+
+- [ ] Run: `go test ./pkg/shell/ -run 'TestPropagateTaint_Scoped|TestScopedTaint_At' -v`
+- [ ] Expected: 全 pass (Task 4 の FuncDecl 実装と Task 2 の Subshell 実装で composition は自然動作するはず)
+- [ ] FAIL があれば walker の入れ子処理を確認
+
+### Step 3: Commit
+
+- [ ] Run:
+```bash
+git add pkg/shell/taint_test.go
+git commit -m "$(cat <<'EOF'
+test(taint): #447 ネストスコープと NilFile / 回帰ケースを追加
+
+subshell_with_funcdecl_inside / function_with_subshell_inside /
+regression_no_scope_constructs / nil_file の 4 ケース。Task 4-5 の
+walker composition で動作することを確認。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `pkg/core/taint.go` を scope-aware に統合
+
+**Files:**
+- Modify: `pkg/core/taint.go:226-241` — `recordRedirWrite` のシグネチャ更新と `AnalyzeStep` での per-stmt 展開
+- Modify: `pkg/core/taint.go:459-487` — `recordRedirWrite` 本体
+- Modify: `pkg/core/taint_test.go` — `TestTaintTracker_RedirWriteInSubshell` 追加
+
+### Step 1: 失敗テストを追加
+
+- [ ] Edit `pkg/core/taint_test.go` — ファイル末尾に追加 (`makeBPatternRunStep` ヘルパは L878 で既存):
+
+```go
+// TestTaintTracker_RedirWriteInSubshell は subshell 内の `>> $GITHUB_OUTPUT`
+// 書き込みでも親スコープの tainted vars が正しく検出されることを検証する (#447)。
+func TestTaintTracker_RedirWriteInSubshell(t *testing.T) {
+	t.Parallel()
+
+	step := makeBPatternRunStep("leak", `T="${{ github.event.issue.body }}"
+( echo "out=$T" >> $GITHUB_OUTPUT )`)
+
+	tracker := NewTaintTracker()
+	tracker.AnalyzeStep(step)
+
+	outputs := tracker.GetTaintedOutputs()
+	stepOutputs, ok := outputs["leak"]
+	if !ok {
+		t.Fatalf("step %q should have tainted outputs, got %v", "leak", outputs)
+	}
+	srcs, ok := stepOutputs["out"]
+	if !ok {
+		keys := make([]string, 0, len(stepOutputs))
+		for k := range stepOutputs {
+			keys = append(keys, k)
+		}
+		t.Fatalf("output %q should be tainted, got keys %v", "out", keys)
+	}
+	if len(srcs) == 0 || !strings.Contains(srcs[0], "github.event.issue.body") {
+		t.Errorf("output sources should reference github.event.issue.body, got %v", srcs)
+	}
+}
+```
+
+`strings` import が無ければ:
+
+- [ ] Run: `grep -n '"strings"' pkg/core/taint_test.go`
+- [ ] If absent, add to import block
+
+### Step 2: 失敗確認
+
+- [ ] Run: `go test ./pkg/core/ -run TestTaintTracker_RedirWriteInSubshell -v`
+- [ ] Expected: FAIL — subshell 内の T 参照が検出されない (現行 `recordRedirWrite` は global `t.taintedVars` 参照、subshell scope を意識していない)
+
+### Step 3: `pkg/core/taint.go` の `AnalyzeStep` を per-stmt 展開に変更
+
+- [ ] Edit `pkg/core/taint.go` — `AnalyzeStep` 内 (現 L228-241) を以下に置き換え:
+
+```go
+	scoped := shell.PropagateTaint(file, t.taintedVars)
+	t.taintedVars = scoped.Final
+	expandShellvarMarkers(t.taintedVars)
+
+	// GITHUB_OUTPUT writes
+	for _, w := range shell.WalkRedirectWrites(file, "GITHUB_OUTPUT") {
+		visible := scoped.At(w.Stmt)
+		// shellvar:X markers must be expanded before recording into taintedOutputs
+		// (cross-step propagation). expand a per-stmt copy to keep the scoped
+		// snapshot intact for any later use.
+		expanded := maps.Clone(visible)
+		if expanded == nil {
+			expanded = make(map[string]shell.Entry)
+		}
+		expandShellvarMarkers(expanded)
+		t.recordRedirWrite(stepID, w, exprMap, expanded)
+	}
+```
+
+`maps` パッケージの import を上に追加:
+
+- [ ] Run: `grep -n '"maps"' pkg/core/taint.go`
+- [ ] If absent, add to import block
+
+### Step 4: `recordRedirWrite` のシグネチャと本体を更新
+
+- [ ] Edit `pkg/core/taint.go` — `recordRedirWrite` (現 L459-487) を以下に置き換え:
+
+```go
+// recordRedirWrite は WalkRedirectWrites の結果をもとに taintedOutputs に記録する。
+// VALUE 内に直接 untrusted 式（プレースホルダ経由を含む）があるか、または
+// visible 内の tainted 変数を参照していれば、その output を tainted として登録する。
+//
+// visible は scope-aware な per-stmt visible map (caller で展開済み)。
+func (t *TaintTracker) recordRedirWrite(stepID string, w shell.RedirWrite, exprMap map[string]string, visible map[string]shell.Entry) {
+	sources := t.collectExpressionSources(w.Value, exprMap)
+
+	// VALUE 内の $VAR 参照を visible と照合
+	if w.ValueWord != nil {
+		if name, ok := shell.WordReferencesEntry(w.ValueWord, visible); ok {
+			sources = mergeUnique(sources, visible[name].Sources)
+		}
+	} else {
+		// heredoc 等で ValueWord が無い場合は文字列ベースで $VAR を検出
+		varRefPattern := regexp.MustCompile(`\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?`)
+		for _, m := range varRefPattern.FindAllStringSubmatch(w.Value, -1) {
+			if len(m) < 2 {
+				continue
+			}
+			if entry, ok := visible[m[1]]; ok {
+				sources = mergeUnique(sources, entry.Sources)
+			}
+		}
+	}
+
+	if len(sources) == 0 {
+		return
+	}
+	if t.taintedOutputs[stepID] == nil {
+		t.taintedOutputs[stepID] = make(map[string][]string)
+	}
+	t.taintedOutputs[stepID][w.Name] = sources
+}
+```
+
+### Step 5: テスト pass 確認
+
+- [ ] Run: `go test ./pkg/core/ -run TestTaintTracker_RedirWriteInSubshell -v`
+- [ ] Expected: PASS
+- [ ] Run: `go test ./pkg/core/...`
+- [ ] Expected: 全 pass (回帰なし)
+
+### Step 6: Commit
+
+- [ ] Run:
+```bash
+git add pkg/core/taint.go pkg/core/taint_test.go
+git commit -m "$(cat <<'EOF'
+feat(taint): #447 TaintTracker を scope-aware lookup に統合
+
+recordRedirWrite に visible map を引数追加し、AnalyzeStep で per-stmt の
+scoped.At() を expandShellvarMarkers してから渡すように変更。これで
+subshell 内の `>> $GITHUB_OUTPUT` でも親スコープの tainted vars が
+正しく検出される。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `pkg/core/secretinlog.go` を scope-aware に統合
+
+**Files:**
+- Modify: `pkg/core/secretinlog.go:71-110` — `findEchoLeaks`
+- Modify: `pkg/core/secretinlog.go:128-166` — `collectRedirectSinkLeaks` (シグネチャは変えず、呼び出し元で per-stmt visible を渡す)
+- Modify: `pkg/core/secretinlog.go:225-266` — `collectLeakedVars` (シグネチャ不変、呼び出し元で per-stmt visible を渡す)
+- Modify: `pkg/core/secretinlog.go:669-704` — `collectGitHubEnvTaintWrites`
+- Modify: `pkg/core/secretinlog.go:398-409` — caller (今回ここで scoped を直接使う)
+- Modify: `pkg/core/secretinlog_test.go` — 2 ケース追加
+
+### Step 1: 失敗テストを追加
+
+`secretinlog_test.go` には専用ヘルパが無く、`*ast.Step` / `*ast.Job` を inline で組む既存パターン (`TestSecretInLog_VisitJob_Integration` L131-236 参照) を踏襲する。
+
+- [ ] Edit `pkg/core/secretinlog_test.go` — ファイル末尾に追加:
+
+```go
+// TestSecretInLog_FunctionLocalScope_DetectsLeak は関数本体内で local 宣言された
+// 変数を echo すると leak として検出されることを検証する (#447 FN 修正)。
+func TestSecretInLog_FunctionLocalScope_DetectsLeak(t *testing.T) {
+	t.Parallel()
+
+	rule := NewSecretInLogRule()
+
+	envVars := map[string]*ast.EnvVar{
+		"secret": {
+			Name:  &ast.String{Value: "SECRET"},
+			Value: &ast.String{Value: "${{ secrets.GH_TOKEN }}"},
+		},
+	}
+	step := &ast.Step{
+		Env: &ast.Env{Vars: envVars},
+		Exec: &ast.ExecRun{
+			Run: &ast.String{Value: `leak() {
+  local SECRET_LOCAL="$SECRET"
+  echo "$SECRET_LOCAL"
+}
+leak`, Pos: &ast.Position{Line: 1, Col: 1}},
+		},
+	}
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got == 0 {
+		t.Fatalf("expected leak detection for SECRET_LOCAL inside function body, got 0 errors")
+	}
+}
+
+// TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent は subshell 内の
+// 上書きが親スコープの sink 検出に影響しないことを検証する (#447 FP/FN 防止)。
+func TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent(t *testing.T) {
+	t.Parallel()
+
+	rule := NewSecretInLogRule()
+
+	envVars := map[string]*ast.EnvVar{
+		"secret": {
+			Name:  &ast.String{Value: "SECRET"},
+			Value: &ast.String{Value: "${{ secrets.GH_TOKEN }}"},
+		},
+	}
+	step := &ast.Step{
+		Env: &ast.Env{Vars: envVars},
+		Exec: &ast.ExecRun{
+			Run: &ast.String{Value: `( SECRET="dummy" )
+echo "$SECRET"`, Pos: &ast.Position{Line: 1, Col: 1}},
+		},
+	}
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got == 0 {
+		t.Fatalf("expected leak detection for parent SECRET (subshell override should not affect parent)")
+	}
+}
+```
+
+### Step 2: 失敗確認
+
+- [ ] Run: `go test ./pkg/core/ -run 'TestSecretInLog_FunctionLocalScope_DetectsLeak|TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent' -v`
+- [ ] Expected: 1 つ目は FAIL (関数内 local の sink を `findEchoLeaks` が検出しない)、2 つ目は **既に PASS する可能性**あり (subshell 内の代入が親に漏れる現状でも、scoped でないので親の SECRET は env 由来 tainted のまま) — 実際の挙動を確認
+
+### Step 3: `findEchoLeaks` のシグネチャを `*shell.ScopedTaint` に変更
+
+- [ ] Edit `pkg/core/secretinlog.go:71-110` — `findEchoLeaks` を以下に置き換え:
+
+```go
+func (rule *SecretInLogRule) findEchoLeaks(file *syntax.File, scoped *shell.ScopedTaint, script string, runStr *ast.String) []echoLeakOccurrence {
+	if file == nil {
+		return nil
+	}
+	var leaks []echoLeakOccurrence
+	// currentVisible は最後に visit した *syntax.Stmt の visible map。
+	// 内側の CallExpr などは同じ stmt スコープにいるため、これを使って lookup する。
+	var currentVisible map[string]shell.Entry
+
+	syntax.Walk(file, func(node syntax.Node) bool {
+		// コマンド置換の内部は stdout がパイプに接続されるため、
+		// echo/printf の出力はビルドログには現れない。子ノードの探索をスキップする。
+		if _, isCmdSubst := node.(*syntax.CmdSubst); isCmdSubst {
+			return false
+		}
+		if stmt, isStmt := node.(*syntax.Stmt); isStmt {
+			// stdout を「ログに出ない先」へリダイレクトしている Stmt は子ノードごとスキップ。
+			if stmtRedirectsStdoutAwayFromLog(stmt) {
+				return false
+			}
+			currentVisible = scoped.At(stmt)
+			// cat / tee / dd の here-string (<<<) や heredoc (<<) を経由した
+			// 漏洩は Stmt の Redirs 側に taint があるため、ここで検査する。
+			rule.collectRedirectSinkLeaks(stmt, currentVisible, script, runStr, &leaks)
+			return true
+		}
+		call, ok := node.(*syntax.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		cmdName := firstWordLiteral(call.Args[0])
+		if cmdName != "echo" && cmdName != "printf" {
+			return true
+		}
+		if cmdName == "printf" && len(call.Args) >= 2 && firstWordLiteral(call.Args[1]) == "-v" {
+			return true
+		}
+		for _, arg := range call.Args[1:] {
+			rule.collectLeakedVars(arg, currentVisible, script, runStr, cmdName, &leaks)
+		}
+		return true
+	})
+	return leaks
+}
+```
+
+### Step 4: `collectGitHubEnvTaintWrites` も scoped 化
+
+- [ ] Edit `pkg/core/secretinlog.go:669-704` — `collectGitHubEnvTaintWrites` を以下に置き換え:
+
+```go
+func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
+	file *syntax.File,
+	scoped *shell.ScopedTaint,
+	script string,
+) map[string]string {
+	result := make(map[string]string)
+	if file == nil {
+		return result
+	}
+	syntax.Walk(file, func(node syntax.Node) bool {
+		stmt, ok := node.(*syntax.Stmt)
+		if !ok {
+			return true
+		}
+		if !stmtRedirectsToGitHubEnv(stmt) {
+			return true
+		}
+		call, ok := stmt.Cmd.(*syntax.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		visible := scoped.At(stmt)
+		cmdName := firstWordLiteral(call.Args[0])
+		switch cmdName {
+		case "echo", "printf":
+			rule.collectEchoEnvWrites(call, visible, result)
+		case "cat", "tee", "dd":
+			rule.collectHeredocEnvWrites(stmt, visible, script, result)
+		}
+		return true
+	})
+	return result
+}
+```
+
+### Step 5: caller (`AnalyzeStep` 相当部分 L398-409) を更新
+
+- [ ] Edit `pkg/core/secretinlog.go:398-409` — Task 1 で書いた:
+
+```go
+	scoped := shell.PropagateTaint(file, initialTainted)
+	tainted := scoped.Final
+	leaks := rule.findEchoLeaks(file, tainted, script, execRun.Run)
+	for _, leak := range leaks {
+		rule.reportLeak(leak)
+		rule.addAutoFixerForLeak(step, leak)
+	}
+	for name, origin := range rule.collectGitHubEnvTaintWrites(file, tainted, script) {
+		rule.crossStepEnv[name] = origin
+	}
+```
+
+を以下に置き換え:
+
+```go
+	scoped := shell.PropagateTaint(file, initialTainted)
+	leaks := rule.findEchoLeaks(file, scoped, script, execRun.Run)
+	for _, leak := range leaks {
+		rule.reportLeak(leak)
+		rule.addAutoFixerForLeak(step, leak)
+	}
+	// 後続 step の crossStepEnv に伝播させる。
+	for name, origin := range rule.collectGitHubEnvTaintWrites(file, scoped, script) {
+		rule.crossStepEnv[name] = origin
+	}
+```
+
+注: secretinlog.go は `expandShellvarMarkers` を呼ばない (autofix が `shellvar:X` 形式を必要とするため、§5.2 spec 参照)。`scoped.At()` の戻り値はそのまま渡す。
+
+### Step 6: テスト pass 確認
+
+- [ ] Run: `go test ./pkg/core/ -run 'TestSecretInLog' -v`
+- [ ] Expected: 全 pass (新規 2 ケース含む、既存 secretinlog テストの回帰なし)
+- [ ] Run: `go test ./pkg/core/...`
+- [ ] Expected: 全 pass
+
+### Step 7: Commit
+
+- [ ] Run:
+```bash
+git add pkg/core/secretinlog.go pkg/core/secretinlog_test.go
+git commit -m "$(cat <<'EOF'
+feat(taint): #447 SecretInLog を scope-aware lookup に統合
+
+findEchoLeaks と collectGitHubEnvTaintWrites を *shell.ScopedTaint
+受け取りに変更し、各 *syntax.Stmt の入口で scoped.At() を取って per-stmt
+visible map で sink 判定する。関数本体内 local 変数の echo / subshell 内
+書き込みの取扱いを正しくし、FN 修正と FP 抑制を両立。
+
+shellvar:X マーカーは autofix が変数アサイン直後への ::add-mask:: 挿入
+判定に使うため、secretinlog 側では展開せずそのまま流す (taint.go 側の
+per-stmt 展開とは独立のポリシー、spec §5 参照)。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Workflow fixture 追加 + 手動動作確認
+
+**Files:**
+- Create: `script/actions/taint-scope-fp-safe.yaml`
+- Create: `script/actions/taint-scope-fn-vulnerable.yaml`
+- Modify: `script/README.md`
+
+### Step 1: FP 抑制 fixture を作成
+
+- [ ] Create `script/actions/taint-scope-fp-safe.yaml`:
+
+```yaml
+# このワークフローは sisakulint の TaintTracker シェルスコープ対応 (#447) の
+# False Positive 抑制を示すデモ。
+#
+# ( ... ) サブシェル内での変数上書きは親スコープに漏れない (bash 仕様)。
+# scoped TaintTracker はこれを正しく区別し、subshell 内の curl は "sanitized"
+# のみを参照、親の curl は依然として tainted な BODY を参照していると判定する。
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          BODY="${{ github.event.pull_request.body }}"
+          ( BODY="sanitized"; curl "https://api.example.com?q=$BODY" )
+          curl "https://api.example.com?q=$BODY"
+```
+
+### Step 2: FN 修正 fixture を作成
+
+- [ ] Create `script/actions/taint-scope-fn-vulnerable.yaml`:
+
+```yaml
+# このワークフローは sisakulint の TaintTracker シェルスコープ対応 (#447) の
+# False Negative 修正を示すデモ。
+#
+# 関数本体内で local 宣言された SECRET_LOCAL を echo するパターンは、scope-aware
+# な secret-in-log ルールが leak として検出する。
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          SECRET: ${{ secrets.GH_TOKEN }}
+        run: |
+          leak() {
+            local SECRET_LOCAL="$SECRET"
+            echo "$SECRET_LOCAL"
+          }
+          leak
+```
+
+### Step 3: `script/README.md` に追記
+
+- [ ] Run: `head -50 script/README.md` でフォーマット確認
+- [ ] Edit `script/README.md` — 該当セクション (例: "Examples by rule") に以下を追加:
+
+```markdown
+- `taint-scope-fp-safe.yaml` — TaintTracker scope-aware (#447): subshell 内の変数上書きが親スコープに漏れないことを示す
+- `taint-scope-fn-vulnerable.yaml` — TaintTracker scope-aware (#447): 関数本体内 local 変数の secret-in-log 検出を示す
+```
+
+### Step 4: 手動動作確認
+
+- [ ] Run: `go build -o /tmp/sisakulint ./cmd/sisakulint`
+- [ ] Run: `/tmp/sisakulint script/actions/taint-scope-fp-safe.yaml`
+- [ ] Expected: 親 curl の `$BODY` についての code-injection (medium または critical) 警告が出る。subshell 内 curl については適切に判定される
+- [ ] Run: `/tmp/sisakulint script/actions/taint-scope-fn-vulnerable.yaml`
+- [ ] Expected: 関数本体内 echo の SECRET_LOCAL について secret-in-log 警告が出る
+
+### Step 5: Commit
+
+- [ ] Run:
+```bash
+git add script/actions/taint-scope-fp-safe.yaml script/actions/taint-scope-fn-vulnerable.yaml script/README.md
+git commit -m "$(cat <<'EOF'
+test(taint): #447 scope-aware fixture 2 ファイルを追加
+
+taint-scope-fp-safe.yaml: subshell 内変数上書きの隔離を示す。
+taint-scope-fn-vulnerable.yaml: 関数本体内 local 変数の secret-in-log
+正検出を示す。script/README.md に追記。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: ドキュメント更新と TODO コメント削除
+
+**Files:**
+- Modify: `pkg/shell/taint.go` — `PropagateTaint` の docstring から旧 TODO 文言を削除
+- Modify: `CLAUDE.md` — TaintTracker の説明にスコープ対応の旨を追記
+
+### Step 1: 旧 TODO コメントを削除
+
+- [ ] Edit `pkg/shell/taint.go` — Task 4 で `PropagateTaint` の docstring を書き換え済み。念のため `grep -n '#447 で対応' pkg/shell/taint.go` で残存していないか確認
+- [ ] Run: `grep -n '#447 で対応\|スコープは無視' pkg/shell/taint.go`
+- [ ] Expected: 0 件 (Task 4 の置換でクリーンアップ済みのはず)
+
+### Step 2: `CLAUDE.md` の TaintTracker 説明を更新
+
+- [ ] Run: `grep -n 'taint analysis\|TaintTracker\|#446' CLAUDE.md | head`
+- [ ] Edit `CLAUDE.md` — `pkg/shell/taint.go` を扱うセクションを更新。具体的には #446 の項目に続けて以下を追加 (既存 `Taint analysis (#446)` の節の末尾あたり):
+
+```markdown
+- **Scope-aware propagation (#447)**: `shell.PropagateTaint` は scope frame stack ベースで walk し、`*syntax.Subshell` / `*syntax.CmdSubst` は entry 時に親 visible を snapshot copy して隔離、`*syntax.FuncDecl` 本体は parent への lookup chain で bash dynamic scoping を近似 (`local` / 装飾なし `declare` は本体ローカル、その他は簡略案 A により親に漏らさない)。戻り値は `*shell.ScopedTaint` で、`Final` (script 末尾の親スコープ) と `At(stmt)` (per-stmt visible) を持つ。`taint.go` は per-stmt 展開で `recordRedirWrite` に渡す。`secretinlog.go` は `shellvar:X` マーカーを autofix のため raw 保持する (展開しない)
+```
+
+### Step 3: 全テスト最終確認
+
+- [ ] Run: `go test ./...`
+- [ ] Expected: 全 pass
+
+### Step 4: lint / vet
+
+- [ ] Run: `go vet ./...`
+- [ ] Expected: 警告なし
+
+### Step 5: Commit
+
+- [ ] Run:
+```bash
+git add CLAUDE.md pkg/shell/taint.go
+git commit -m "$(cat <<'EOF'
+docs(taint): #447 CLAUDE.md と taint.go docstring を更新
+
+scope-aware な PropagateTaint の挙動と caller ごとの shellvar 展開
+ポリシー (taint.go: 展開、secretinlog.go: 保持) を CLAUDE.md に追記。
+旧 TODO コメントは Task 4 の docstring 書き換えで削除済み。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## 完了チェック
+
+- [ ] `pkg/shell/taint_test.go` — `TestPropagateTaint_Scoped` 13 ケース、`TestScopedTaint_At` 5 ケース、全 pass
+- [ ] `pkg/core/taint_test.go` — `TestTaintTracker_RedirWriteInSubshell` pass
+- [ ] `pkg/core/secretinlog_test.go` — `TestSecretInLog_FunctionLocalScope_DetectsLeak`, `TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent` pass
+- [ ] 既存テスト全 pass (回帰なし)
+- [ ] `script/actions/taint-scope-fp-safe.yaml` で親 curl の検出が観測できる
+- [ ] `script/actions/taint-scope-fn-vulnerable.yaml` で関数内 echo の secret-in-log 警告が出る
+- [ ] `pkg/shell/taint.go` の旧 TODO コメント (`#447 で対応`) が削除済み
+- [ ] `CLAUDE.md` に scope 対応の説明が追加済み
+- [ ] commit 履歴: 10 commits (Task 1-10)
+
+---
+
+## 後続作業 (本プラン外)
+
+- #448 (関数引数の taint 伝播) — 本 plan 完了後に着手可能
+- Pipeline / バックグラウンド `&` の subshell 化 — 必要であれば新規 issue 化
+- `shell.ScopedTaint.AtExpanded(stmt)` ヘルパ — caller 側展開の DRY 化候補

--- a/docs/superpowers/specs/2026-04-27-447-tainttracker-shell-scope-design.md
+++ b/docs/superpowers/specs/2026-04-27-447-tainttracker-shell-scope-design.md
@@ -1,0 +1,389 @@
+# #447: TaintTracker のシェルスコープ対応 (subshell / function / export / local) — 設計
+
+| 項目 | 内容 |
+| --- | --- |
+| Issue | [#447](https://github.com/sisaku-security/sisakulint/issues/447) |
+| 親 Epic | [#445](https://github.com/sisaku-security/sisakulint/issues/445) (TaintTracker AST 移行・拡張) |
+| 関連 / 後続 | #448 (関数引数 taint 伝播 — 本 issue が unblock) |
+| 前提 | #446 (TaintTracker AST 化) — マージ済み (commit `d3ab32a`) |
+| 工数目安 | 2-3 日 |
+| 作成日 | 2026-04-27 |
+
+---
+
+## 1. 背景と目的
+
+`pkg/shell/taint.go::PropagateTaint` は AST ベース化済み (#446) だが、スクリプト全体をフラットな単一名前空間として扱っており、以下のシェルスコープ意味論を区別しない:
+
+- サブシェル `( ... )` 内の代入は親に漏れない
+- `$(...)` (CmdSubst) も同様
+- `local` / `declare` 宣言は関数本体に閉じる
+- 関数本体内の sink (echo/printf/redir) は本体ローカルの変数も参照し得る
+
+結果として以下の FP / FN が発生する:
+
+```bash
+# FP: 親スコープの BODY は依然 tainted のはずだが、subshell 内の上書きが伝播してしまう
+BODY="${{ github.event.pull_request.body }}"
+( BODY="sanitized"; curl "https://example.com?q=$BODY" )
+curl "https://example.com?q=$BODY"  # ← 親では tainted のまま正しく検出されるべき
+
+# FN: 関数本体内の local SECRET が echo されているが、本体内 sink が捉えられていない
+foo() {
+  local SECRET="${{ secrets.GH_TOKEN }}"
+  echo "$SECRET"   # secret-in-log が leak と判定すべき
+}
+foo
+```
+
+本 spec は `pkg/shell/taint.go` にスコープスタックを導入し、両 caller (`pkg/core/taint.go`, `pkg/core/secretinlog.go`) を scope-aware に切り替える設計を定義する。
+
+## 2. ゴール / 非ゴール
+
+### ゴール
+
+- `pkg/shell/taint.go::PropagateTaint` をスコープ対応に拡張し、戻り値で per-Stmt の visible tainted set を返す
+- bash 準拠のスコープ semantics を実装:
+  - `( ... )` Subshell / `$(...)` CmdSubst — entry 時に親 visible を snapshot copy、内部代入は親に漏らさない
+  - 関数本体 — `local` / 装飾なし `declare` は本体ローカル、`declare -g` / `export` / `readonly` は親 frame に書く (※ 本 issue では関数の non-local 副作用は親に伝播させない簡略案 A を採用)
+- 両 caller (`taint.go`, `secretinlog.go`) を scope-aware lookup に書き換え
+- 上記 semantics を unit + integration テストで固定
+
+### 非ゴール (本 issue では扱わない)
+
+- 関数引数経由の taint 伝播 (`foo "$T"; foo() { echo "$1"; }`) — #448
+- パイプライン要素の subshell 化 / バックグラウンド `&` の subshell 化 — Q2 で別 issue 化
+- `unset X` による untaint
+- 関数の副作用 (関数本体内の non-local 代入) を呼び出し位置の親に伝播させること
+- workflow / job / file 境界をまたぐ taint — #392 / #432 / #433
+
+## 3. API 設計
+
+### 3.1 新しい型
+
+```go
+// pkg/shell/taint.go
+
+// ScopedTaint は scope-aware な taint propagation の結果。
+type ScopedTaint struct {
+    // Final は親スコープで script 末尾時点での tainted vars。
+    // 旧 PropagateTaint の戻り値と同形式。cross-step 伝播 (taint.go の
+    // GITHUB_OUTPUT 記録、step→step 連鎖の seed) で使う。
+    Final map[string]Entry
+
+    // visibleAt は AST 内の各 *syntax.Stmt 入口時点で「そのスコープから
+    // 見える tainted vars の union」を保持。sink 検出 (echo/printf, redir
+    // write) で「この位置でこの変数は tainted か?」のクエリに使う。
+    visibleAt map[*syntax.Stmt]map[string]Entry
+}
+
+// At は stmt の入口時点で見えている tainted set を返す。
+// stmt が nil または visibleAt に未登録の場合は Final を返す
+// (root scope sink のフォールバック)。
+func (s *ScopedTaint) At(stmt *syntax.Stmt) map[string]Entry
+```
+
+### 3.2 PropagateTaint シグネチャ変更
+
+```go
+// 旧: func PropagateTaint(file *syntax.File, initial map[string]Entry) map[string]Entry
+// 新:
+func PropagateTaint(file *syntax.File, initial map[string]Entry) *ScopedTaint
+```
+
+`file == nil` の場合は `&ScopedTaint{Final: maps.Clone(initial), visibleAt: nil}` を返す。
+
+### 3.3 内部データ構造 (PropagateTaint 内のローカル状態)
+
+```go
+type scopeKind int
+const (
+    scopeRoot scopeKind = iota  // スクリプトルート
+    scopeFunc                   // FuncDecl 本体
+    scopeSubshell               // ( ... )
+    scopeCmdSubst               // $(...)
+)
+
+type scopeFrame struct {
+    parent *scopeFrame   // bash dynamic scoping の lookup chain (function 用)
+    local  map[string]Entry
+    kind   scopeKind
+}
+```
+
+## 4. スコープ Semantics
+
+### 4.1 代入の書き込み先
+
+| 文脈 \ 代入形態 | `X=v` (None) | `local X=v` | `export X=v` | `readonly X=v` | `declare X=v` | `declare -g X=v` |
+|---|---|---|---|---|---|---|
+| **スクリプトルート** | root | root (※1) | root | root | root | root |
+| **`( ... )` Subshell 内** | subshell | subshell (※1) | subshell | subshell | subshell | subshell (※2) |
+| **`$(...)` CmdSubst 内** | cmdsubst | cmdsubst (※1) | cmdsubst | cmdsubst | cmdsubst | cmdsubst (※2) |
+| **FuncDecl 本体** | (簡略案 A: 無視 ※3) | **func 本体ローカル** | (簡略案 A: 無視 ※3) | (簡略案 A: 無視 ※3) | **func 本体ローカル** | (簡略案 A: 無視 ※3) |
+
+注:
+- (※1) ルートでの `local` は bash 実行時エラーだが、AST 解析では root に書く (FN 抑制側に倒す)
+- (※2) Subshell/CmdSubst 内の `declare -g` は技術的に subshell 内 global なので、結局 subshell frame 内に書かれるのと同じ。簡略化して subshell frame に書く
+- (※3) 簡略案 A: 関数本体内の non-local 代入を呼び出し位置の親 frame に **漏らさない**。関数の副作用伝播は #448 で扱う。本体内 sink の検出は visibleAt 経由で動作する
+
+### 4.2 `local -X` フラグ付き
+
+`local -r X=v`, `local -x X=v` 等のフラグはすべて **local 扱い** (frame ローカルに書く) で簡略化。`declare -g` のみ特別扱い (= 本体内代入なら親 frame ターゲットだが簡略案 A により無視)。
+
+### 4.3 変数参照の lookup chain
+
+| 現在の frame | lookup 順序 |
+|---|---|
+| **root** | root.local のみ |
+| **subshell / cmdsubst** | 自 frame.local のみ (entry 時に親 visible を snapshot コピー済み) |
+| **func 本体** | func.local → parent.visible() (再帰的に chain) |
+
+### 4.4 Subshell / CmdSubst の entry 時 snapshot
+
+```go
+// 入場時
+child := &scopeFrame{kind: scopeSubshell, parent: current}
+child.local = maps.Clone(current.visible())  // 浅コピーで親 visible を snapshot
+push(child)
+
+// 退場時
+pop()  // child を破棄、親の状態は不変
+```
+
+### 4.5 `visibleAt` の生成タイミング
+
+- 戦略: **eager snapshot at every `*syntax.Stmt`**
+- `syntax.Walk` のコールバック内で `*syntax.Stmt` ノード Pre-visit 時に `visibleAt[stmt] = maps.Clone(currentFrame.visible())`
+- 理由: シンプル＆caller 中立。GHA workflow 規模 (数十〜数百 stmt × 十数個 tainted) で性能・メモリとも問題なし
+
+```go
+func (f *scopeFrame) visible() map[string]Entry {
+    out := maps.Clone(f.local)
+    if f.kind == scopeFunc && f.parent != nil {
+        // function body は parent への chain lookup
+        for k, v := range f.parent.visible() {
+            if _, ok := out[k]; !ok {
+                out[k] = v
+            }
+        }
+    }
+    // subshell/cmdsubst は entry 時に snapshot 済みなので chain 不要
+    return out
+}
+```
+
+## 5. Caller 修正
+
+### 5.1 `pkg/core/taint.go` (`TaintTracker.AnalyzeStep`)
+
+**現状 (L226-241)**:
+
+```go
+t.taintedVars = shell.PropagateTaint(file, t.taintedVars)
+expandShellvarMarkers(t.taintedVars)
+for _, w := range shell.WalkRedirectWrites(file, "GITHUB_OUTPUT") {
+    t.recordRedirWrite(stepID, w, exprMap)
+}
+```
+
+**修正後**:
+
+```go
+scoped := shell.PropagateTaint(file, t.taintedVars)
+t.taintedVars = scoped.Final
+expandShellvarMarkers(t.taintedVars)  // Final 用 (将来の cross-step 直接参照に備え)
+
+for _, w := range shell.WalkRedirectWrites(file, "GITHUB_OUTPUT") {
+    visible := scoped.At(w.Stmt)
+    expanded := maps.Clone(visible)
+    expandShellvarMarkers(expanded)        // ★ per-stmt で展開してから recordRedirWrite に渡す
+    t.recordRedirWrite(stepID, w, exprMap, expanded)
+}
+```
+
+`recordRedirWrite` のシグネチャに `visible map[string]shell.Entry` を追加し、内部の `t.taintedVars` 参照 (L463-477) を `visible` で置き換え。
+
+**`expandShellvarMarkers` を per-stmt で適用する理由**:
+`recordRedirWrite` は最終的に `taintedOutputs` (cross-step に伝播する map) に sources を書き込む。`shellvar:X` マーカーはこの map に入ると次 step では解決不能になるため、必ず展開済みである必要がある。`scoped.At(stmt)` の戻り値は walker が生の `shellvar:X` を保持したまま返すので、caller 側で per-stmt にコピー＋展開する。`maps.Clone` の per-loop 呼び出しは GHA workflow 規模では実害なし。
+
+### 5.2 `pkg/core/secretinlog.go`
+
+**現状 (L398-399)**:
+
+```go
+tainted := shell.PropagateTaint(file, initialTainted)
+leaks := rule.findEchoLeaks(file, tainted, script, execRun.Run)
+```
+
+**修正後**:
+
+```go
+scoped := shell.PropagateTaint(file, initialTainted)
+leaks := rule.findEchoLeaks(file, scoped, script, execRun.Run)
+```
+
+`findEchoLeaks` のシグネチャを `(file, scoped *shell.ScopedTaint, ...)` に変更。内部で各 echo/printf stmt の位置から `scoped.At(stmt)` を取り、`WordReferencesEntry(arg, scoped.At(stmt))` で照合する。
+
+**`secretinlog.go` では `expandShellvarMarkers` を呼ばない**:
+`secretinlog.go` は origin の `shellvar:X` 形式を **意図的に保持** している (autofix が「変数 X のアサイン直後に `::add-mask::` を挿入」する判定に使うため、L440-475)。よって `scoped.At(stmt)` を直接渡す。`taint.go` 側の per-stmt 展開とは独立した方針。
+
+### 5.3 影響範囲
+
+`shell.PropagateTaint` の caller は以下の 3 箇所に閉じる:
+
+- `pkg/core/taint.go:229`
+- `pkg/core/secretinlog.go:398`
+- `pkg/shell/taint_test.go` (テスト群)
+
+外部公開はパッケージ内のみ。社外利用者なし。
+
+## 6. テスト設計
+
+### 6.1 `pkg/shell/taint_test.go` — ユニット (セマンティクス固定)
+
+`TestPropagateTaint_Scoped` を新設し、テーブル駆動で以下のケースを検証:
+
+| # | ケース名 | スクリプト (initial: `T` tainted) | Final | visibleAt (sink 位置) |
+|---|---|---|---|---|
+| 1 | subshell isolation (FP 抑制) | `X="$T"; ( X="safe"; cmd "$X" )` | `X` tainted | subshell 内 cmd: `X` snapshot で tainted (subshell 内代入は subshell frame のみ) |
+| 2 | subshell が親の tainted を見る | `X="$T"; ( cmd "$X" )` | `X` tainted | subshell 内 cmd: `X` visible |
+| 3 | cmdsubst isolation | `R=$(X="leaked"; echo "$X"); cmd "$X"` | `X` tainted (initial 維持), `R` は X 経由 tainted | cmdsubst 内 echo: `X="leaked"` subshell 限定 |
+| 4 | function local 隔離 | `foo() { local X="$T"; cmd "$X"; }; foo; cmd "$X"` | 親 `X` = tainted (initial 維持) | foo body 内 cmd: `X` local tainted; foo 後 cmd: 親 `X` tainted (initial) |
+| 5 | function 内 declare (Q4-B) | `foo() { declare X="$T"; cmd "$X"; }; foo` | 親 `X` 不変 | foo body cmd: `X` local |
+| 6 | function 内 declare -g | `foo() { declare -g X="$T"; }; foo; cmd "$X"` | 親 `X` 不変 (簡略案 A) | — |
+| 7 | function 内 export | `foo() { export X="$T"; }; cmd "$X"` | 親 `X` 不変 (簡略案 A) | — |
+| 8 | function 内 readonly | 同上 | 同上 | — |
+| 9 | nested subshell | `( X="$T"; ( cmd "$X" ) )` | `X` 不変 | 内側 cmd: `X` visible |
+| 10 | subshell 内 function 定義 | `( foo() { local X="$T"; cmd "$X"; }; foo )` | 不変 | foo body cmd: visible |
+| 11 | function 内 subshell | `foo() { local X="$T"; ( cmd "$X" ); }; foo` | 不変 | 内側 subshell cmd: `X` visible |
+| 12 | root scope の local (実行時エラーだが解析許容) | `local X="$T"; cmd "$X"` | `X` tainted (root 扱い) | cmd: `X` visible |
+| 13 | 既存挙動回帰 | `X="$T"; Y="$X"; cmd "$Y"` | `X`, `Y` tainted | cmd: 両方 visible |
+
+加えて以下の API 形状検証を追加:
+
+- `TestPropagateTaint_NilFile` — `file=nil` で `&ScopedTaint{Final: copy(initial), visibleAt: nil}` を返す
+- `TestScopedTaint_At_Fallback` — 未登録 stmt で `Final` を返す
+
+### 6.2 `pkg/core/secretinlog_test.go` — 統合 (caller 経由)
+
+最低 2 ケース追加:
+
+- `TestSecretInLog_FunctionLocalScope_DetectsLeak` — 関数本体内の `local SECRET=...; echo "$SECRET"` で leak 検出 (FN 修正)
+- `TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent` — `( SECRET="dummy" ); echo "$SECRET"` で「親の SECRET (env 由来 tainted) は subshell 内の上書きに影響されない」→ echo $SECRET は依然 leak 検出 (FP/FN 防止)
+
+### 6.3 `pkg/core/taint_test.go` — 統合
+
+最低 1 ケース追加:
+
+- `TestTaintTracker_RedirWriteInSubshell` — subshell 内の `echo "x=$T" >> $GITHUB_OUTPUT` で `T` tainted のとき output が tainted 記録される
+
+### 6.4 `script/actions/` — workflow fixture (ミニ C)
+
+2 ファイル新設:
+
+**`taint-scope-fp-safe.yaml`** — false positive 抑制を示す:
+
+```yaml
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          BODY="${{ github.event.pull_request.body }}"
+          ( BODY="sanitized"; curl "https://api.example.com?q=$BODY" )
+          curl "https://api.example.com?q=$BODY"  # 親スコープでは tainted のまま (検出されるべき)
+```
+
+**`taint-scope-fn-vulnerable.yaml`** — function 本体内 sink の正検出を示す:
+
+```yaml
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          SECRET: ${{ secrets.GH_TOKEN }}
+        run: |
+          leak() {
+            local SECRET_LOCAL="$SECRET"
+            echo "$SECRET_LOCAL"   # secret-in-log: leak 検出されるべき
+          }
+          leak
+```
+
+`script/README.md` に簡単な説明を追加。
+
+## 7. エッジケース
+
+| ケース | 方針 |
+|---|---|
+| **再帰関数** (`foo() { foo; }`) | 関数本体は walk 1 回のみ。再帰呼び出しは `*syntax.CallExpr` として通常の Stmt 扱い。簡略案 A により副作用は親に伝播しないので無限展開しない |
+| **匿名 subshell** in pipeline (`cmd1 \| (X=v; cmd2)`) | `*syntax.Subshell` 単体は検出。pipeline 要素全体の subshell 化は別 issue (Q2 で確認) |
+| **ネスト FuncDecl** (`foo() { bar() { local X=v; }; bar; }`) | scope chain で `bar` body の parent = `foo` body。`bar` の `local X` は bar 本体のみ |
+| **`function foo { ... }` Bash 構文** | mvdan.cc/sh の `*syntax.FuncDecl` で同じく扱う (Variant 違いだけ) → 透過処理 |
+| **`local`/`declare` を root で使う** | bash 実行時エラーだが、static 解析では root frame に書く (FN 抑制側) |
+| **`declare X` (値なし)** | `WalkAssignments` が `Value=nil` で返すので taint 伝播対象外 (現行通り) |
+| **`local -r X=v`, `local -x X=v` 等のフラグ付き** | すべて local 扱いに簡略化 |
+| **`export -f foo`** (関数 export) | 関数定義は変数 namespace に影響しないので無視 |
+| **`unset X`** | 簡略化のため無視 (既存 `PropagateTaint` も "untaint" しない方針)。別 issue 化候補 |
+| **Subshell 内 function 定義 → subshell 外で呼び出し** | bash 実挙動では subshell 内定義は外に漏れない。AST 上は関数定義あるが簡略案 A により副作用なし → 結果一致 |
+| **`PropagateTaint(file=nil, initial)`** | `&ScopedTaint{Final: maps.Clone(initial), visibleAt: nil}` を返す |
+| **`At(stmt=nil)`** | `Final` を返す (defensive) |
+| **`At(未登録 stmt)`** | `Final` を返す (root scope sink のフォールバック) |
+
+### 7.1 Order-aware Offset との整合
+
+既存の `Entry.Offset` (script 内バイトオフセット) は scope に依らずグローバル。subshell/function 本体内でも `*syntax.Stmt.Pos().Offset()` はファイル全体の絶対オフセット。よって現行の `secretinlog.go` の order-aware FP suppression (`entry.Offset < sinkOffset`) はそのまま有効。
+
+### 7.2 パフォーマンス
+
+- AST walk は O(N)
+- `visibleAt` snapshot は per-Stmt の `maps.Clone(visible)` → O(stmt数 × tainted数)
+- frame stack 深度は通常 ≤ 5 程度 (subshell ネスト + function 1 段)
+- GHA workflow 規模では実害なし
+
+## 8. 実装順序
+
+実装は次の順序で進める。各ステップでテストが通ることを確認 (TDD):
+
+1. **`pkg/shell/taint.go`** — `ScopedTaint` 型と `scopeFrame` 内部構造を追加
+2. **`pkg/shell/taint.go`** — `PropagateTaint` を scope-aware walker に書き換え (Subshell + CmdSubst の snapshot copy 動作のみ先に実装)
+3. **`pkg/shell/taint_test.go`** — Subshell / CmdSubst ケース (1, 2, 3, 9) のテスト追加・通す
+4. **`pkg/shell/taint.go`** — FuncDecl 本体の scope frame push/pop と lookup chain 追加 (簡略案 A)
+5. **`pkg/shell/taint_test.go`** — Function ケース (4-8, 10, 11) のテスト追加・通す
+6. **`pkg/shell/taint_test.go`** — Edge / API ケース (12, 13, NilFile, At fallback) 追加
+7. **`pkg/core/taint.go`** — `recordRedirWrite` のシグネチャ更新と caller 更新
+8. **`pkg/core/taint_test.go`** — `TestTaintTracker_RedirWriteInSubshell` 追加・通す
+9. **`pkg/core/secretinlog.go`** — `findEchoLeaks` を scope-aware に書き換え
+10. **`pkg/core/secretinlog_test.go`** — 統合ケース 2 件追加・通す
+11. **`script/actions/taint-scope-fp-safe.yaml`** + **`taint-scope-fn-vulnerable.yaml`** + `script/README.md` 更新
+12. 全テスト実行 (`go test ./...`) と `sisakulint script/actions/` で fixture 動作確認
+13. mutation test (#446 で導入) を再走させ survived 件数の変化を確認
+
+## 9. 受け入れ基準
+
+- [ ] `pkg/shell/taint_test.go` の新規 13+ ケースが緑
+- [ ] `pkg/core/taint_test.go` の新規 1 ケースが緑
+- [ ] `pkg/core/secretinlog_test.go` の新規 2 ケースが緑
+- [ ] 既存の全テストが緑 (回帰なし)
+- [ ] `sisakulint script/actions/taint-scope-fp-safe.yaml` で「subshell 内 curl」と「親 curl」の検出差が観測できる
+- [ ] `sisakulint script/actions/taint-scope-fn-vulnerable.yaml` で関数内 echo の leak が検出される
+- [ ] `pkg/shell/taint.go::PropagateTaint` の docstring から `// スコープは無視（subshell/function 内も親と同じ namespace ← #447 で対応）` の TODO コメントが削除されている
+- [ ] CLAUDE.md の TaintTracker 説明に scope 対応の旨を追記
+
+## 10. リスクと未対応項目
+
+- **関数の副作用伝播 (簡略案 A)**: 関数本体内の non-local 代入を親に漏らさないため、`X="${T}"; foo() { X=safe; }; foo; cmd "$X"` のような「sanitize する関数」が漏れる FP が残る。これは bash 実挙動では `X=safe` が global に書かれるため、本来 untaint すべきだが、`PropagateTaint` は untaint 自体しない設計なので影響は限定的。完全対応は #448 と合わせて検討
+- **関数本体は FuncDecl 出現位置で walk される (call-site context は反映されない)**: `foo() { echo "$X"; }; X="${T}"; foo` のように関数定義後に親 X が tainted 化されるケースで、foo body 内の echo の visibleAt は X が tainted **でない**状態で snapshot される (FN)。bash 実挙動では call site で X が visible だが、本 issue では cross-call-site 解析を扱わない。FN 影響は実用上限定的: 関数内で `local` / `declare` 宣言してから sink するケースは正検出される。完全対応は call-site lazy walk が必要で、#448 と合わせて再設計候補
+- **Pipeline / バックグラウンド `&` の subshell 化未対応**: Q2 でスコープ外。`cmd | (X=v; cmd2)` のような pipeline 内 subshell は単体検出されるが、`X=v | cmd` のような pipeline LHS の subshell 化は捉えない。FN 影響軽微なため別 issue 候補
+- **API シグネチャ変更**: `pkg/shell/taint.go::PropagateTaint` の戻り値変更により、外部利用者がいた場合は影響あり。社内利用のみなので問題なし、ドキュメントには明記
+- **`shellvar:X` マーカー展開ポリシーが caller ごとに違う**: `taint.go` は per-stmt で展開、`secretinlog.go` は展開しない (autofix のため raw 保持)。新たな caller を追加する際は §5 の方針を踏襲する必要があり、混乱リスクあり。`pkg/shell` 側で展開ヘルパ (`scoped.AtExpanded(stmt)` など) を将来的に追加する余地あり
+
+## 11. 後続作業
+
+- #448 (関数引数の taint 伝播) — 本 issue 完了後に着手可能
+- Pipeline / バックグラウンド subshell 化 — 必要であれば新規 issue 化
+- `unset X` による untaint — 別 issue 化検討

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -395,7 +395,8 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 		return // パース失敗時は解析をスキップ（他ルールの管轄）
 	}
 
-	tainted := shell.PropagateTaint(file, initialTainted)
+	scoped := shell.PropagateTaint(file, initialTainted)
+	tainted := scoped.Final
 	leaks := rule.findEchoLeaks(file, tainted, script, execRun.Run)
 
 	for _, leak := range leaks {

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -68,11 +68,14 @@ type echoLeakOccurrence struct {
 //
 // ただし `>&2` / `/dev/stderr` / `/dev/stdout` / `/dev/tty` への出力は GitHub Actions の
 // ビルドログに引き続き表示されるため、スキップ対象から除外する。
-func (rule *SecretInLogRule) findEchoLeaks(file *syntax.File, tainted map[string]shell.Entry, script string, runStr *ast.String) []echoLeakOccurrence {
+func (rule *SecretInLogRule) findEchoLeaks(file *syntax.File, scoped *shell.ScopedTaint, script string, runStr *ast.String) []echoLeakOccurrence {
 	if file == nil {
 		return nil
 	}
 	var leaks []echoLeakOccurrence
+	// currentVisible は最後に visit した *syntax.Stmt の visible map。
+	// 内側の CallExpr などは同じ stmt スコープにいるため、これを使って lookup する。
+	var currentVisible map[string]shell.Entry
 
 	syntax.Walk(file, func(node syntax.Node) bool {
 		// コマンド置換の内部は stdout がパイプに接続されるため、
@@ -85,9 +88,10 @@ func (rule *SecretInLogRule) findEchoLeaks(file *syntax.File, tainted map[string
 			if stmtRedirectsStdoutAwayFromLog(stmt) {
 				return false
 			}
+			currentVisible = scoped.At(stmt)
 			// cat / tee / dd の here-string (<<<) や heredoc (<<) を経由した
 			// 漏洩は Stmt の Redirs 側に taint があるため、ここで検査する。
-			rule.collectRedirectSinkLeaks(stmt, tainted, script, runStr, &leaks)
+			rule.collectRedirectSinkLeaks(stmt, currentVisible, script, runStr, &leaks)
 			return true
 		}
 		call, ok := node.(*syntax.CallExpr)
@@ -103,7 +107,7 @@ func (rule *SecretInLogRule) findEchoLeaks(file *syntax.File, tainted map[string
 			return true
 		}
 		for _, arg := range call.Args[1:] {
-			rule.collectLeakedVars(arg, tainted, script, runStr, cmdName, &leaks)
+			rule.collectLeakedVars(arg, currentVisible, script, runStr, cmdName, &leaks)
 		}
 		return true
 	})
@@ -396,8 +400,7 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 	}
 
 	scoped := shell.PropagateTaint(file, initialTainted)
-	tainted := scoped.Final
-	leaks := rule.findEchoLeaks(file, tainted, script, execRun.Run)
+	leaks := rule.findEchoLeaks(file, scoped, script, execRun.Run)
 
 	for _, leak := range leaks {
 		rule.reportLeak(leak)
@@ -406,7 +409,9 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 
 	// この step の $GITHUB_ENV 書き込みから tainted な env var を抽出し、
 	// 後続 step の crossStepEnv に伝播させる。
-	for name, origin := range rule.collectGitHubEnvTaintWrites(file, tainted, script) {
+	// shellvar:X マーカーは autofix が変数アサイン直後への ::add-mask:: 挿入
+	// 判定に使うため、ここでは展開せずそのまま流す (spec §5.2)。
+	for name, origin := range rule.collectGitHubEnvTaintWrites(file, scoped, script) {
 		rule.crossStepEnv[name] = origin
 	}
 }
@@ -669,7 +674,7 @@ func firstNameEqualsPrefix(word *syntax.Word) string {
 // 漏洩メッセージに表示される識別子（`secrets.X` or `shellvar:Y`）。
 func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
 	file *syntax.File,
-	tainted map[string]shell.Entry,
+	scoped *shell.ScopedTaint,
 	script string,
 ) map[string]string {
 	result := make(map[string]string)
@@ -688,16 +693,17 @@ func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
 		if !ok || len(call.Args) == 0 {
 			return true
 		}
+		visible := scoped.At(stmt)
 		cmdName := firstWordLiteral(call.Args[0])
 		switch cmdName {
 		case "echo", "printf":
-			rule.collectEchoEnvWrites(call, tainted, result)
+			rule.collectEchoEnvWrites(call, visible, result)
 		case "cat", "tee", "dd":
 			// heredoc 経由で `>> $GITHUB_ENV` に流し込むパターン。
 			// tee/dd も stdin を受け取って stdout（もしくは file 引数）に流すので
 			// `cmd <<EOF >> $GITHUB_ENV ... EOF` 形式で taint を書き込みうる。
 			// sink 検出側 (collectRedirectSinkLeaks) との対称性を保つ。
-			rule.collectHeredocEnvWrites(stmt, tainted, script, result)
+			rule.collectHeredocEnvWrites(stmt, visible, script, result)
 		}
 		return true
 	})

--- a/pkg/core/secretinlog_test.go
+++ b/pkg/core/secretinlog_test.go
@@ -114,7 +114,11 @@ echo "Value: $TOKEN"
 			rule := NewSecretInLogRule()
 			file := parseShellForTest(t, tc.script)
 			runStr := &ast.String{Value: tc.script, Pos: &ast.Position{Line: 1, Col: 1}}
-			got := rule.findEchoLeaks(file, tc.tainted, tc.script, runStr)
+			// findEchoLeaks は scope-aware に *shell.ScopedTaint を受ける。
+			// テスト用 seed (tc.tainted) を初期 taint として PropagateTaint で
+			// スコープ付き taint set を構築する。
+			scoped := shell.PropagateTaint(file, tc.tainted)
+			got := rule.findEchoLeaks(file, scoped, tc.script, runStr)
 			if len(got) != len(tc.wantHits) {
 				t.Fatalf("found %d leaks, want %d. got=%v", len(got), len(tc.wantHits), got)
 			}
@@ -232,6 +236,69 @@ func TestSecretInLog_VisitJob_Integration(t *testing.T) {
 				t.Errorf("errors = %d, want %d. details=%v", got, tc.wantErrors, rule.Errors())
 			}
 		})
+	}
+}
+
+// TestSecretInLog_FunctionLocalScope_DetectsLeak は関数本体内で local 宣言された
+// 変数を echo すると leak として検出されることを検証する (#447 FN 修正)。
+func TestSecretInLog_FunctionLocalScope_DetectsLeak(t *testing.T) {
+	t.Parallel()
+
+	rule := NewSecretInLogRule()
+
+	envVars := map[string]*ast.EnvVar{
+		"secret": {
+			Name:  &ast.String{Value: "SECRET"},
+			Value: &ast.String{Value: "${{ secrets.GH_TOKEN }}"},
+		},
+	}
+	step := &ast.Step{
+		Env: &ast.Env{Vars: envVars},
+		Exec: &ast.ExecRun{
+			Run: &ast.String{Value: `leak() {
+  local SECRET_LOCAL="$SECRET"
+  echo "$SECRET_LOCAL"
+}
+leak`, Pos: &ast.Position{Line: 1, Col: 1}},
+		},
+	}
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got == 0 {
+		t.Fatalf("expected leak detection for SECRET_LOCAL inside function body, got 0 errors")
+	}
+}
+
+// TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent は subshell 内の
+// 上書きが親スコープの sink 検出に影響しないことを検証する (#447 FP/FN 防止)。
+func TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent(t *testing.T) {
+	t.Parallel()
+
+	rule := NewSecretInLogRule()
+
+	envVars := map[string]*ast.EnvVar{
+		"secret": {
+			Name:  &ast.String{Value: "SECRET"},
+			Value: &ast.String{Value: "${{ secrets.GH_TOKEN }}"},
+		},
+	}
+	step := &ast.Step{
+		Env: &ast.Env{Vars: envVars},
+		Exec: &ast.ExecRun{
+			Run: &ast.String{Value: `( SECRET="dummy" )
+echo "$SECRET"`, Pos: &ast.Position{Line: 1, Col: 1}},
+		},
+	}
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got == 0 {
+		t.Fatalf("expected leak detection for parent SECRET (subshell override should not affect parent)")
 	}
 }
 

--- a/pkg/core/taint.go
+++ b/pkg/core/taint.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -234,11 +235,19 @@ func (t *TaintTracker) AnalyzeStep(step *ast.Step) {
 	// markers; taint.go callers expect transitive source lists for richer
 	// reporting (e.g. trace back to "github.event.issue.title"). Expand the
 	// markers in place. Bounded passes guard against pathological chains.
-	// (NOTE: scope-aware per-stmt expansion is added in Task 10)
 
-	// GITHUB_OUTPUT writes
+	// GITHUB_OUTPUT writes — scope-aware per-stmt visible map で recordRedirWrite。
+	// scoped.At(stmt) は subshell / func body 内の代入も正しく可視化する。
+	// shellvar:X マーカーは cross-step 伝播される taintedOutputs に残せないので、
+	// per-stmt のクローンを expandShellvarMarkers してから渡す。
 	for _, w := range shell.WalkRedirectWrites(file, "GITHUB_OUTPUT") {
-		t.recordRedirWrite(stepID, w, exprMap)
+		visible := scoped.At(w.Stmt)
+		expanded := maps.Clone(visible)
+		if expanded == nil {
+			expanded = make(map[string]shell.Entry)
+		}
+		expandShellvarMarkers(expanded)
+		t.recordRedirWrite(stepID, w, exprMap, expanded)
 	}
 }
 
@@ -457,14 +466,16 @@ func mergeUnique(dst, src []string) []string {
 
 // recordRedirWrite は WalkRedirectWrites の結果をもとに taintedOutputs に記録する。
 // VALUE 内に直接 untrusted 式（プレースホルダ経由を含む）があるか、または
-// tainted 変数を参照していれば、その output を tainted として登録する。
-func (t *TaintTracker) recordRedirWrite(stepID string, w shell.RedirWrite, exprMap map[string]string) {
+// visible 内の tainted 変数を参照していれば、その output を tainted として登録する。
+//
+// visible は scope-aware な per-stmt visible map (caller で展開済み)。
+func (t *TaintTracker) recordRedirWrite(stepID string, w shell.RedirWrite, exprMap map[string]string, visible map[string]shell.Entry) {
 	sources := t.collectExpressionSources(w.Value, exprMap)
 
-	// VALUE 内の $VAR 参照を tainted vars と照合
+	// VALUE 内の $VAR 参照を visible と照合
 	if w.ValueWord != nil {
-		if name, ok := shell.WordReferencesEntry(w.ValueWord, t.taintedVars); ok {
-			sources = mergeUnique(sources, t.taintedVars[name].Sources)
+		if name, ok := shell.WordReferencesEntry(w.ValueWord, visible); ok {
+			sources = mergeUnique(sources, visible[name].Sources)
 		}
 	} else {
 		// heredoc 等で ValueWord が無い場合は文字列ベースで $VAR を検出
@@ -473,7 +484,7 @@ func (t *TaintTracker) recordRedirWrite(stepID string, w shell.RedirWrite, exprM
 			if len(m) < 2 {
 				continue
 			}
-			if entry, ok := t.taintedVars[m[1]]; ok {
+			if entry, ok := visible[m[1]]; ok {
 				sources = mergeUnique(sources, entry.Sources)
 			}
 		}

--- a/pkg/core/taint.go
+++ b/pkg/core/taint.go
@@ -226,13 +226,15 @@ func (t *TaintTracker) AnalyzeStep(step *ast.Step) {
 	t.seedTaintFromExpressions(file, exprMap)
 
 	// Forward dataflow with order-aware Offset
-	t.taintedVars = shell.PropagateTaint(file, t.taintedVars)
+	scoped := shell.PropagateTaint(file, t.taintedVars)
+	t.taintedVars = scoped.Final
+	expandShellvarMarkers(t.taintedVars)
 
 	// shell.PropagateTaint marks derived variables with "shellvar:X" chain
 	// markers; taint.go callers expect transitive source lists for richer
 	// reporting (e.g. trace back to "github.event.issue.title"). Expand the
 	// markers in place. Bounded passes guard against pathological chains.
-	expandShellvarMarkers(t.taintedVars)
+	// (NOTE: scope-aware per-stmt expansion is added in Task 10)
 
 	// GITHUB_OUTPUT writes
 	for _, w := range shell.WalkRedirectWrites(file, "GITHUB_OUTPUT") {

--- a/pkg/core/taint_test.go
+++ b/pkg/core/taint_test.go
@@ -1089,3 +1089,52 @@ echo "out=$X" >> $GITHUB_OUTPUT`},
 		t.Errorf("taint should still trace to github.event.issue.title, got: %v", sources)
 	}
 }
+
+// TestTaintTracker_RedirWriteInSubshell は subshell 内の `>> $GITHUB_OUTPUT`
+// 書き込みで scope-aware な per-stmt visible map が参照されることを検証する (#447)。
+//
+// このテストは shell-var 経由の派生 taint で discriminating を担保する:
+//   - 親スコープで U="${{ ... }}" を seed (parent frame に taint)
+//   - subshell で T="$U" を実行 → T は subshell frame でのみ tainted
+//   - subshell 内の `>> $GITHUB_OUTPUT` で T を参照
+//
+// 親スコープの Final には T は escape しない (subshell scope で消える)。
+// 旧実装の recordRedirWrite は Final を見て T を tainted と認識できず
+// output 'out' が tainted として登録されない。
+// 新実装は per-stmt visible map (subshell frame で T tainted) を参照し、
+// 'out' を tainted として正しく検出する。
+func TestTaintTracker_RedirWriteInSubshell(t *testing.T) {
+	t.Parallel()
+
+	step := makeBPatternRunStep("leak", `U="${{ github.event.issue.body }}"
+( T="$U"; echo "out=$T" >> $GITHUB_OUTPUT )`)
+
+	tracker := NewTaintTracker()
+	tracker.AnalyzeStep(step)
+
+	outputs := tracker.GetTaintedOutputs()
+	stepOutputs, ok := outputs["leak"]
+	if !ok {
+		t.Fatalf("step %q should have tainted outputs, got %v", "leak", outputs)
+	}
+	srcs, ok := stepOutputs["out"]
+	if !ok {
+		keys := make([]string, 0, len(stepOutputs))
+		for k := range stepOutputs {
+			keys = append(keys, k)
+		}
+		t.Fatalf("output %q should be tainted, got keys %v", "out", keys)
+	}
+	foundOrigin := false
+	for _, s := range srcs {
+		if strings.Contains(s, "github.event.issue.body") {
+			foundOrigin = true
+		}
+		if strings.HasPrefix(s, "shellvar:") {
+			t.Errorf("unresolved shellvar marker survived expansion: %q (sources=%v)", s, srcs)
+		}
+	}
+	if !foundOrigin {
+		t.Errorf("output sources should reference github.event.issue.body, got %v", srcs)
+	}
+}

--- a/pkg/shell/taint.go
+++ b/pkg/shell/taint.go
@@ -328,7 +328,7 @@ func makeWalkFn(current **scopeFrame, result *ScopedTaint) func(syntax.Node) boo
 			}
 			return false
 		case *syntax.Assign:
-			processAssign(*current, n, AssignNone)
+			processAssign(*current, n)
 			return true
 		}
 		return true
@@ -337,11 +337,10 @@ func makeWalkFn(current **scopeFrame, result *ScopedTaint) func(syntax.Node) boo
 
 // processAssign は単純代入 X=Y を current frame に書き込む。
 // 既に tainted な変数の上書きはしない (最初の taint を保持)。
-func processAssign(current *scopeFrame, a *syntax.Assign, kw AssignKeyword) {
+func processAssign(current *scopeFrame, a *syntax.Assign) {
 	if a == nil || a.Name == nil {
 		return
 	}
-	_ = kw // kw は processDeclClause で参照済み。processAssign 自体は kw を使わない (将来の拡張用に残す)
 	name := a.Name.Value
 	if _, already := current.local[name]; already {
 		return
@@ -384,7 +383,7 @@ func processDeclClause(current *scopeFrame, decl *syntax.DeclClause) {
 	}
 
 	for _, a := range decl.Args {
-		processAssign(current, a, kw)
+		processAssign(current, a)
 	}
 }
 
@@ -408,24 +407,6 @@ func declHasGlobalFlag(decl *syntax.DeclClause) bool {
 		}
 	}
 	return false
-}
-
-// dedupAppend は順序保持で重複なしの append。
-// 既存 pkg/core/taint.go の deduplicateStrings と同等。
-func dedupAppend(dst []string, items ...string) []string {
-	seen := make(map[string]struct{}, len(dst)+len(items))
-	for _, s := range dst {
-		seen[s] = struct{}{}
-	}
-	out := dst
-	for _, s := range items {
-		if _, ok := seen[s]; ok {
-			continue
-		}
-		seen[s] = struct{}{}
-		out = append(out, s)
-	}
-	return out
 }
 
 // WalkRedirectWrites は `>> $TARGET` または `> $TARGET` リダイレクトを持つ Stmt を探し、

--- a/pkg/shell/taint.go
+++ b/pkg/shell/taint.go
@@ -40,6 +40,36 @@ func (e Entry) First() string {
 	return e.Sources[0]
 }
 
+// ScopedTaint は scope-aware な taint propagation の結果。
+//
+// Final はスクリプト末尾時点で親スコープから見える tainted vars。
+// 旧 PropagateTaint の戻り値と同じ形。cross-step 伝播 (taint.go の
+// $GITHUB_OUTPUT 記録、secretinlog.go の crossStepEnv 構築) で使う。
+//
+// visibleAt は AST 内の各 *syntax.Stmt 入口時点で「そのスコープから
+// 見える tainted vars の union」を保持。sink 検出で「この位置でこの
+// 変数は tainted か?」のクエリに使う。直接アクセスせず At() を経由する。
+type ScopedTaint struct {
+	Final     map[string]Entry
+	visibleAt map[*syntax.Stmt]map[string]Entry
+}
+
+// At は stmt の入口時点で見えている tainted set を返す。
+// stmt が nil または visibleAt に未登録の場合は Final を返す
+// (root scope sink のフォールバック)。
+func (s *ScopedTaint) At(stmt *syntax.Stmt) map[string]Entry {
+	if s == nil {
+		return nil
+	}
+	if stmt == nil {
+		return s.Final
+	}
+	if v, ok := s.visibleAt[stmt]; ok {
+		return v
+	}
+	return s.Final
+}
+
 // AssignKeyword は代入文に付随する宣言キーワード。
 type AssignKeyword int
 
@@ -170,34 +200,44 @@ func WordReferencesEntry(word *syntax.Word, tainted map[string]Entry) (string, b
 }
 
 // PropagateTaint は initial を seed として AST を順方向 1 パス walk し、
-// 代入の RHS が tainted な変数を参照していれば LHS を tainted に追加する。
+// scope-aware に taint を伝播する。
 //
 // セマンティクス:
 //   - 既に tainted な変数への再代入は origin/Offset を上書きしない（最初の taint を保持）
 //   - LHS 名は AST 順序で処理される（forward dataflow）
 //   - 代入の RHS が tainted を参照しない場合は LHS に何もしない（"untaint" はしない）
-//   - スコープは無視（subshell/function 内も親と同じ namespace ← #447 で対応）
+//   - スコープ:
+//     - *syntax.Subshell `( ... )` と *syntax.CmdSubst `$(...)` は entry 時に
+//       親 visible を snapshot copy して隔離。内部代入は親に漏れない
+//     - *syntax.FuncDecl 本体は parent への lookup chain で bash dynamic scoping を
+//       近似。`local` / 装飾なし `declare` は本体ローカル、その他の代入は本 issue の
+//       簡略案 A により親に漏らさない (#448 で改善予定)
 //
-// 戻り値は initial を変更せず新しい map を返す。
-func PropagateTaint(file *syntax.File, initial map[string]Entry) map[string]Entry {
-	result := make(map[string]Entry, len(initial))
-	maps.Copy(result, initial)
+// 戻り値は initial を変更せず新しい *ScopedTaint を返す。
+func PropagateTaint(file *syntax.File, initial map[string]Entry) *ScopedTaint {
+	result := &ScopedTaint{
+		Final:     make(map[string]Entry, len(initial)),
+		visibleAt: make(map[*syntax.Stmt]map[string]Entry),
+	}
+	maps.Copy(result.Final, initial)
 	if file == nil {
 		return result
 	}
 
+	// 暫定実装: 旧フラット動作で Final を埋める。
+	// Task 2 以降でスコープ対応に置き換える。
 	for _, a := range WalkAssignments(file) {
-		if _, already := result[a.Name]; already {
+		if _, already := result.Final[a.Name]; already {
 			continue
 		}
 		if a.Value == nil {
 			continue
 		}
-		refName, found := WordReferencesEntry(a.Value, result)
+		refName, found := WordReferencesEntry(a.Value, result.Final)
 		if !found {
 			continue
 		}
-		result[a.Name] = Entry{
+		result.Final[a.Name] = Entry{
 			Sources: []string{"shellvar:" + refName},
 			Offset:  a.Offset,
 		}

--- a/pkg/shell/taint.go
+++ b/pkg/shell/taint.go
@@ -311,7 +311,15 @@ func makeWalkFn(current **scopeFrame, result *ScopedTaint) func(syntax.Node) boo
 			return true
 		case *syntax.DeclClause:
 			processDeclClause(*current, n)
-			return false // children は処理済み (二重カウント防止)
+			// RHS Words (Args.Value) を別途 walk して、入れ子の Subshell / CmdSubst が
+			// scope frame を push し、内側 Stmt が visibleAt を記録できるようにする。
+			// Args.Name は Lit のみで taint semantics を持たないので skip。
+			for _, a := range n.Args {
+				if a.Value != nil {
+					syntax.Walk(a.Value, makeWalkFn(current, result))
+				}
+			}
+			return false
 		case *syntax.Assign:
 			processAssign(*current, n, AssignNone)
 			return true

--- a/pkg/shell/taint.go
+++ b/pkg/shell/taint.go
@@ -303,7 +303,14 @@ func makeWalkFn(current **scopeFrame, result *ScopedTaint) func(syntax.Node) boo
 			*current = (*current).parent
 			return false
 		case *syntax.FuncDecl:
-			// 関数本体の処理は Task 4 で実装
+			if n.Body == nil {
+				return false
+			}
+			child := &scopeFrame{kind: scopeFunc, parent: *current, local: make(map[string]Entry)}
+			prev := *current
+			*current = child
+			syntax.Walk(n.Body, makeWalkFn(current, result))
+			*current = prev
 			return false
 		case *syntax.Stmt:
 			// 各 Stmt 入口で visibleAt を記録
@@ -354,13 +361,22 @@ func processAssign(current *scopeFrame, a *syntax.Assign, kw AssignKeyword) {
 }
 
 // processDeclClause は DeclClause (export X=Y / local X=Y / readonly X=Y / declare X=Y) を処理する。
-// keyword に応じた scope target は Task 6/7 で実装。本 Task では全部 current frame に書く
-// (Subshell/CmdSubst では結果同じ、FuncDecl 内は Task 5/6/7 で再分岐する)。
+// セマンティクス (#447):
+//   - local: 常に current frame に書く (FuncDecl 内なら本体ローカル、root なら root ※bash エラーだが解析許容)
+//   - declare (装飾なし): FuncDecl 内なら current frame、それ以外なら current frame に書く (Task 5 で declare -g 対応)
+//   - export / readonly: FuncDecl 内では簡略案 A により無視 (親に漏らさない)、それ以外なら current frame に書く
 func processDeclClause(current *scopeFrame, decl *syntax.DeclClause) {
 	if decl == nil {
 		return
 	}
 	kw := keywordFor(decl.Variant.Value)
+
+	// FuncDecl 内で export / readonly は簡略案 A により無視 (親に漏らさない)
+	if current.kind == scopeFunc && (kw == AssignExport || kw == AssignReadonly) {
+		return
+	}
+	// declare -g の判定は Task 5 で追加。本 Task では declare は current frame に書く
+
 	for _, a := range decl.Args {
 		processAssign(current, a, kw)
 	}

--- a/pkg/shell/taint.go
+++ b/pkg/shell/taint.go
@@ -341,7 +341,7 @@ func processAssign(current *scopeFrame, a *syntax.Assign, kw AssignKeyword) {
 	if a == nil || a.Name == nil {
 		return
 	}
-	_ = kw // Task 5/6/7 で `local` / `declare -g` の振り分けに利用予定
+	_ = kw // kw は processDeclClause で参照済み。processAssign 自体は kw を使わない (将来の拡張用に残す)
 	name := a.Name.Value
 	if _, already := current.local[name]; already {
 		return
@@ -360,26 +360,54 @@ func processAssign(current *scopeFrame, a *syntax.Assign, kw AssignKeyword) {
 	}
 }
 
-// processDeclClause は DeclClause (export X=Y / local X=Y / readonly X=Y / declare X=Y) を処理する。
+// processDeclClause は DeclClause を処理する。
 // セマンティクス (#447):
-//   - local: 常に current frame に書く (FuncDecl 内なら本体ローカル、root なら root ※bash エラーだが解析許容)
-//   - declare (装飾なし): FuncDecl 内なら current frame、それ以外なら current frame に書く (Task 5 で declare -g 対応)
-//   - export / readonly: FuncDecl 内では簡略案 A により無視 (親に漏らさない)、それ以外なら current frame に書く
+//   - local: 常に current frame に書く
+//   - declare / typeset (装飾なし): current frame に書く (FuncDecl 内なら本体ローカル)
+//   - declare -g (グローバル指定): FuncDecl 内では簡略案 A により無視
+//   - export / readonly: FuncDecl 内では簡略案 A により無視、それ以外なら current frame に書く
 func processDeclClause(current *scopeFrame, decl *syntax.DeclClause) {
 	if decl == nil {
 		return
 	}
 	kw := keywordFor(decl.Variant.Value)
 
-	// FuncDecl 内で export / readonly は簡略案 A により無視 (親に漏らさない)
-	if current.kind == scopeFunc && (kw == AssignExport || kw == AssignReadonly) {
-		return
+	if current.kind == scopeFunc {
+		// FuncDecl 内で export / readonly は簡略案 A により無視
+		if kw == AssignExport || kw == AssignReadonly {
+			return
+		}
+		// declare -g も簡略案 A により無視
+		if kw == AssignDeclare && declHasGlobalFlag(decl) {
+			return
+		}
 	}
-	// declare -g の判定は Task 5 で追加。本 Task では declare は current frame に書く
 
 	for _, a := range decl.Args {
 		processAssign(current, a, kw)
 	}
+}
+
+// declHasGlobalFlag は DeclClause に -g (global) フラグが付いているか判定する。
+//
+// mvdan/sh では `declare -g X="$T"` のフラグは `*syntax.Assign{Name: nil,
+// Value: Word{Parts: [Lit{Value: "-g"}]}}` として表現される (Name は代入の
+// 左辺名なので、フラグでは nil)。代入 args は Name != nil 側にある。
+// したがって Name == nil かつ Value Word の先頭 Lit が `-` で始まり 'g' を
+// 含むものを探す。これで `-g` / `-gA` / `-Ag` 等を正しく検出できる
+// (bash semantics: 単一のフラグ束に 'g' が含まれていれば global)。
+func declHasGlobalFlag(decl *syntax.DeclClause) bool {
+	for _, a := range decl.Args {
+		if a == nil || a.Name != nil {
+			// Name != nil は代入 (X=v) なのでフラグではない
+			continue
+		}
+		flag := wordLitPrefix(a.Value)
+		if strings.HasPrefix(flag, "-") && strings.ContainsRune(flag, 'g') {
+			return true
+		}
+	}
+	return false
 }
 
 // dedupAppend は順序保持で重複なしの append。

--- a/pkg/shell/taint.go
+++ b/pkg/shell/taint.go
@@ -199,6 +199,47 @@ func WordReferencesEntry(word *syntax.Word, tainted map[string]Entry) (string, b
 	return foundName, found
 }
 
+// scopeKind は scope frame の種別。
+type scopeKind int
+
+const (
+	scopeRoot     scopeKind = iota // スクリプトルート
+	scopeFunc                      // FuncDecl 本体
+	scopeSubshell                  // ( ... )
+	scopeCmdSubst                  // $(...)
+)
+
+// scopeFrame は scope-aware walker のスタック要素。
+//
+// local はこの frame で局所宣言された tainted vars。
+// parent は lookup chain (function 用) または nil (root)。
+// subshell/cmdsubst frame は entry 時に親の visible を local に snapshot copy
+// しているため、parent chain は使わない (kind の判定で分岐する)。
+type scopeFrame struct {
+	parent *scopeFrame
+	local  map[string]Entry
+	kind   scopeKind
+}
+
+// visible はこの frame から見える tainted vars の union を返す。
+// FuncDecl 本体: 自 frame.local + parent.visible() (再帰 chain)
+// Subshell/CmdSubst: 自 frame.local のみ (entry 時 snapshot 済み)
+// Root: 自 frame.local のみ
+func (f *scopeFrame) visible() map[string]Entry {
+	out := maps.Clone(f.local)
+	if out == nil {
+		out = make(map[string]Entry)
+	}
+	if f.kind == scopeFunc && f.parent != nil {
+		for k, v := range f.parent.visible() {
+			if _, ok := out[k]; !ok {
+				out[k] = v
+			}
+		}
+	}
+	return out
+}
+
 // PropagateTaint は initial を seed として AST を順方向 1 パス walk し、
 // scope-aware に taint を伝播する。
 //
@@ -224,25 +265,97 @@ func PropagateTaint(file *syntax.File, initial map[string]Entry) *ScopedTaint {
 		return result
 	}
 
-	// 暫定実装: 旧フラット動作で Final を埋める。
-	// Task 2 以降でスコープ対応に置き換える。
-	for _, a := range WalkAssignments(file) {
-		if _, already := result.Final[a.Name]; already {
-			continue
-		}
-		if a.Value == nil {
-			continue
-		}
-		refName, found := WordReferencesEntry(a.Value, result.Final)
-		if !found {
-			continue
-		}
-		result.Final[a.Name] = Entry{
-			Sources: []string{"shellvar:" + refName},
-			Offset:  a.Offset,
-		}
+	root := &scopeFrame{kind: scopeRoot, local: maps.Clone(initial)}
+	if root.local == nil {
+		root.local = make(map[string]Entry)
 	}
+	current := root
+	syntax.Walk(file, makeWalkFn(&current, result))
+
+	// Final は root frame の最終状態 (subshell/funcdecl frame は pop 済み)
+	maps.Copy(result.Final, root.local)
 	return result
+}
+
+// makeWalkFn は scope frame stack を維持しつつ walk するクロージャを返す。
+// `current` は現在の frame を指す pointer-to-pointer で、subshell/funcdecl 入退場時に
+// 書き換える。
+func makeWalkFn(current **scopeFrame, result *ScopedTaint) func(syntax.Node) bool {
+	return func(node syntax.Node) bool {
+		if node == nil {
+			return false
+		}
+		switch n := node.(type) {
+		case *syntax.Subshell:
+			child := &scopeFrame{kind: scopeSubshell, parent: *current, local: maps.Clone((*current).visible())}
+			*current = child
+			for _, stmt := range n.Stmts {
+				syntax.Walk(stmt, makeWalkFn(current, result))
+			}
+			*current = (*current).parent
+			return false
+		case *syntax.CmdSubst:
+			child := &scopeFrame{kind: scopeCmdSubst, parent: *current, local: maps.Clone((*current).visible())}
+			*current = child
+			for _, stmt := range n.Stmts {
+				syntax.Walk(stmt, makeWalkFn(current, result))
+			}
+			*current = (*current).parent
+			return false
+		case *syntax.FuncDecl:
+			// 関数本体の処理は Task 4 で実装
+			return false
+		case *syntax.Stmt:
+			// 各 Stmt 入口で visibleAt を記録
+			result.visibleAt[n] = (*current).visible()
+			return true
+		case *syntax.DeclClause:
+			processDeclClause(*current, n)
+			return false // children は処理済み (二重カウント防止)
+		case *syntax.Assign:
+			processAssign(*current, n, AssignNone)
+			return true
+		}
+		return true
+	}
+}
+
+// processAssign は単純代入 X=Y を current frame に書き込む。
+// 既に tainted な変数の上書きはしない (最初の taint を保持)。
+func processAssign(current *scopeFrame, a *syntax.Assign, kw AssignKeyword) {
+	if a == nil || a.Name == nil {
+		return
+	}
+	_ = kw // Task 5/6/7 で `local` / `declare -g` の振り分けに利用予定
+	name := a.Name.Value
+	if _, already := current.local[name]; already {
+		return
+	}
+	if a.Value == nil {
+		return
+	}
+	visible := current.visible()
+	refName, found := WordReferencesEntry(a.Value, visible)
+	if !found {
+		return
+	}
+	current.local[name] = Entry{
+		Sources: []string{"shellvar:" + refName},
+		Offset:  int(a.Pos().Offset()), //nolint:gosec // file offsets fit in int
+	}
+}
+
+// processDeclClause は DeclClause (export X=Y / local X=Y / readonly X=Y / declare X=Y) を処理する。
+// keyword に応じた scope target は Task 6/7 で実装。本 Task では全部 current frame に書く
+// (Subshell/CmdSubst では結果同じ、FuncDecl 内は Task 5/6/7 で再分岐する)。
+func processDeclClause(current *scopeFrame, decl *syntax.DeclClause) {
+	if decl == nil {
+		return
+	}
+	kw := keywordFor(decl.Variant.Value)
+	for _, a := range decl.Args {
+		processAssign(current, a, kw)
+	}
 }
 
 // dedupAppend は順序保持で重複なしの append。

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -817,6 +817,43 @@ func TestPropagateTaint_Scoped(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "function_declare_local_by_default",
+			script:  `foo() { declare X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"}, // 関数内 declare はデフォルト local
+			},
+		},
+		{
+			name:    "function_declare_g_simplified_A_ignored",
+			script:  `foo() { declare -g X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				// 簡略案 A: 関数内の non-local 代入 (declare -g 含む) は親に漏らさない
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "function_export_simplified_A_ignored",
+			script:  `foo() { export X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "function_readonly_simplified_A_ignored",
+			script:  `foo() { readonly X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -982,6 +1019,82 @@ func TestScopedTaint_At(t *testing.T) {
 			t.Errorf("function body cmd visible should contain X (local), got %v", keysOf(visible))
 		}
 	})
+
+	t.Run("function_body_inner_sees_root_via_chain", func(t *testing.T) {
+		t.Parallel()
+		// 関数内で local 宣言なしで親スコープの T を参照
+		// → bash dynamic scoping の lookup chain が効くことを確認
+		file := parseScript(t, `foo() { cmd "$T"; }; foo`)
+		initial := map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+
+		var cmdStmt *syntax.Stmt
+		syntax.Walk(file, func(n syntax.Node) bool {
+			fd, ok := n.(*syntax.FuncDecl)
+			if !ok || fd.Body == nil {
+				return true
+			}
+			body, ok := fd.Body.Cmd.(*syntax.Block)
+			if !ok {
+				return true
+			}
+			if len(body.Stmts) >= 1 {
+				cmdStmt = body.Stmts[0]
+			}
+			return false
+		})
+		if cmdStmt == nil {
+			t.Fatal("function body cmd stmt not found")
+		}
+		visible := result.At(cmdStmt)
+		if _, ok := visible["T"]; !ok {
+			t.Errorf("function body cmd visible should contain T (via parent chain), got %v", keysOf(visible))
+		}
+	})
+}
+
+// TestDeclHasGlobalFlag は declHasGlobalFlag が mvdan/sh の DeclClause 表現
+// (フラグは Name=nil, Value=Word{Lit{"-g"}} の Assign) を正しく解釈することを検証する。
+// FuncDecl 内で frame が pop されるため end-to-end テストでは差が出ないが、
+// この関数自体の AST inspection ロジックを lock-in するために単体で検証する。
+func TestDeclHasGlobalFlag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		script string
+		want   bool
+	}{
+		{name: "no_flag", script: `declare X="$T"`, want: false},
+		{name: "g_flag", script: `declare -g X="$T"`, want: true},
+		{name: "gA_bundle", script: `declare -gA X="$T"`, want: true},
+		{name: "Ag_bundle", script: `declare -Ag X="$T"`, want: true},
+		{name: "A_only", script: `declare -A X="$T"`, want: false},
+		{name: "r_only", script: `declare -r X="$T"`, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			file := parseScript(t, tc.script)
+			var got bool
+			var found bool
+			syntax.Walk(file, func(n syntax.Node) bool {
+				if d, ok := n.(*syntax.DeclClause); ok {
+					got = declHasGlobalFlag(d)
+					found = true
+					return false
+				}
+				return true
+			})
+			if !found {
+				t.Fatal("DeclClause not found in script")
+			}
+			if got != tc.want {
+				t.Errorf("declHasGlobalFlag(%q) = %v; want %v", tc.script, got, tc.want)
+			}
+		})
+	}
 }
 
 // keysOf is a test helper that returns sorted keys of a map for debug output.

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -229,10 +229,13 @@ func TestPropagateTaint(t *testing.T) {
 			wantNames: []string{"X", "A", "B"},
 		},
 		{
-			name:      "subshell_flat_namespace",
+			// Subshell `( Y=$X )` 内の代入は親に漏れない (Task 2 で scope 隔離)。
+			// Y は subshell frame ローカルに留まるため Final には現れない。
+			// より詳細な scope 検証は TestPropagateTaint_Scoped を参照。
+			name:      "subshell_isolation",
 			script:    `(Y=$X)`,
 			initial:   map[string]Entry{"X": envEntry("secrets.X")},
-			wantNames: []string{"X", "Y"},
+			wantNames: []string{"X"},
 		},
 		{
 			name:   "first_taint_preserved_on_reassign",
@@ -698,5 +701,60 @@ func TestDedupAppend(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("[%d] got %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+// TestPropagateTaint_Scoped は scope-aware な PropagateTaint の挙動を検証する。
+func TestPropagateTaint_Scoped(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		// finalHas は Final に含まれるべき変数名 → Sources の最初の値
+		finalHas map[string]string
+		// finalAbsent は Final に含まれてはいけない変数名
+		finalAbsent []string
+	}
+
+	cases := []struct {
+		name    string
+		script  string
+		initial map[string]Entry
+		want    want
+	}{
+		{
+			name:    "subshell_isolation_fp_suppressed",
+			script:  `X="$T"; ( X="safe"; cmd "$X" )`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				// 親 X は T 経由で tainted (subshell 内の X="safe" は親に漏れない)
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+					"X": "shellvar:T",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			file := parseScript(t, tc.script)
+			result := PropagateTaint(file, tc.initial)
+			for name, wantOrigin := range tc.want.finalHas {
+				entry, ok := result.Final[name]
+				if !ok {
+					t.Errorf("Final[%q] missing; want origin %q", name, wantOrigin)
+					continue
+				}
+				if entry.First() != wantOrigin {
+					t.Errorf("Final[%q].First() = %q; want %q", name, entry.First(), wantOrigin)
+				}
+			}
+			for _, name := range tc.want.finalAbsent {
+				if _, ok := result.Final[name]; ok {
+					t.Errorf("Final[%q] should be absent", name)
+				}
+			}
+		})
 	}
 }

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -854,6 +854,36 @@ func TestPropagateTaint_Scoped(t *testing.T) {
 				finalAbsent: []string{"X"},
 			},
 		},
+		{
+			name:    "subshell_with_funcdecl_inside",
+			script:  `( foo() { local X="$T"; }; foo )`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "function_with_subshell_inside",
+			script:  `foo() { local X="$T"; ( cmd "$X" ); }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			name:    "regression_no_scope_constructs",
+			script:  `X="$T"; Y="$X"; cmd "$Y"`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "secrets.GH",
+					"X": "shellvar:T",
+					"Y": "shellvar:X",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -985,6 +1015,18 @@ func TestScopedTaint_At(t *testing.T) {
 		var s *ScopedTaint
 		if got := s.At(nil); got != nil {
 			t.Errorf("nil ScopedTaint.At should return nil, got %v", got)
+		}
+	})
+
+	t.Run("nil_file", func(t *testing.T) {
+		t.Parallel()
+		initial := map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}}
+		result := PropagateTaint(nil, initial)
+		if result == nil {
+			t.Fatal("PropagateTaint(nil, ...) should return non-nil ScopedTaint")
+		}
+		if _, ok := result.Final["T"]; !ok {
+			t.Errorf("Final should contain initial T, got %v", keysOf(result.Final))
 		}
 	})
 

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -767,11 +767,12 @@ func TestPropagateTaint_Scoped(t *testing.T) {
 			},
 		},
 		{
-			// CmdSubst `$(X="leaked"; echo "$X")` 内の X 代入は親 (root) に
-			// 漏れない。R は cmdsubst RHS なので tainted にもならない (内側で
-			// $T を参照していないため)。後続の `cmd "$X"` も X が undefined。
+			// CmdSubst `$(X="$T"; echo "$X")` 内で X は $T を参照して tainted
+			// になるが、その代入は親 (root) に漏れない。X が cmdsubst-local で
+			// あることを示す discriminating ケース: flat walker なら X が root
+			// に漏れて finalAbsent が失敗する。後続の `cmd "$X"` も X 未定義。
 			name:    "cmdsubst_isolation",
-			script:  `R=$(X="leaked"; echo "$X"); cmd "$X"`,
+			script:  `R=$(X="$T"; echo "$X"); cmd "$X"`,
 			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
 			want: want{
 				finalHas: map[string]string{

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
@@ -751,6 +752,49 @@ func TestPropagateTaint_Scoped(t *testing.T) {
 				finalAbsent: []string{"Y"},
 			},
 		},
+		{
+			// Subshell `( cmd "$X" )` は親の tainted snapshot を持って入るため
+			// 親の X (T 経由で tainted) が subshell 内でも見える。X の代入は
+			// subshell の外で起きており Final にも残る。
+			name:    "subshell_inner_sees_parent_tainted",
+			script:  `X="$T"; ( cmd "$X" )`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+					"X": "shellvar:T",
+				},
+			},
+		},
+		{
+			// CmdSubst `$(X="leaked"; echo "$X")` 内の X 代入は親 (root) に
+			// 漏れない。R は cmdsubst RHS なので tainted にもならない (内側で
+			// $T を参照していないため)。後続の `cmd "$X"` も X が undefined。
+			name:    "cmdsubst_isolation",
+			script:  `R=$(X="leaked"; echo "$X"); cmd "$X"`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+				},
+				finalAbsent: []string{"X"},
+			},
+		},
+		{
+			// 入れ子 subshell `( X="$T"; ( cmd "$X" ) )` の外側 subshell 内で
+			// 代入された X は最外殻 (root) の Final には漏れない。内側 subshell
+			// は外側 subshell の snapshot を引き継ぐので X が見えるが、これは
+			// scope 内の話で Final には影響しない。
+			name:    "nested_subshell",
+			script:  `( X="$T"; ( cmd "$X" ) )`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+				},
+				finalAbsent: []string{"X"},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -821,6 +865,69 @@ func TestScopedTaint_At(t *testing.T) {
 			t.Errorf("assign stmt should have T in visibleAt (snapshotted from parent), got %v", keysOf(visibleAtAssign))
 		}
 	})
+
+	t.Run("subshell_inner_stmt_sees_parent_tainted", func(t *testing.T) {
+		t.Parallel()
+		file := parseScript(t, `X="$T"; ( cmd "$X" )`)
+		initial := map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+
+		var innerStmt *syntax.Stmt
+		syntax.Walk(file, func(n syntax.Node) bool {
+			if sub, ok := n.(*syntax.Subshell); ok {
+				if len(sub.Stmts) > 0 {
+					innerStmt = sub.Stmts[0]
+				}
+				return false
+			}
+			return true
+		})
+		if innerStmt == nil {
+			t.Fatal("inner subshell stmt not found")
+		}
+		visible := result.At(innerStmt)
+		if _, ok := visible["T"]; !ok {
+			t.Errorf("inner subshell visible should contain T, got %v", keysOf(visible))
+		}
+		if _, ok := visible["X"]; !ok {
+			t.Errorf("inner subshell visible should contain X (snapshotted from parent), got %v", keysOf(visible))
+		}
+	})
+
+	t.Run("at_nil_returns_final", func(t *testing.T) {
+		t.Parallel()
+		file := parseScript(t, `X=v`)
+		initial := map[string]Entry{"T": {Sources: []string{"x"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+		got := result.At(nil)
+		if _, ok := got["T"]; !ok {
+			t.Errorf("At(nil) should fall back to Final, got %v", keysOf(got))
+		}
+	})
+
+	t.Run("at_unknown_stmt_returns_final", func(t *testing.T) {
+		t.Parallel()
+		file := parseScript(t, `X=v`)
+		other := parseScript(t, `Y=z`)
+		initial := map[string]Entry{"T": {Sources: []string{"x"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+		var otherStmt *syntax.Stmt
+		if len(other.Stmts) > 0 {
+			otherStmt = other.Stmts[0]
+		}
+		got := result.At(otherStmt)
+		if _, ok := got["T"]; !ok {
+			t.Errorf("At(unknown stmt) should fall back to Final, got %v", keysOf(got))
+		}
+	})
+
+	t.Run("nil_scoped_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		var s *ScopedTaint
+		if got := s.At(nil); got != nil {
+			t.Errorf("nil ScopedTaint.At should return nil, got %v", got)
+		}
+	})
 }
 
 // keysOf is a test helper that returns sorted keys of a map for debug output.
@@ -829,5 +936,6 @@ func keysOf(m map[string]Entry) []string {
 	for k := range m {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -796,6 +796,27 @@ func TestPropagateTaint_Scoped(t *testing.T) {
 				finalAbsent: []string{"X"},
 			},
 		},
+		{
+			name:    "function_local_isolated",
+			script:  `foo() { local X="$T"; }; foo`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				finalHas:    map[string]string{"T": "secrets.GH"},
+				finalAbsent: []string{"X"}, // 関数内の local X は親に漏れない
+			},
+		},
+		{
+			name:    "root_local_treated_as_root_assign",
+			script:  `local X="$T"`,
+			initial: map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}},
+			want: want{
+				// root scope の local は bash 実行時エラーだが、解析では root に書く (FN 抑制)
+				finalHas: map[string]string{
+					"T": "secrets.GH",
+					"X": "shellvar:T",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -927,6 +948,38 @@ func TestScopedTaint_At(t *testing.T) {
 		var s *ScopedTaint
 		if got := s.At(nil); got != nil {
 			t.Errorf("nil ScopedTaint.At should return nil, got %v", got)
+		}
+	})
+
+	t.Run("function_body_inner_sees_local", func(t *testing.T) {
+		t.Parallel()
+		file := parseScript(t, `foo() { local X="$T"; cmd "$X"; }; foo`)
+		initial := map[string]Entry{"T": {Sources: []string{"secrets.GH"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+
+		// 関数本体内の `cmd "$X"` Stmt を取り出す
+		var cmdStmt *syntax.Stmt
+		syntax.Walk(file, func(n syntax.Node) bool {
+			fd, ok := n.(*syntax.FuncDecl)
+			if !ok || fd.Body == nil {
+				return true
+			}
+			body, ok := fd.Body.Cmd.(*syntax.Block)
+			if !ok {
+				return true
+			}
+			// body.Stmts: [0]=local X=, [1]=cmd "$X"
+			if len(body.Stmts) >= 2 {
+				cmdStmt = body.Stmts[1]
+			}
+			return false
+		})
+		if cmdStmt == nil {
+			t.Fatal("function body cmd stmt not found")
+		}
+		visible := result.At(cmdStmt)
+		if _, ok := visible["X"]; !ok {
+			t.Errorf("function body cmd visible should contain X (local), got %v", keysOf(visible))
 		}
 	})
 }

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -252,7 +252,7 @@ func TestPropagateTaint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			file := parseScript(t, tc.script)
-			got := PropagateTaint(file, tc.initial)
+			got := PropagateTaint(file, tc.initial).Final
 
 			for _, name := range tc.wantNames {
 				if _, ok := got[name]; !ok {
@@ -284,7 +284,7 @@ func TestPropagateTaint_OrderAware(t *testing.T) {
 	script := `Y=$X`
 	initial := map[string]Entry{"X": {Sources: []string{"secrets.X"}, Offset: -1}}
 	file := parseScript(t, script)
-	got := PropagateTaint(file, initial)
+	got := PropagateTaint(file, initial).Final
 
 	if got["X"].Offset != -1 {
 		t.Errorf("X should keep Offset=-1, got %d", got["X"].Offset)
@@ -564,7 +564,7 @@ func TestRedirTargetMatches_Edge(t *testing.T) {
 func TestPropagateTaint_NilFile(t *testing.T) {
 	t.Parallel()
 	initial := map[string]Entry{"X": {Sources: []string{"s"}, Offset: -1}}
-	got := PropagateTaint(nil, initial)
+	got := PropagateTaint(nil, initial).Final
 	if _, ok := got["X"]; !ok {
 		t.Error("initial entry must be preserved with nil file")
 	}

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -691,20 +691,6 @@ func TestExtractHeredocAssignments_CommentLine(t *testing.T) {
 	}
 }
 
-func TestDedupAppend(t *testing.T) {
-	t.Parallel()
-	got := dedupAppend([]string{"a"}, "b", "a", "c", "b")
-	want := []string{"a", "b", "c"}
-	if len(got) != len(want) {
-		t.Fatalf("len: got %d, want %d", len(got), len(want))
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("[%d] got %q, want %q", i, got[i], want[i])
-		}
-	}
-}
-
 // TestPropagateTaint_Scoped は scope-aware な PropagateTaint の挙動を検証する。
 func TestPropagateTaint_Scoped(t *testing.T) {
 	t.Parallel()

--- a/pkg/shell/taint_test.go
+++ b/pkg/shell/taint_test.go
@@ -733,6 +733,24 @@ func TestPropagateTaint_Scoped(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "declclause_rhs_cmdsubst_isolated",
+			script:  `local X=$(Y="$T"; echo "$Y")`,
+			initial: map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}},
+			want: want{
+				finalHas: map[string]string{
+					"T": "github.event.issue.body",
+					// X は cmdsubst を含む Word を RHS とする代入で、現状の
+					// WordReferencesEntry は Word 内の全 ParamExp を deep walk
+					// するため cmdsubst 内側の "$T" を捕捉して X を tainted に
+					// する (cmdsubst の出力が本当に X に流れる場合と過剰に
+					// マッチするが、現状の挙動を lock-in しておく)。
+					"X": "shellvar:T",
+				},
+				// Y は cmdsubst 内の代入なので親 (root) には漏れない。
+				finalAbsent: []string{"Y"},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -757,4 +775,59 @@ func TestPropagateTaint_Scoped(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestScopedTaint_At は visibleAt の per-Stmt snapshot を検証する。
+// Task 3 で更にケースを追加予定。
+func TestScopedTaint_At(t *testing.T) {
+	t.Parallel()
+
+	t.Run("declclause_rhs_cmdsubst_inner_stmt_records_visibleAt", func(t *testing.T) {
+		t.Parallel()
+		// local X=$(Y="$T"; echo "$Y")
+		// cmdsubst 内の 2 番目の Stmt (echo "$Y") の入口時点で Y が visible
+		// であることを確認する。Y は cmdsubst frame ローカルなので Final
+		// には含まれず、もし visibleAt が記録されていなければ At() の
+		// Final フォールバックにより Y が見えない。
+		// (本テストは fix 前の defect — DeclClause RHS の cmdsubst が walk
+		//  されず inner stmt の visibleAt が空になる — を検出する)
+		file := parseScript(t, `local X=$(Y="$T"; echo "$Y")`)
+		initial := map[string]Entry{"T": {Sources: []string{"github.event.issue.body"}, Offset: -1}}
+		result := PropagateTaint(file, initial)
+
+		var innerStmts []*syntax.Stmt
+		syntax.Walk(file, func(n syntax.Node) bool {
+			if cs, ok := n.(*syntax.CmdSubst); ok {
+				innerStmts = cs.Stmts
+				return false
+			}
+			return true
+		})
+		if len(innerStmts) < 2 {
+			t.Fatalf("expected >=2 inner cmdsubst stmts, got %d", len(innerStmts))
+		}
+		// 2 番目の Stmt (echo "$Y") の入口で Y が visible なら fix が効いている。
+		visibleAtEcho := result.At(innerStmts[1])
+		if _, ok := visibleAtEcho["Y"]; !ok {
+			t.Errorf("echo stmt should have Y in visibleAt (cmdsubst frame), got %v", keysOf(visibleAtEcho))
+		}
+		// Final には Y が含まれない (cmdsubst スコープが pop された結果)。
+		if _, ok := result.Final["Y"]; ok {
+			t.Errorf("Final should NOT have Y (cmdsubst-local), got %v", keysOf(result.Final))
+		}
+		// 1 番目の Stmt (Y="$T") の入口でも T は visible (親から snapshot)。
+		visibleAtAssign := result.At(innerStmts[0])
+		if _, ok := visibleAtAssign["T"]; !ok {
+			t.Errorf("assign stmt should have T in visibleAt (snapshotted from parent), got %v", keysOf(visibleAtAssign))
+		}
+	})
+}
+
+// keysOf is a test helper that returns sorted keys of a map for debug output.
+func keysOf(m map[string]Entry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/script/README.md
+++ b/script/README.md
@@ -42,6 +42,8 @@ Contains example GitHub Actions workflow files that demonstrate various security
 | `ai-action-execution-order-safe.yaml` | AI action as the last step in the job (recommended pattern) |
 | `secret-in-log-vulnerable.yaml` | Secrets leaked to build logs via `echo`/`printf` of shell variables derived from secret-sourced environment variables (chained assignment, direct echo patterns) |
 | `secret-in-log-safe.yaml` | Safe counterparts using `::add-mask::` before printing derived variables, unrelated echo, and no-echo (curl-only) patterns |
+| `taint-scope-fp-safe.yaml` | TaintTracker scope-aware (#447): subshell 内の変数上書きが親スコープに漏れないことを示す |
+| `taint-scope-fn-vulnerable.yaml` | TaintTracker scope-aware (#447): 関数本体内 local 変数の secret-in-log 検出を示す |
 
 ### Usage
 

--- a/script/actions/taint-scope-fn-vulnerable.yaml
+++ b/script/actions/taint-scope-fn-vulnerable.yaml
@@ -1,0 +1,18 @@
+# このワークフローは sisakulint の TaintTracker シェルスコープ対応 (#447) の
+# False Negative 修正を示すデモ。
+#
+# 関数本体内で local 宣言された SECRET_LOCAL を echo するパターンは、scope-aware
+# な secret-in-log ルールが leak として検出する。
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          SECRET: ${{ secrets.GH_TOKEN }}
+        run: |
+          leak() {
+            local SECRET_LOCAL="$SECRET"
+            echo "$SECRET_LOCAL"
+          }
+          leak

--- a/script/actions/taint-scope-fp-safe.yaml
+++ b/script/actions/taint-scope-fp-safe.yaml
@@ -1,0 +1,15 @@
+# このワークフローは sisakulint の TaintTracker シェルスコープ対応 (#447) の
+# False Positive 抑制を示すデモ。
+#
+# ( ... ) サブシェル内での変数上書きは親スコープに漏れない (bash 仕様)。
+# scoped TaintTracker はこれを正しく区別し、subshell 内の curl は "sanitized"
+# のみを参照、親の curl は依然として tainted な BODY を参照していると判定する。
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          BODY="${{ github.event.pull_request.body }}"
+          ( BODY="sanitized"; curl "https://api.example.com?q=$BODY" )
+          curl "https://api.example.com?q=$BODY"


### PR DESCRIPTION
## Summary

`pkg/shell/taint.go::PropagateTaint` を flat namespace から scope-aware walker に拡張し、両 caller (`pkg/core/taint.go`, `pkg/core/secretinlog.go`) を per-stmt visible lookup に統合。closes #447

- **Subshell `( ... )` / CmdSubst `\$(...)`**: entry 時に親 visible を snapshot copy して隔離 → 内部代入は親に漏れない (FP 抑制)
- **FuncDecl 本体**: `scopeFunc` frame で push、parent への lookup chain で bash dynamic scoping を近似。`local` / 装飾なし `declare` は本体ローカル、`declare -g` / `export` / `readonly` は簡略案 A により親に漏らさない (#448 で改善)
- 戻り値を `*ScopedTaint{Final, At(stmt)}` に変更。`Final` は cross-step 用、`At(stmt)` は sink 検出の per-stmt visible
- `taint.go` は per-stmt で `expandShellvarMarkers` してから `recordRedirWrite` に渡す。`secretinlog.go` は autofix が \`shellvar:X\` マーカーを必要とするため raw 保持 (caller ごとの方針差を spec §5 で明記)

実装は 13 commits の bite-sized タスク (TDD, fresh subagent per task + 2-stage review for each)。Spec / Plan は \`docs/superpowers/{specs,plans}/2026-04-27-447-*.md\`。

## Test Plan

- [x] \`go test ./...\` 全 pass (※ \`TestCrossJobTaintPropagation/3ジョブチェーン: multi-hop\` の pre-existing flake は本 PR 無関係 — main でも 4/30 失敗、別 issue 化候補)
- [x] \`go vet ./...\` clean
- [x] 新規 unit ケース 27 件 (\`TestPropagateTaint_Scoped\` 13, \`TestScopedTaint_At\` 8, \`TestDeclHasGlobalFlag\` 6)
- [x] 統合テスト 3 件 (\`TestTaintTracker_RedirWriteInSubshell\`, \`TestSecretInLog_FunctionLocalScope_DetectsLeak\`, \`TestSecretInLog_SubshellLocalAssignment_NotLeakedInParent\`)
- [x] 手動 fixture 確認: \`script/actions/taint-scope-fp-safe.yaml\` で subshell 内 curl が二重 flag されない / \`script/actions/taint-scope-fn-vulnerable.yaml\` で関数本体内 echo が secret-in-log で検出される

## Known Limitations / Follow-ups

- **\`seedTaintFromExpressions\` は scope 非対応** — 直接 \`\${{ untrusted }}\` 代入が subshell 内でも seed 経由で Final に漏れる。Task 7 reviewer が発見、CLAUDE.md に明記。本 PR スコープ外、follow-up issue 候補
- **関数引数の taint 伝播 (#448)** — 本 PR が unblock。簡略案 A の関数副作用伝播未対応もここで解消予定
- **Pipeline / バックグラウンド \`&\` の subshell 化** — Q2 でスコープ外 (FN 影響軽微、別 issue 候補)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * シェル変数のスコープを認識した秘密漏洩検出により、サブシェルと関数内のローカル変数を正確に追跡。より精密で正確な検出結果を提供します。

* **テスト**
  * スコープ対応の動作検証用テストケースを追加。

* **ドキュメント**
  * スコープ対応の設計仕様および実装計画を文書化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->