### PR TITLE
feat: make missing-timeout-minutes opt-in via -enable-rule flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ sisakulint includes the following security rules (as of pkg/core/linter.go:500-5
 - **ExpressionRule** - Parses and validates `${{ }}` expressions
 - **DeprecatedCommandsRule** - Detects deprecated GitHub Actions commands
 - **ConditionalRule** - Validates conditional expressions
-- **TimeoutMinuteRule** - Enforces timeout configurations (auto-fix supported)
+- **TimeoutMinuteRule** - Enforces timeout configurations (auto-fix supported, **opt-in: requires `-enable-rule missing-timeout-minutes`**)
 - **CodeInjectionCriticalRule** - Detects code injection in privileged triggers (auto-fix supported)
 - **CodeInjectionMediumRule** - Detects code injection in normal triggers (auto-fix supported)
 - **EnvVarInjectionCriticalRule** - Detects environment variable injection in privileged triggers (auto-fix supported)
@@ -225,6 +225,9 @@ sisakulint -ignore "SC2086" -ignore "permissions"
 
 # Generate boilerplate workflow
 sisakulint -boilerplate
+
+# Enable an opt-in rule (currently available: missing-timeout-minutes)
+sisakulint -enable-rule missing-timeout-minutes
 ```
 
 ## Exit Codes
@@ -285,7 +288,7 @@ See `pkg/core/permissionrule.go` for auto-fix example.
 
 ### Current Auto-Fix Implementations
 
-- **TimeoutMinutesRule** (`timeout_minutes.go`) - Adds default timeout-minutes: 5
+- **TimeoutMinutesRule** (`timeout_minutes.go`) - Adds default timeout-minutes: 5 (only runs when the rule is enabled via `-enable-rule missing-timeout-minutes`)
 - **CommitSHARule** (`commitsha.go`) - Converts action tags to commit SHAs with comment preservation
 - **CredentialRule** (`credential.go`) - Removes hardcoded passwords from container configs
 - **CodeInjectionRule** (`codeinjection.go`) - Moves untrusted expressions to environment variables

--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ $ sisakulint -fix on
 
 # Output in SARIF format for CI/CD integration
 $ sisakulint -format "{{sarif .}}"
+
+# Enable an opt-in rule (e.g. missing-timeout-minutes is opt-in)
+$ sisakulint -enable-rule missing-timeout-minutes
 ```
 
 ## Example: Detecting Security Vulnerabilities

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ jobs:
         run: npm install && npm run build
 ```
 
-Running `sisakulint` detects multiple security issues:
+Running `sisakulint -enable-rule missing-timeout-minutes` detects multiple security issues (the `-enable-rule` flag enables the opt-in `missing-timeout-minutes` rule shown in the output below):
 
 ```
 .github/workflows/demo.yaml:1:1: workflow does not have explicit 'permissions' block. Without explicit permissions, the workflow uses the default repository permissions which may be overly broad. Add a 'permissions:' block to follow the principle of least privilege. See https://sisaku-security.github.io/lint/docs/rules/permissions/ [permissions]

--- a/docs/timeoutminutesrule.md
+++ b/docs/timeoutminutesrule.md
@@ -3,7 +3,7 @@ title: "Timeout Minutes Rule"
 weight: 1
 ---
 
-### Status: opt-in (disabled by default)
+## Status: opt-in (disabled by default)
 
 This rule is disabled by default and must be explicitly enabled with the
 `-enable-rule` CLI flag:
@@ -183,14 +183,14 @@ jobs:
 
 ### Auto-Fix Support
 
-The timeout-minutes rule supports auto-fixing by adding a default timeout:
+The timeout-minutes rule supports auto-fixing by adding a default timeout. Because the rule is opt-in, the `-enable-rule` flag is required for the auto-fixer to fire:
 
 ```bash
 # Preview changes without applying
-sisakulint -fix dry-run
+sisakulint -enable-rule missing-timeout-minutes -fix dry-run
 
 # Apply fixes
-sisakulint -fix on
+sisakulint -enable-rule missing-timeout-minutes -fix on
 ```
 
 **Before (Missing Timeout):**

--- a/docs/timeoutminutesrule.md
+++ b/docs/timeoutminutesrule.md
@@ -314,11 +314,7 @@ jobs:
 
 ### False Positives
 
-This rule has no false positives because:
-
-1. Explicit timeouts are always a best practice
-2. The default 6-hour timeout is rarely appropriate
-3. Setting timeouts has no negative side effects (when properly configured)
+This rule has no false positives in the strict sense — every match is technically a missing timeout — but the volume of matches in real-world repos (every job and step without an explicit timeout) is what motivated the opt-in default. Teams can opt into the rule once they're ready to enforce timeouts across their workflows.
 
 ### Related Rules
 
@@ -337,22 +333,22 @@ This rule has no false positives because:
 
 ### Testing
 
-To test this rule:
+To test this rule (the `-enable-rule` flag is required because the rule is opt-in):
 
 ```bash
 # Detect missing timeouts
-sisakulint .github/workflows/*.yml
+sisakulint -enable-rule missing-timeout-minutes .github/workflows/*.yml
 
 # Apply auto-fix
-sisakulint -fix on .github/workflows/*.yml
+sisakulint -enable-rule missing-timeout-minutes -fix on .github/workflows/*.yml
 ```
 
 ### Configuration
 
-This rule is enabled by default. To disable it:
+This rule is **disabled by default** (opt-in). See the [Status](#status-opt-in-disabled-by-default) section above for the enable command and rationale.
+
+If you have enabled the rule and want to suppress only the message text without disabling the rule itself, you can still use:
 
 ```bash
 sisakulint -ignore missing-timeout-minutes
 ```
-
-However, disabling this rule is **not recommended** as explicit timeouts are an important security and resource management practice.

--- a/docs/timeoutminutesrule.md
+++ b/docs/timeoutminutesrule.md
@@ -3,6 +3,20 @@ title: "Timeout Minutes Rule"
 weight: 1
 ---
 
+### Status: opt-in (disabled by default)
+
+This rule is disabled by default and must be explicitly enabled with the
+`-enable-rule` CLI flag:
+
+```bash
+sisakulint -enable-rule missing-timeout-minutes
+```
+
+Why opt-in? `missing-timeout-minutes` is primarily a best practice rather
+than a security finding, and it fires on every job/step without an explicit
+timeout — which generated noisy reports and skewed severity summaries.
+Teams that want to enforce timeouts can still do so by enabling the rule.
+
 ### Timeout Minutes Rule Overview
 
 This rule enforces the `timeout-minutes` attribute for all jobs in GitHub Actions workflows. Without explicit timeouts, jobs can run indefinitely, consuming CI/CD resources and potentially being exploited for malicious purposes.

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -177,11 +177,22 @@ func (i *ignorePatternFlags) Set(v string) error {
 	return nil
 }
 
+type enabledRuleFlags []string
+
+func (e *enabledRuleFlags) String() string {
+	return "option for enabling opt-in rules"
+}
+func (e *enabledRuleFlags) Set(v string) error {
+	*e = append(*e, v)
+	return nil
+}
+
 // todo: sisakulintのmain関数
 func (cmd *Command) Main(args []string) int {
 	var showVersion bool
 	var linterOpts LinterOptions
 	var ignorePats ignorePatternFlags
+	var enabledRules enabledRuleFlags
 	var initConfig bool
 	var generateBoilerplate bool
 	var generateActionList bool
@@ -195,6 +206,9 @@ func (cmd *Command) Main(args []string) int {
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flags.SetOutput(cmd.Stderr)
 	flags.Var(&ignorePats, "ignore", "Regular expression matching to error messages you want to ignore. This flag is repeatable")
+	flags.Var(&enabledRules, "enable-rule",
+		"Enable an opt-in rule by name. Repeatable. "+
+			"Currently available opt-in rules: missing-timeout-minutes")
 	flags.BoolVar(&generateBoilerplate, "boilerplate", false, "Generate a costomized template file for GitHub Actions workflow")
 	flags.StringVar(&linterOpts.CustomErrorMessageFormat, "format", "", "Custom template to format error messages in Go template syntax.")
 	flags.StringVar(&linterOpts.ConfigurationFilePath, "config-file", "", "File path to config file")
@@ -238,6 +252,7 @@ func (cmd *Command) Main(args []string) int {
 	}
 
 	linterOpts.ErrorIgnorePatterns = ignorePats
+	linterOpts.EnabledOptInRules = enabledRules
 	linterOpts.LogOutputDestination = cmd.Stderr
 
 	if generateActionList {

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -666,6 +666,18 @@ func (l *Linter) validate(
 		validationStart = time.Now()
 	}
 
+	// Validate -enable-rule names early so unknown names surface regardless
+	// of the file type or whether parsing later succeeds. Without this, a
+	// dependabot config / composite action / unparseable workflow would
+	// silently skip the rule-name check and the user's CLI typo would not
+	// be reported until a parseable workflow happened to reach validate().
+	rules := makeRules(filePath, l.isRemote, localActions, localReusableWorkflow)
+	filteredRules, optErr := applyOptInRules(rules, l.enabledOptInRules)
+	if optErr != nil {
+		return nil, optErr
+	}
+	rules = filteredRules
+
 	// Check if this is a dependabot configuration file
 	if isDependabotConfigFile(filePath) {
 		l.log("validating dependabot config...", filePath)
@@ -723,13 +735,8 @@ func (l *Linter) validate(
 	if parsedWorkflow != nil {
 		dbg := l.debugWriter()
 
-		rules := makeRules(filePath, l.isRemote, localActions, localReusableWorkflow)
-
-		filteredRules, optErr := applyOptInRules(rules, l.enabledOptInRules)
-		if optErr != nil {
-			return nil, optErr
-		}
-		rules = filteredRules
+		// rules were built and filtered at the top of validate() so that
+		// rule-name validation runs even when this branch is skipped.
 
 		v := NewSyntaxTreeVisitor()
 		for _, rule := range rules {

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -77,6 +77,9 @@ type LinterOptions struct {
 	// IsRemoteは、リモートスキャンモードで実行されているかどうかを示すフラグ
 	// trueの場合、ローカルファイルシステムへのアクセスが不要なチェックをスキップする
 	IsRemote bool
+	// EnabledOptInRules は、CLI -enable-rule で指定された
+	// オプトインルール名のリスト。空の場合、opt-in なルールはすべて無効。
+	EnabledOptInRules []string
 }
 
 // Linterは、workflowをlintするための構造体
@@ -105,6 +108,8 @@ type Linter struct {
 	modifyCheckRules func([]Rule) []Rule
 	// isRemoteは、リモートスキャンモードで実行されているかどうかを示すフラグ
 	isRemote bool
+	// enabledOptInRules は、有効化されたオプトインルール名のリスト。
+	enabledOptInRules []string
 }
 
 // NewLinterは新しいLinterインスタンスを作成する
@@ -182,18 +187,19 @@ func NewLinter(errorOutput io.Writer, options *LinterOptions) (*Linter, error) {
 	}
 
 	return &Linter{
-		NewProjects(),
-		errorOutput,
-		logOutput,
-		logLevel,
-		options.ShellcheckExecutable,
-		ignorePatterns,
-		config,
-		boiler,
-		errorFormatter,
-		workDir,
-		options.OnCheckRulesModified,
-		options.IsRemote,
+		projectInformation:       NewProjects(),
+		errorOutput:              errorOutput,
+		logOutput:                logOutput,
+		loggingLevel:             logLevel,
+		shellcheckExecutablePath: options.ShellcheckExecutable,
+		errorIgnorePatterns:      ignorePatterns,
+		defaultConfiguration:     config,
+		boilerplateGeneration:    boiler,
+		errorFormatter:           errorFormatter,
+		currentWorkingDirectory:  workDir,
+		modifyCheckRules:         options.OnCheckRulesModified,
+		isRemote:                 options.IsRemote,
+		enabledOptInRules:        options.EnabledOptInRules,
 	}, nil
 }
 
@@ -718,6 +724,12 @@ func (l *Linter) validate(
 		dbg := l.debugWriter()
 
 		rules := makeRules(filePath, l.isRemote, localActions, localReusableWorkflow)
+
+		filteredRules, optErr := applyOptInRules(rules, l.enabledOptInRules)
+		if optErr != nil {
+			return nil, optErr
+		}
+		rules = filteredRules
 
 		v := NewSyntaxTreeVisitor()
 		for _, rule := range rules {

--- a/pkg/core/linter_optin_test.go
+++ b/pkg/core/linter_optin_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLinter_MissingTimeoutMinutesIsOptIn(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	fixture := filepath.Join(repoRoot, "script", "actions", "timeout-minutes.yaml")
+	content, err := os.ReadFile(fixture)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	hasTimeoutErr := func(t *testing.T, errs []*LintingError) bool {
+		t.Helper()
+		for _, e := range errs {
+			// LintingError.Type carries the rule name (see pkg/core/errorformatter.go).
+			if e.Type == "missing-timeout-minutes" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("default (opt-in disabled): missing-timeout-minutes is suppressed", func(t *testing.T) {
+		opts := &LinterOptions{LogOutputDestination: io.Discard}
+		linter, err := NewLinter(bytes.NewBuffer(nil), opts)
+		if err != nil {
+			t.Fatalf("NewLinter: %v", err)
+		}
+		result, err := linter.Lint(fixture, content, nil)
+		if err != nil {
+			t.Fatalf("Lint: %v", err)
+		}
+		if hasTimeoutErr(t, result.Errors) {
+			t.Errorf("missing-timeout-minutes should be suppressed by default; got errors: %v", result.Errors)
+		}
+	})
+
+	t.Run("with -enable-rule missing-timeout-minutes: errors are emitted", func(t *testing.T) {
+		opts := &LinterOptions{
+			LogOutputDestination: io.Discard,
+			EnabledOptInRules:    []string{"missing-timeout-minutes"},
+		}
+		linter, err := NewLinter(bytes.NewBuffer(nil), opts)
+		if err != nil {
+			t.Fatalf("NewLinter: %v", err)
+		}
+		result, err := linter.Lint(fixture, content, nil)
+		if err != nil {
+			t.Fatalf("Lint: %v", err)
+		}
+		if !hasTimeoutErr(t, result.Errors) {
+			t.Errorf("missing-timeout-minutes should be emitted when enabled; got: %v", result.Errors)
+		}
+	})
+
+	t.Run("unknown rule name produces an error", func(t *testing.T) {
+		opts := &LinterOptions{
+			LogOutputDestination: io.Discard,
+			EnabledOptInRules:    []string{"no-such-rule"},
+		}
+		linter, err := NewLinter(bytes.NewBuffer(nil), opts)
+		if err != nil {
+			t.Fatalf("NewLinter: %v", err)
+		}
+		_, err = linter.Lint(fixture, content, nil)
+		if err == nil {
+			t.Fatal("expected error for unknown rule name, got nil")
+		}
+		if !strings.Contains(err.Error(), "no-such-rule") {
+			t.Fatalf("error = %q, want substring %q", err.Error(), "no-such-rule")
+		}
+	})
+}

--- a/pkg/core/optin.go
+++ b/pkg/core/optin.go
@@ -1,0 +1,38 @@
+package core
+
+import "fmt"
+
+// applyOptInRules は makeRules() の戻り値からデフォルト無効 (opt-in) ルールを
+// フィルタする。enabled に名前が含まれない opt-in ルールは結果から除外される。
+//
+// enabled に含まれる名前のうち、どのルールにも対応しないものはエラーで返す
+// (CLI typo / 削除済みルール名の検出)。
+//
+// enabled に含まれる名前が既知だが opt-in でない場合は no-op として黙って受け入れる。
+// これにより将来 opt-in から default-on に降格したルール名が CLI 側に残っていても
+// 既存ユーザーの CI が壊れない。
+func applyOptInRules(rules []Rule, enabled []string) ([]Rule, error) {
+	enabledSet := make(map[string]struct{}, len(enabled))
+	for _, n := range enabled {
+		enabledSet[n] = struct{}{}
+	}
+
+	knownNames := make(map[string]struct{}, len(rules))
+	out := make([]Rule, 0, len(rules))
+	for _, r := range rules {
+		knownNames[r.RuleNames()] = struct{}{}
+		if r.IsOptIn() {
+			if _, ok := enabledSet[r.RuleNames()]; !ok {
+				continue
+			}
+		}
+		out = append(out, r)
+	}
+
+	for name := range enabledSet {
+		if _, ok := knownNames[name]; !ok {
+			return nil, fmt.Errorf("unknown rule name passed to -enable-rule: %q", name)
+		}
+	}
+	return out, nil
+}

--- a/pkg/core/optin_test.go
+++ b/pkg/core/optin_test.go
@@ -24,11 +24,11 @@ func (r *stubRule) VisitStep(*ast.Step) error             { return nil }
 
 func TestApplyOptInRules(t *testing.T) {
 	tests := []struct {
-		name        string
-		rules       []Rule
-		enabled     []string
-		wantNames   []string
-		wantErrSub  string
+		name       string
+		rules      []Rule
+		enabled    []string
+		wantNames  []string
+		wantErrSub string
 	}{
 		{
 			name:      "default excludes opt-in rule",

--- a/pkg/core/optin_test.go
+++ b/pkg/core/optin_test.go
@@ -1,0 +1,88 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// stubRule is a minimal Rule implementation used only by optin_test.go.
+type stubRule struct {
+	BaseRule
+}
+
+func newStubRule(name string, optIn bool) *stubRule {
+	return &stubRule{BaseRule: BaseRule{RuleName: name, optIn: optIn}}
+}
+
+func (r *stubRule) VisitWorkflowPre(*ast.Workflow) error  { return nil }
+func (r *stubRule) VisitWorkflowPost(*ast.Workflow) error { return nil }
+func (r *stubRule) VisitJobPre(*ast.Job) error            { return nil }
+func (r *stubRule) VisitJobPost(*ast.Job) error           { return nil }
+func (r *stubRule) VisitStep(*ast.Step) error             { return nil }
+
+func TestApplyOptInRules(t *testing.T) {
+	tests := []struct {
+		name        string
+		rules       []Rule
+		enabled     []string
+		wantNames   []string
+		wantErrSub  string
+	}{
+		{
+			name:      "default excludes opt-in rule",
+			rules:     []Rule{newStubRule("opt-a", true), newStubRule("normal-b", false)},
+			enabled:   nil,
+			wantNames: []string{"normal-b"},
+		},
+		{
+			name:      "explicit enable keeps opt-in rule",
+			rules:     []Rule{newStubRule("opt-a", true), newStubRule("normal-b", false)},
+			enabled:   []string{"opt-a"},
+			wantNames: []string{"opt-a", "normal-b"},
+		},
+		{
+			name:       "unknown rule name returns error",
+			rules:      []Rule{newStubRule("opt-a", true), newStubRule("normal-b", false)},
+			enabled:    []string{"typo-name"},
+			wantErrSub: `"typo-name"`,
+		},
+		{
+			name:      "enabling a default-on rule is a no-op",
+			rules:     []Rule{newStubRule("opt-a", true), newStubRule("normal-b", false)},
+			enabled:   []string{"normal-b"},
+			wantNames: []string{"normal-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := applyOptInRules(tt.rules, tt.enabled)
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotNames := make([]string, len(got))
+			for i, r := range got {
+				gotNames[i] = r.RuleNames()
+			}
+			if len(gotNames) != len(tt.wantNames) {
+				t.Fatalf("got %v, want %v", gotNames, tt.wantNames)
+			}
+			for i := range gotNames {
+				if gotNames[i] != tt.wantNames[i] {
+					t.Fatalf("got %v, want %v", gotNames, tt.wantNames)
+				}
+			}
+		})
+	}
+}

--- a/pkg/core/rule.go
+++ b/pkg/core/rule.go
@@ -10,8 +10,8 @@ import (
 
 // BaseRuleはruleの基本構造体
 type BaseRule struct {
-	RuleName   string
-	RuleDesc   string
+	RuleName string
+	RuleDesc string
 	// optIn が true のルールはデフォルト無効 (オプトイン)。
 	// CLI -enable-rule で名前を指定したときだけ動作する。
 	optIn      bool

--- a/pkg/core/rule.go
+++ b/pkg/core/rule.go
@@ -12,6 +12,9 @@ import (
 type BaseRule struct {
 	RuleName   string
 	RuleDesc   string
+	// optIn が true のルールはデフォルト無効 (オプトイン)。
+	// CLI -enable-rule で名前を指定したときだけ動作する。
+	optIn      bool
 	ruleErrors []*LintingError
 	autoFixers []AutoFixer
 	debugOut   io.Writer
@@ -58,6 +61,12 @@ func (rule *BaseRule) RuleDescription() string {
 	return rule.RuleDesc
 }
 
+// IsOptIn は、このルールがデフォルト無効 (オプトイン) かどうかを返す。
+// true の場合、CLI -enable-rule <name> による明示的有効化が必要。
+func (rule *BaseRule) IsOptIn() bool {
+	return rule.optIn
+}
+
 func (rule *BaseRule) EnableDebugOutput(out io.Writer) {
 	rule.debugOut = out
 }
@@ -87,4 +96,5 @@ type Rule interface {
 	UpdateConfig(config *Config)
 	AddAutoFixer(fixer AutoFixer)
 	AutoFixers() []AutoFixer
+	IsOptIn() bool
 }

--- a/pkg/core/timeout_minutes.go
+++ b/pkg/core/timeout_minutes.go
@@ -14,6 +14,7 @@ func TimeoutMinuteRule() *TimeoutMinutesRule {
 		BaseRule: BaseRule{
 			RuleName: "missing-timeout-minutes",
 			RuleDesc: "This rule checks missing timeout-minutes in job level.",
+			optIn:    true,
 		},
 	}
 }

--- a/pkg/core/timeout_minutes_test.go
+++ b/pkg/core/timeout_minutes_test.go
@@ -28,6 +28,9 @@ func TestTimeoutMinuteRule(t *testing.T) {
 			if got.RuleName != tt.want.RuleName || got.RuleDesc != tt.want.RuleDesc {
 				t.Errorf("TimeoutMinuteRule() = %v, want %v", got, tt.want)
 			}
+			if !got.IsOptIn() {
+				t.Errorf("TimeoutMinuteRule().IsOptIn() = false, want true (rule is opt-in)")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Introduces a generic opt-in rule mechanism: `BaseRule.optIn` + `Rule.IsOptIn()`, plus a filter `applyOptInRules(rules, enabled)` that drops opt-in rules unless explicitly listed.
- Adds CLI flag `-enable-rule <name>` (repeatable) wired through `LinterOptions.EnabledOptInRules`. Unknown rule names produce a fatal error.
- Marks `missing-timeout-minutes` as opt-in. The rule, its tests, its auto-fix, and its documentation are preserved — only the default behavior changes.
- E2E regression test (`pkg/core/linter_optin_test.go`) covers the three behaviors: default suppression, explicit enable, unknown rule name.
- Docs (`CLAUDE.md`, `README.md`, `docs/timeoutminutesrule.md`) updated and reconciled so all pages tell the same opt-in story.

## Why

`missing-timeout-minutes` is primarily a best-practice check, not a security finding, and it fires on every job/step lacking an explicit `timeout-minutes`. In real-world repos that produced large, noisy reports and led to discrepancies between Severity Summary counts and Findings counts (raised in sister-repo issue `sisaku-security/sisakuintel-worker#859`). Making the rule opt-in lets teams that want to enforce timeouts opt in explicitly, and removes it from the default noise floor for everyone else.

## Breaking change

- Users who relied on this rule firing by default will see no `missing-timeout-minutes` errors after upgrading. To restore the previous behavior, pass `-enable-rule missing-timeout-minutes` (or set `LinterOptions.EnabledOptInRules`).
- Auto-fix for `timeout-minutes` only runs when the rule itself is enabled; `-fix on` alone no longer adds `timeout-minutes: 5`.

## Design / plan documents

The detailed spec and implementation plan live in `docs/superpowers/specs/` and `docs/superpowers/plans/` respectively (untracked in this PR per project convention; happy to commit them on request).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green (pre-existing flake `TestCrossJobTaintPropagation` unrelated)
- [x] `gofmt -l` clean for files touched by this PR
- [x] `./sisakulint script/actions/timeout-minutes.yaml` → no `missing-timeout-minutes` errors
- [x] `./sisakulint -enable-rule missing-timeout-minutes script/actions/timeout-minutes.yaml` → emits job-level and step-level errors
- [x] `./sisakulint -enable-rule no-such-rule script/actions/timeout-minutes.yaml` → fatal: `unknown rule name passed to -enable-rule: "no-such-rule"`, exit code 3
- [ ] CI green
- [ ] Manual verify on a workflow that previously triggered the rule

## Commits

```
32265dc feat(core): add IsOptIn() infrastructure to Rule
c08a814 feat(core): mark missing-timeout-minutes as opt-in
8d646bb feat(core): add applyOptInRules filter for opt-in rule gating
f2240d9 feat(core): gate opt-in rules in Linter pipeline
92b9dd1 feat(cli): add -enable-rule flag for opt-in rules
cfbef9b test(core): E2E regression for opt-in missing-timeout-minutes
b9ca7a7 docs: document missing-timeout-minutes opt-in status
6849312 docs(timeoutminutesrule): reconcile bottom-of-file with opt-in status
621adcf style(core): gofmt rule.go and optin_test.go
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **New Features**
  * `missing-timeout-minutes` ルールがオプトイン形式に変更。明示的に有効化が必要です。
  * 新しい `-enable-rule` CLI フラグでオプトインルールを有効化できます。例: `sisakulint -enable-rule missing-timeout-minutes`

* **Documentation**
  * ルール有効化方法と新しい CLI フラグの使用方法を説明する追加例を含めました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/466)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->