### PR TITLE
fix(secret-in-log): track output and summary leaks

### DIFF
--- a/docs/secretinlogrule.md
+++ b/docs/secretinlogrule.md
@@ -79,7 +79,7 @@ Derived values flow through standard shell variable assignment and GitHub Action
 The rule performs taint propagation within a single `run` step, and additionally propagates
 taint across steps that belong to the same job via `$GITHUB_ENV`:
 
-1. **Taint sources** — environment variables whose value contains `${{ secrets.* }}` declared at the workflow-level, job-level, or step-level `env` (all four scopes — workflow / job / cross-step / step — are merged, with step-level entries overriding the others on name conflict; cross-step entries propagated from previous steps are also overridden by step-level `env:` on the same name).
+1. **Taint sources** — environment variables whose value either (a) contains `${{ secrets.* }}` declared at workflow-level, job-level, or step-level `env`, or (b) is assigned a tainted `${{ steps.<id>.outputs.<name> }}` expression at step-level `env`. All five sources — workflow `env` / job `env` / cross-step `$GITHUB_ENV` propagation / step-level step-output-derived `env` / step-level secrets `env` — are merged in that order, with later entries overriding earlier ones on name conflict (so step-level entries always win).
 2. **Taint propagation** — shell assignments that reference a tainted variable, including command substitutions (`VAR=$(cmd $TAINTED)`). Propagation is **order-aware**: a single forward pass records the byte offset of each assignment, and sinks that appear *before* the assignment are not flagged (avoids false positives on `a=1; echo $a; a=$SECRET`). Environment-sourced variables are treated as set before the script begins (offset `-1`) and always considered valid.
 3. **Shell function argument propagation** — when a shell function is called with tainted arguments, positional parameters (`$1`, `$2`, `$@`, `$*`) inside the function body inherit that taint. Composite words such as `"$TOKEN-$KEY"` keep all upstream variables, so a partial mask does not suppress an unmasked upstream value.
 4. **Cross-step propagation via `$GITHUB_ENV`** — if a tainted shell variable is written to `$GITHUB_ENV` (via `echo "NAME=$VAR" >> $GITHUB_ENV`, `echo "NAME=$VAR" > $GITHUB_ENV`, or `cat <<EOF >> $GITHUB_ENV ... EOF`), the environment variable `NAME` becomes tainted for subsequent steps in the same job.
@@ -96,7 +96,8 @@ taint across steps that belong to the same job via `$GITHUB_ENV`:
 The following patterns are intentionally excluded from detection because their output does not reach *the current step's* build log directly:
 
 - **Stdout redirected to a file** — `echo "$TOKEN" > secret.txt`, `echo "$TOKEN" 1> out.txt` etc. Redirects to `/dev/stderr`, `/dev/stdout`, `/dev/tty`, or `/dev/fd/{1,2}` are *not* excluded because they are still shown in the log.
-- **Stdout redirected to `$GITHUB_OUTPUT`** — the current step's log does not receive the value, so no warning is raised for the redirect itself. If a subsequent step prints the resulting `${{ steps.<id>.outputs.<name> }}` value, that downstream use is reported.
+- **Stdout redirected to `$GITHUB_OUTPUT`** — the current step's log does not receive the value, so no warning is raised for the redirect itself. If a subsequent step (a) prints the resulting `${{ steps.<id>.outputs.<name> }}` value directly, or (b) assigns that expression to a step-level `env:` and prints the resulting shell variable, both downstream uses are reported.
+- **Direct `${{ secrets.X }}` expression written to `$GITHUB_OUTPUT`** — when a producer step has no env-derived shell taint and writes `${{ secrets.X }}` directly (e.g. `echo "token=${{ secrets.X }}" >> $GITHUB_OUTPUT`), no leak is reported for downstream `${{ steps.<id>.outputs.* }}` expansion. GitHub Actions auto-masks any occurrence of a `secrets.*` value across the entire run, so the same value is masked when the downstream step expands the step output. This rule only tracks shell-derived values whose auto-mask coverage is broken (jq / sed / base64 / etc.).
 - **`printf -v VAR ...`** — captures to a shell variable instead of printing.
 - **Inside command substitutions** — `VAR=$(echo "$SECRET")` does not leak because the inner stdout is captured by `$(...)`.
 
@@ -208,7 +209,7 @@ must be masked before the leak is suppressed.
 
 ### Scope Limitations (MVP)
 
-- **Same-job scope only** — cross-step taint is tracked within a single job via `$GITHUB_ENV`. Taint does not cross *job* boundaries (`needs.*.outputs.*`); cross-job propagation is a planned follow-up (see #432).
+- **Same-job scope only** — cross-step taint is tracked within a single job via `$GITHUB_ENV` and `$GITHUB_OUTPUT`. Taint does not cross *job* boundaries (`needs.*.outputs.*`); cross-job propagation is a planned follow-up (see #432).
 - **`logger` and pipe-consuming commands not yet covered** — `logger`, `xargs`, and similar sinks are not yet detected. Pipes (`cmd1 | cmd2`) flag the upstream source if it is `echo`/`printf`, but the downstream command is not individually analyzed.
 - **Reusable workflow boundaries** — taint does not cross `workflow_call` boundaries; that is a planned follow-up (see #433).
 - **Composite / JS / Docker action internals are not parsed** — only `run:` blocks in the analyzed workflow are inspected. Leaks inside a `uses:`-referenced action are invisible.

--- a/docs/secretinlogrule.md
+++ b/docs/secretinlogrule.md
@@ -82,10 +82,12 @@ taint across steps that belong to the same job via `$GITHUB_ENV`:
 1. **Taint sources** — environment variables whose value contains `${{ secrets.* }}` declared at the workflow-level, job-level, or step-level `env` (all four scopes — workflow / job / cross-step / step — are merged, with step-level entries overriding the others on name conflict; cross-step entries propagated from previous steps are also overridden by step-level `env:` on the same name).
 2. **Taint propagation** — shell assignments that reference a tainted variable, including command substitutions (`VAR=$(cmd $TAINTED)`). Propagation is **order-aware**: a single forward pass records the byte offset of each assignment, and sinks that appear *before* the assignment are not flagged (avoids false positives on `a=1; echo $a; a=$SECRET`). Environment-sourced variables are treated as set before the script begins (offset `-1`) and always considered valid.
 3. **Shell function argument propagation** — when a shell function is called with tainted arguments, positional parameters (`$1`, `$2`, `$@`, `$*`) inside the function body inherit that taint. Composite words such as `"$TOKEN-$KEY"` keep all upstream variables, so a partial mask does not suppress an unmasked upstream value.
-4. **Cross-step propagation via `$GITHUB_ENV`** — if a tainted shell variable is written to `$GITHUB_ENV` (via `echo "NAME=$VAR" >> $GITHUB_ENV`, `echo "NAME=$VAR" > $GITHUB_ENV`, or `cat <<EOF >> $GITHUB_ENV ... EOF`), the environment variable `NAME` becomes tainted for subsequent steps in the same job. Cross-*job* propagation (`needs.*.outputs.*`) and reusable-workflow propagation are separate follow-up items.
-5. **Sink detection** — the following commands are treated as sinks when they reference a tainted variable without a preceding `::add-mask::` for that variable:
+4. **Cross-step propagation via `$GITHUB_ENV`** — if a tainted shell variable is written to `$GITHUB_ENV` (via `echo "NAME=$VAR" >> $GITHUB_ENV`, `echo "NAME=$VAR" > $GITHUB_ENV`, or `cat <<EOF >> $GITHUB_ENV ... EOF`), the environment variable `NAME` becomes tainted for subsequent steps in the same job.
+5. **Cross-step propagation via `$GITHUB_OUTPUT`** — if a tainted shell variable is written to `$GITHUB_OUTPUT` by a step with an `id`, the corresponding `${{ steps.<id>.outputs.<name> }}` expression is treated as secret-derived for subsequent steps in the same job. Direct `run:` interpolation into `echo` / `printf` is flagged, and assigning that expression to `env:` taints the shell variable used by the step. Cross-*job* propagation (`needs.*.outputs.*`) and reusable-workflow propagation are separate follow-up items.
+6. **Sink detection** — the following commands are treated as sinks when they reference a tainted variable without a preceding `::add-mask::` for that variable:
    - `echo` / `printf` with a tainted argument
    - `cat` / `tee` / `dd` receiving tainted data via here-string (`<<<`) or heredoc (`<<EOF ... EOF`)
+   - writes of tainted values to `$GITHUB_STEP_SUMMARY`, because the value is rendered in the job summary UI
 
    Masks that appear *after* the sink are not considered protective, since GitHub Actions applies masking only to subsequent log output.
 
@@ -94,8 +96,7 @@ taint across steps that belong to the same job via `$GITHUB_ENV`:
 The following patterns are intentionally excluded from detection because their output does not reach *the current step's* build log directly:
 
 - **Stdout redirected to a file** — `echo "$TOKEN" > secret.txt`, `echo "$TOKEN" 1> out.txt` etc. Redirects to `/dev/stderr`, `/dev/stdout`, `/dev/tty`, or `/dev/fd/{1,2}` are *not* excluded because they are still shown in the log.
-- **Stdout redirected to `$GITHUB_OUTPUT` / `$GITHUB_STEP_SUMMARY`** — the current step's log does not receive the value, so no warning is raised for the redirect itself.
-  - However **the value is not gone**: writes to `$GITHUB_OUTPUT` become `steps.<id>.outputs.<name>` and will leak if a subsequent step does `run: echo ${{ steps.x.outputs.TOKEN }}`, and writes to `$GITHUB_STEP_SUMMARY` are rendered in the job summary UI. Downstream template-expression leaks and summary-UI leaks are **out of scope** for this rule and are not tracked.
+- **Stdout redirected to `$GITHUB_OUTPUT`** — the current step's log does not receive the value, so no warning is raised for the redirect itself. If a subsequent step prints the resulting `${{ steps.<id>.outputs.<name> }}` value, that downstream use is reported.
 - **`printf -v VAR ...`** — captures to a shell variable instead of printing.
 - **Inside command substitutions** — `VAR=$(echo "$SECRET")` does not leak because the inner stdout is captured by `$(...)`.
 
@@ -105,7 +106,6 @@ These are real leakage paths that this rule does **not** currently detect. They 
 
 - **Shell trace mode (`set -x` / `set -o xtrace` / `PS4`)** — when trace is enabled, bash prints every expanded command to stderr, which goes to the build log. Any command referencing a tainted variable leaks under trace mode. The rule only looks at `echo` / `printf` / `cat` / `tee` / `dd`, so trace-mode leaks are not flagged.
 - **File-based cross-step leakage (non-`$GITHUB_ENV`)** — `echo "$VAL" > /tmp/x` in one step followed by `cat /tmp/x` in another step. Taint is not tracked across the filesystem, and `cat file` (without heredoc / here-string) is not treated as a sink.
-- **Downstream use of `steps.<id>.outputs.*`** — see the `$GITHUB_OUTPUT` note above. The rule does not follow template-expression references between steps.
 - **Composite actions and JavaScript/Docker actions (`uses:`)** — only `run:` scripts in the caller workflow are analyzed. A vulnerable `echo` inside an external action's internals is invisible to this rule.
 - **`eval` / `bash -c '...'` / `trap '...' ERR|EXIT`** — sinks embedded inside a string argument to `eval` or `bash -c`, or inside `trap` handler bodies, are not parsed as `CallExpr` nodes and are therefore not recognized.
 - **Process substitution `>(cmd)` / `<(cmd)`** — sink detection does not descend into process substitutions.
@@ -163,6 +163,27 @@ The first step's derivation (`DERIVED`) is tainted, and writing `TOKEN=$DERIVED`
 marks `TOKEN` as a tainted environment variable for the next step. The next step's `echo "$TOKEN"`
 is therefore flagged even though neither the step nor the job declares `TOKEN` in `env:`.
 
+### Step output propagation example
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SECRET_JSON: ${{ secrets.SECRET_JSON }}
+    steps:
+      - id: derive
+        run: |
+          TOKEN=$(echo "$SECRET_JSON" | jq -r '.token')
+          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+      - run: |
+          echo "got: ${{ steps.derive.outputs.token }}"   # flagged
+```
+
+Writing to `$GITHUB_OUTPUT` does not print the value in the producing step, but GitHub Actions
+does not automatically mask the derived output when a later step expands
+`${{ steps.derive.outputs.token }}`. The rule tracks this same-job path.
+
 ### Shell function argument example
 
 ```yaml
@@ -193,7 +214,7 @@ must be masked before the leak is suppressed.
 - **Composite / JS / Docker action internals are not parsed** — only `run:` blocks in the analyzed workflow are inspected. Leaks inside a `uses:`-referenced action are invisible.
 - **Dynamic shell function dispatch is not resolved** — direct function calls are analyzed, but variable-driven calls such as `$cmd "$TOKEN"` are treated as statically unresolved.
 - **Shell trace mode, `eval` / `bash -c` strings, `trap` handlers, process substitution, env-dumping commands, and indirect expansion are not modeled** — see "Patterns the rule does not analyze at all" above.
-- **`$GITHUB_OUTPUT` downstream references are not tracked** — writes to `$GITHUB_OUTPUT` are excluded as non-sinks for the current step, but subsequent steps that expand `${{ steps.<id>.outputs.* }}` and print the result are not analyzed.
+- **`$GITHUB_OUTPUT` tracking is same-job only** — writes to `$GITHUB_OUTPUT` are tracked for subsequent `steps.<id>.outputs.*` uses in the same job, but job outputs consumed through `needs.*.outputs.*` are not tracked yet.
 
 ### Related Rules
 

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
 	"mvdan.cc/sh/v3/syntax"
 
 	"github.com/sisaku-security/sisakulint/pkg/ast"
+	"github.com/sisaku-security/sisakulint/pkg/expressions"
 	"github.com/sisaku-security/sisakulint/pkg/shell"
 )
 
@@ -33,6 +35,10 @@ type SecretInLogRule struct {
 	// VisitJobPre の冒頭でリセットされ、各 step 処理後に $GITHUB_ENV 書き込みから
 	// 追加される。クロスジョブ伝播は範囲外（follow-up issue）。
 	crossStepEnv map[string]string
+	// crossStepOutputs は同一 Job 内で前 step が `$GITHUB_OUTPUT` 経由で書き出した
+	// tainted な step output を、後続 step の `${{ steps.<id>.outputs.<name> }}`
+	// 参照に引き継ぐためのマップ。
+	crossStepOutputs map[string]map[string]string
 }
 
 // NewSecretInLogRule は新規ルールインスタンスを返す。
@@ -57,6 +63,13 @@ type echoLeakOccurrence struct {
 	Origin   string
 	Position *ast.Position
 	Offset   int // sink のバイトオフセット（script 内での位置。offset-aware な add-mask 判定に使用）
+	Command  string
+}
+
+type stepOutputLeakOccurrence struct {
+	Expr     string
+	Origin   string
+	Position *ast.Position
 	Command  string
 }
 
@@ -196,6 +209,9 @@ func stmtRedirectsStdoutAwayFromLog(stmt *syntax.Stmt) bool {
 		case "/dev/stderr", "/dev/stdout", "/dev/tty", "/dev/fd/1", "/dev/fd/2":
 			continue
 		}
+		if wordIsEnvVarRef(r.Word) == "GITHUB_STEP_SUMMARY" {
+			continue
+		}
 		return true
 	}
 	return false
@@ -304,6 +320,131 @@ func (rule *SecretInLogRule) collectLeakedVars(
 	})
 }
 
+func (rule *SecretInLogRule) findStepOutputExpressionLeaks(script string, runStr *ast.String) []stepOutputLeakOccurrence {
+	if script == "" || len(rule.crossStepOutputs) == 0 {
+		return nil
+	}
+	sanitized, exprMap := sanitizeForShellParse(script)
+	if len(exprMap) == 0 {
+		return nil
+	}
+	placeholderOffsets := expressionOffsetsByPlaceholder(script)
+	parser := syntax.NewParser(syntax.KeepComments(true), syntax.Variant(syntax.LangBash))
+	file, err := parser.Parse(strings.NewReader(sanitized), "")
+	if err != nil || file == nil {
+		return nil
+	}
+
+	var leaks []stepOutputLeakOccurrence
+	syntax.Walk(file, func(node syntax.Node) bool {
+		if _, isCmdSubst := node.(*syntax.CmdSubst); isCmdSubst {
+			return false
+		}
+		if stmt, isStmt := node.(*syntax.Stmt); isStmt {
+			if stmtRedirectsStdoutAwayFromLog(stmt) {
+				return false
+			}
+			return true
+		}
+		call, ok := node.(*syntax.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		cmdName := leadingBareLiteral(call.Args[0])
+		if cmdName != "echo" && cmdName != "printf" {
+			return true
+		}
+		if cmdName == "printf" && len(call.Args) >= 2 && leadingBareLiteral(call.Args[1]) == "-v" {
+			return true
+		}
+		for _, arg := range call.Args[1:] {
+			rule.collectLeakedStepOutputExprs(arg, exprMap, placeholderOffsets, script, runStr, cmdName, &leaks)
+		}
+		return true
+	})
+	return leaks
+}
+
+func (rule *SecretInLogRule) collectLeakedStepOutputExprs(
+	arg *syntax.Word,
+	exprMap map[string]string,
+	placeholderOffsets map[string]int,
+	script string,
+	runStr *ast.String,
+	cmdName string,
+	leaks *[]stepOutputLeakOccurrence,
+) {
+	seen := make(map[string]struct{})
+	syntax.Walk(arg, func(node syntax.Node) bool {
+		var text string
+		switch n := node.(type) {
+		case *syntax.Lit:
+			text = n.Value
+		case *syntax.SglQuoted:
+			text = n.Value
+		default:
+			return true
+		}
+		for _, placeholder := range taintPlaceholderPattern.FindAllString(text, -1) {
+			expr, ok := exprMap[placeholder]
+			if !ok {
+				continue
+			}
+			path, origin, ok := rule.resolveTaintedStepOutputExpr(expr)
+			if !ok {
+				continue
+			}
+			key := path + "\x00" + cmdName
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			offset := placeholderOffsets[placeholder]
+			if hasAddMaskForExpressionBefore(script, expr, offset) {
+				continue
+			}
+			*leaks = append(*leaks, stepOutputLeakOccurrence{
+				Expr:     path,
+				Origin:   origin,
+				Position: offsetToPosition(runStr, script, offset),
+				Command:  cmdName,
+			})
+		}
+		return true
+	})
+}
+
+func expressionOffsetsByPlaceholder(script string) map[string]int {
+	offsets := make(map[string]int)
+	for i, m := range taintGhExprPattern.FindAllStringSubmatchIndex(script, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		offsets[taintPlaceholderPrefix+strconv.Itoa(i)+"_"] = m[0]
+	}
+	return offsets
+}
+
+func hasAddMaskForExpressionBefore(script, expr string, beforeOffset int) bool {
+	for _, m := range taintGhExprPattern.FindAllStringSubmatchIndex(script, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		if strings.TrimSpace(script[m[2]:m[3]]) != strings.TrimSpace(expr) {
+			continue
+		}
+		exprStart := m[0]
+		prefixStart := exprStart - len("::add-mask::")
+		if prefixStart < 0 || !strings.HasSuffix(script[:exprStart], "::add-mask::") {
+			continue
+		}
+		if beforeOffset < 0 || exprStart <= beforeOffset {
+			return true
+		}
+	}
+	return false
+}
+
 // hasAddMaskFor は script 内に該当変数への ::add-mask:: 呼び出しがあれば true。
 // ブレース形式 "${NAME}" は常に "}" で終端されるため単純検索で十分。
 // ベア形式 "$NAME" は識別子境界チェックを行い、"$NAME_SUFFIX" の誤マッチを防ぐ。
@@ -376,6 +517,7 @@ func (rule *SecretInLogRule) VisitWorkflowPre(node *ast.Workflow) error {
 func (rule *SecretInLogRule) VisitJobPre(node *ast.Job) error {
 	rule.jobEnvSecrets = rule.collectSecretEnvVars(node.Env)
 	rule.crossStepEnv = make(map[string]string)
+	rule.crossStepOutputs = make(map[string]map[string]string)
 	for _, step := range node.Steps {
 		rule.checkStep(step)
 	}
@@ -410,9 +552,17 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 	for k, v := range rule.crossStepEnv {
 		initialTainted[k] = shell.Entry{Sources: []string{v}, Offset: -1}
 	}
+	for k, v := range rule.collectTaintedStepOutputEnvVars(step.Env) {
+		initialTainted[k] = shell.Entry{Sources: []string{v}, Offset: -1}
+	}
 	for k, v := range rule.collectSecretEnvVars(step.Env) {
 		initialTainted[k] = shell.Entry{Sources: []string{v}, Offset: -1}
 	}
+
+	for _, leak := range rule.findStepOutputExpressionLeaks(script, execRun.Run) {
+		rule.reportStepOutputLeak(leak)
+	}
+
 	if len(initialTainted) == 0 {
 		return
 	}
@@ -437,6 +587,14 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 	// 判定に使うため、ここでは展開せずそのまま流す (spec §5.2)。
 	for name, origin := range rule.collectGitHubEnvTaintWrites(file, scoped, script) {
 		rule.crossStepEnv[name] = origin
+	}
+	if step.ID != nil && step.ID.Value != "" {
+		for name, origin := range rule.collectGitHubOutputTaintWrites(file, scoped, script) {
+			if rule.crossStepOutputs[step.ID.Value] == nil {
+				rule.crossStepOutputs[step.ID.Value] = make(map[string]string)
+			}
+			rule.crossStepOutputs[step.ID.Value][name] = origin
+		}
 	}
 }
 
@@ -467,6 +625,18 @@ func (rule *SecretInLogRule) reportLeak(leak echoLeakOccurrence) {
 			"tools like jq are not masked and will appear in plaintext in build logs. %s "+
 			"See https://sisaku-security.github.io/lint/docs/rules/secretinlogrule/",
 		leak.VarName, leak.Origin, leak.Command, suggestion,
+	)
+}
+
+func (rule *SecretInLogRule) reportStepOutputLeak(leak stepOutputLeakOccurrence) {
+	rule.Errorf(
+		leak.Position,
+		"secret in log: step output %s (origin: %s) is printed via '%s' without masking. "+
+			"Values written to $GITHUB_OUTPUT are not automatically masked when later expanded "+
+			"through steps.*.outputs.* and can appear in plaintext in build logs. "+
+			"Pass the output through an environment variable and mask it before printing, or avoid printing the value. "+
+			"See https://sisaku-security.github.io/lint/docs/rules/secretinlogrule/",
+		leak.Expr, leak.Origin, leak.Command,
 	)
 }
 
@@ -713,9 +883,9 @@ func wordIsEnvVarRef(w *syntax.Word) string {
 	return ""
 }
 
-// stmtRedirectsToGitHubEnv は Stmt の Redirs に `> $GITHUB_ENV` / `>> $GITHUB_ENV` 系が
-// 含まれていれば true。書き込み先の Word が $GITHUB_ENV の参照であるかを AST で判定する。
-func stmtRedirectsToGitHubEnv(stmt *syntax.Stmt) bool {
+// stmtRedirectsToGitHubFile は Stmt の Redirs に `> $TARGET` / `>> $TARGET` 系が
+// 含まれていれば true。書き込み先の Word が指定 env var の参照であるかを AST で判定する。
+func stmtRedirectsToGitHubFile(stmt *syntax.Stmt, target string) bool {
 	if stmt == nil {
 		return false
 	}
@@ -731,11 +901,17 @@ func stmtRedirectsToGitHubEnv(stmt *syntax.Stmt) bool {
 		if r.N != nil && r.N.Value != "" && r.N.Value != "1" {
 			continue
 		}
-		if wordIsEnvVarRef(r.Word) == "GITHUB_ENV" {
+		if wordIsEnvVarRef(r.Word) == target {
 			return true
 		}
 	}
 	return false
+}
+
+// stmtRedirectsToGitHubEnv は Stmt の Redirs に `> $GITHUB_ENV` / `>> $GITHUB_ENV` 系が
+// 含まれていれば true。
+func stmtRedirectsToGitHubEnv(stmt *syntax.Stmt) bool {
+	return stmtRedirectsToGitHubFile(stmt, "GITHUB_ENV")
 }
 
 // firstNameEqualsPrefix は Word の先頭 Lit 部分から `NAME=` 形式の NAME を取り出す。
@@ -775,6 +951,23 @@ func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
 	scoped *shell.ScopedTaint,
 	script string,
 ) map[string]string {
+	return rule.collectGitHubFileTaintWrites(file, scoped, script, "GITHUB_ENV")
+}
+
+func (rule *SecretInLogRule) collectGitHubOutputTaintWrites(
+	file *syntax.File,
+	scoped *shell.ScopedTaint,
+	script string,
+) map[string]string {
+	return rule.collectGitHubFileTaintWrites(file, scoped, script, "GITHUB_OUTPUT")
+}
+
+func (rule *SecretInLogRule) collectGitHubFileTaintWrites(
+	file *syntax.File,
+	scoped *shell.ScopedTaint,
+	script string,
+	target string,
+) map[string]string {
 	result := make(map[string]string)
 	if file == nil {
 		return result
@@ -784,7 +977,7 @@ func (rule *SecretInLogRule) collectGitHubEnvTaintWrites(
 		if !ok {
 			return true
 		}
-		if !stmtRedirectsToGitHubEnv(stmt) {
+		if !stmtRedirectsToGitHubFile(stmt, target) {
 			return true
 		}
 		call, ok := stmt.Cmd.(*syntax.CallExpr)
@@ -951,4 +1144,70 @@ func (rule *SecretInLogRule) collectSecretEnvVars(env *ast.Env) map[string]strin
 		result[name] = strings.Join(origins, ",")
 	}
 	return result
+}
+
+func (rule *SecretInLogRule) collectTaintedStepOutputEnvVars(env *ast.Env) map[string]string {
+	result := make(map[string]string)
+	if env == nil || env.Vars == nil || len(rule.crossStepOutputs) == 0 {
+		return result
+	}
+	for key, envVar := range env.Vars {
+		if envVar == nil || envVar.Value == nil || !envVar.Value.ContainsExpression() {
+			continue
+		}
+		name := key
+		if envVar.Name != nil && envVar.Name.Value != "" {
+			name = envVar.Name.Value
+		}
+		matches := taintGhExprPattern.FindAllStringSubmatch(envVar.Value.Value, -1)
+		for _, match := range matches {
+			if len(match) < 2 {
+				continue
+			}
+			path, origin, ok := rule.resolveTaintedStepOutputExpr(match[1])
+			if !ok {
+				continue
+			}
+			result[name] = path + " (origin: " + origin + ")"
+			break
+		}
+	}
+	return result
+}
+
+func (rule *SecretInLogRule) resolveTaintedStepOutputExpr(exprStr string) (string, string, bool) {
+	path := normalizeStepOutputExprPath(exprStr)
+	if path == "" {
+		return "", "", false
+	}
+	parts := strings.Split(path, ".")
+	if len(parts) < 4 || parts[0] != "steps" || parts[2] != "outputs" {
+		return "", "", false
+	}
+	stepID := parts[1]
+	outputName := strings.Join(parts[3:], ".")
+	if outputs := rule.crossStepOutputs[stepID]; outputs != nil {
+		if origin, ok := outputs[outputName]; ok {
+			return path, origin, true
+		}
+	}
+	return "", "", false
+}
+
+func normalizeStepOutputExprPath(exprStr string) string {
+	exprStr = strings.TrimSpace(exprStr)
+	if exprStr == "" {
+		return ""
+	}
+	tokenInput := exprStr
+	if !strings.HasSuffix(tokenInput, "}}") {
+		tokenInput += "}}"
+	}
+	l := expressions.NewTokenizer(tokenInput)
+	p := expressions.NewMiniParser()
+	node, err := p.Parse(l)
+	if err == nil && node != nil {
+		return exprNodeToString(node)
+	}
+	return exprStr
 }

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -425,6 +425,21 @@ func expressionOffsetsByPlaceholder(script string) map[string]int {
 	return offsets
 }
 
+// hasAddMaskForExpressionBefore は script 内に同一の `${{ ... }}` 表現に対する
+// `echo "::add-mask::${{ ... }}"` 呼び出しがあり、かつその位置（バイトオフセット）が
+// beforeOffset 以下なら true を返す。beforeOffset に負の値を渡すと位置制約なし。
+//
+// "current-occurrence mask" 不変条件:
+//   GitHub Actions の `::add-mask::` は発行 *後* のログ出力にのみ適用されるため、
+//   sink occurrence より前に置かれた mask 行のみが保護として機能する。
+//   同じ表現が script 内に複数回出現する場合、最初の occurrence が mask 行の前に
+//   置かれていても（例: `: "${{ X }}"; echo "::add-mask::${{ X }}"; echo "${{ X }}"`)、
+//   2 回目以降の occurrence は mask 後のものなので保護される。判定は「mask 行の
+//   位置が *この* sink occurrence （beforeOffset）以下か」で行う必要がある。
+//
+// `exprStart <= beforeOffset` は等号を許容することで `beforeOffset == exprStart`
+// （mask 行自身を sink として誤検出しないための再帰的な保護）も拾う。
+// `beforeOffset < 0` は位置制約なしの全域走査用フォールバック。
 func hasAddMaskForExpressionBefore(script, expr string, beforeOffset int) bool {
 	for _, m := range taintGhExprPattern.FindAllStringSubmatchIndex(script, -1) {
 		if len(m) < 4 {
@@ -434,8 +449,9 @@ func hasAddMaskForExpressionBefore(script, expr string, beforeOffset int) bool {
 			continue
 		}
 		exprStart := m[0]
-		prefixStart := exprStart - len("::add-mask::")
-		if prefixStart < 0 || !strings.HasSuffix(script[:exprStart], "::add-mask::") {
+		// `::add-mask::${{ ... }}` 形式の検出。`HasSuffix` は prefix が短い場合
+		// false を返すため、明示的な長さチェックは不要。
+		if !strings.HasSuffix(script[:exprStart], "::add-mask::") {
 			continue
 		}
 		if beforeOffset < 0 || exprStart <= beforeOffset {
@@ -628,6 +644,14 @@ func (rule *SecretInLogRule) reportLeak(leak echoLeakOccurrence) {
 	)
 }
 
+// reportStepOutputLeak は stepOutputLeakOccurrence をエラーとして記録する。
+//
+// Phase 1 では autofix を実装しない (warning のみ): この経路は consumer 側の
+// `${{ steps.<id>.outputs.* }}` 直接展開なので、autofix は (a) 直前に
+// `echo "::add-mask::${{ … }}"` 行を挿入する形か、(b) producer 側の export を
+// env 経由に書き換える形のいずれかが必要で、後者は producer/consumer 両方の
+// step を編集することになり影響範囲が広い。Phase 2 で対応予定。
+// echoLeak 経路 (env 由来 shellvar) との非対称はこの理由による。
 func (rule *SecretInLogRule) reportStepOutputLeak(leak stepOutputLeakOccurrence) {
 	rule.Errorf(
 		leak.Position,
@@ -906,12 +930,6 @@ func stmtRedirectsToGitHubFile(stmt *syntax.Stmt, target string) bool {
 		}
 	}
 	return false
-}
-
-// stmtRedirectsToGitHubEnv は Stmt の Redirs に `> $GITHUB_ENV` / `>> $GITHUB_ENV` 系が
-// 含まれていれば true。
-func stmtRedirectsToGitHubEnv(stmt *syntax.Stmt) bool {
-	return stmtRedirectsToGitHubFile(stmt, "GITHUB_ENV")
 }
 
 // firstNameEqualsPrefix は Word の先頭 Lit 部分から `NAME=` 形式の NAME を取り出す。

--- a/pkg/core/secretinlog_test.go
+++ b/pkg/core/secretinlog_test.go
@@ -1321,6 +1321,127 @@ func TestSecretInLog_GitHubStepSummaryWriteFlagged(t *testing.T) {
 	}
 }
 
+// TestSecretInLog_GitHubStepSummary_PrintfFlagged は printf 経由の
+// $GITHUB_STEP_SUMMARY 書き込みも検出されることをピン留めする。
+// stmtRedirectsStdoutAwayFromLog の例外（line 212）が echo だけでなく
+// printf にも適用されることのリグレッションガード。
+func TestSecretInLog_GitHubStepSummary_PrintfFlagged(t *testing.T) {
+	t.Parallel()
+
+	step := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\nprintf \"debug: %s\\n\" \"$D\" >> $GITHUB_STEP_SUMMARY",
+	)
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 printf $GITHUB_STEP_SUMMARY leak, got %d: %v", got, rule.Errors())
+	}
+}
+
+// TestSecretInLog_GitHubStepSummary_HeredocFlagged は heredoc 形式の
+// $GITHUB_STEP_SUMMARY 書き込みも検出されることをピン留めする。
+// `cat <<EOF >> $GITHUB_STEP_SUMMARY ... EOF` は collectRedirectSinkLeaks の
+// heredoc sink 経路で flagged される想定。
+func TestSecretInLog_GitHubStepSummary_HeredocFlagged(t *testing.T) {
+	t.Parallel()
+
+	step := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\ncat <<EOF >> $GITHUB_STEP_SUMMARY\ndebug: $D\nEOF",
+	)
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 heredoc $GITHUB_STEP_SUMMARY leak, got %d: %v", got, rule.Errors())
+	}
+}
+
+// TestSecretInLog_CrossStep_NoIDStepOutputDoesNotPropagate は ID を持たない
+// step の $GITHUB_OUTPUT 書き込みが crossStepOutputs に登録されないことを
+// ピン留めする。checkStep の `step.ID != nil && step.ID.Value != ""` ゲート
+// （line 591）のリグレッションガード。
+func TestSecretInLog_CrossStep_NoIDStepOutputDoesNotPropagate(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	// step1.ID は意図的に未設定。
+	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ steps.derive.outputs.token }}"`)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 0 {
+		t.Errorf("ID-less step output write must not propagate; got %d: %v", got, rule.Errors())
+	}
+}
+
+// TestSecretInLog_CrossStep_NeedsOutputsNotFlagged は cross-job propagation
+// （needs.<job>.outputs.<name>）が現在は範囲外であることをピン留めする。
+// resolveTaintedStepOutputExpr が `parts[0] != "steps"` を弾くロジック
+// （line 1184）が誤って needs を受け入れるよう拡張された場合、このテストが落ちる。
+func TestSecretInLog_CrossStep_NeedsOutputsNotFlagged(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	// downstream は needs.<job>.outputs.* を expand している想定。
+	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ needs.upstream.outputs.token }}"`)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 0 {
+		t.Errorf("needs.*.outputs.* is out of scope; got %d unexpected errors: %v", got, rule.Errors())
+	}
+}
+
+// TestSecretInLog_CrossStep_DirectSecretsExprToOutput は producer step が
+// env を介さず直接 ${{ secrets.X }} を $GITHUB_OUTPUT に書く場合、
+// downstream の ${{ steps.derive.outputs.token }} は flag されないことを
+// ピン留めする。
+//
+// この挙動は意図的: GitHub Actions は secrets.* の値をすべての log 出力で
+// 自動マスクするため、shell 派生（jq / sed / base64 等）を経由しない直接の
+// secrets 値は downstream で自動マスクされ、leak にならない。
+// このルールは「shell 派生で auto-mask が外れた値」を対象とするため、
+// 直接表現はあえて追跡しない。env 経由の derivation を介したケース
+// (TestSecretInLog_CrossStep_GithubOutputDirectExpressionLeak) との対比。
+func TestSecretInLog_CrossStep_DirectSecretsExprToOutput(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t, nil, `echo "token=${{ secrets.S }}" >> $GITHUB_OUTPUT`)
+	step1.ID = &ast.String{Value: "derive"}
+	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ steps.derive.outputs.token }}"`)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 0 {
+		t.Errorf("direct secrets.* expression to $GITHUB_OUTPUT relies on GHA auto-mask; got %d unexpected errors: %v", got, rule.Errors())
+	}
+}
+
 func TestSecretInLog_CrossStep_StepEnvOverridesCrossStep(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/core/secretinlog_test.go
+++ b/pkg/core/secretinlog_test.go
@@ -82,7 +82,7 @@ func TestSecretInLog_FindEchoLeaks(t *testing.T) {
 			}{{"PRIVATE_KEY", "echo"}},
 		},
 		{
-			name: "double-quoted dynamic command name is not echo",
+			name:     "double-quoted dynamic command name is not echo",
 			script:   "SUFFIX=x\n\"echo$SUFFIX\" \"$TOKEN\"\n",
 			tainted:  map[string]shell.Entry{"TOKEN": {Sources: []string{"secrets.API"}, Offset: -1}},
 			wantHits: nil,
@@ -1211,6 +1211,116 @@ func TestSecretInLog_CrossStep_GithubOutputDoesNotPropagate(t *testing.T) {
 	}
 }
 
+func TestSecretInLog_CrossStep_GithubOutputDirectExpressionLeak(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ steps.derive.outputs.token }}"`)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 GITHUB_OUTPUT downstream leak, got %d: %v", got, rule.Errors())
+	}
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "steps.derive.outputs.token") {
+		t.Errorf("message should mention the tainted step output, got: %s", msg)
+	}
+}
+
+func TestSecretInLog_CrossStep_GithubOutputEnvExpressionLeak(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	step2 := mkRunStepForTest(t,
+		map[string]string{"TOKEN": "${{ steps.derive.outputs.token }}"},
+		`echo "$TOKEN"`,
+	)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 GITHUB_OUTPUT env downstream leak, got %d: %v", got, rule.Errors())
+	}
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "steps.derive.outputs.token") {
+		t.Errorf("message should mention the tainted step output, got: %s", msg)
+	}
+}
+
+func TestSecretInLog_CrossStep_GithubOutputDirectExpressionMasked(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	step2 := mkRunStepForTest(t, nil, `echo "::add-mask::${{ steps.derive.outputs.token }}"
+echo "got: ${{ steps.derive.outputs.token }}"`)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("masked GITHUB_OUTPUT expression should not leak, got %d: %v", got, rule.Errors())
+	}
+}
+
+func TestSecretInLog_CrossStep_GithubOutputExpressionMaskUsesCurrentOccurrence(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	step2 := mkRunStepForTest(t, nil, `: "${{ steps.derive.outputs.token }}"
+echo "::add-mask::${{ steps.derive.outputs.token }}"
+echo "got: ${{ steps.derive.outputs.token }}"`)
+	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("mask before current sink should suppress even when expression appeared earlier, got %d: %v", got, rule.Errors())
+	}
+}
+
+func TestSecretInLog_GitHubStepSummaryWriteFlagged(t *testing.T) {
+	t.Parallel()
+
+	step := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"debug: $D\" >> $GITHUB_STEP_SUMMARY",
+	)
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	rule := NewSecretInLogRule()
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 GITHUB_STEP_SUMMARY leak, got %d: %v", got, rule.Errors())
+	}
+}
+
 func TestSecretInLog_CrossStep_StepEnvOverridesCrossStep(t *testing.T) {
 	t.Parallel()
 
@@ -1393,10 +1503,11 @@ func TestSecretInLog_LineContinuationDoesNotBreakDetection(t *testing.T) {
 // Literal block 補正、out-of-range フォールバックを直接 assert する。
 //
 // script のオフセット境界:
-//   "echo $TOKEN\n  echo $SECRET\n"
-//        ^5             ^19
-//   - line 1: `echo $TOKEN` (offset 0..10), '\n' at 11
-//   - line 2: `  echo $SECRET` (offset 12..25), '\n' at 26
+//
+//	"echo $TOKEN\n  echo $SECRET\n"
+//	     ^5             ^19
+//	- line 1: `echo $TOKEN` (offset 0..10), '\n' at 11
+//	- line 2: `  echo $SECRET` (offset 12..25), '\n' at 26
 func TestOffsetToPosition_ColumnValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Track tainted same-job `$GITHUB_OUTPUT` writes from steps with an `id` and report downstream `${{ steps.<id>.outputs.<name> }}` leaks when printed via `echo` / `printf`.
- Treat tainted writes to `$GITHUB_STEP_SUMMARY` as `secret-in-log` findings because they render in the job summary UI.
- Add regression tests for direct output expression leaks, env-mediated output leaks, masked output expressions, current-occurrence mask handling, and summary writes.
- Update the `secret-in-log` docs to describe same-job output propagation and the remaining `needs.*.outputs.*` limitation.

## Why

Issue #442 identified that `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY` were excluded as ordinary file redirects. That was correct for the producing step's build log, but missed downstream output expansion and summary UI disclosure paths.

## Validation

- `go test -count=1 ./...`
- `git diff --check`

Fixes #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ステップ出力式（${{ steps.<id>.outputs.* }}）を通じたシークレットリークの検出と報告を実装
  * GITHUB_STEP_SUMMARYへのシークレット書き込み検出機能を追加
  * マスキング検出の精度を向上

* **ドキュメント**
  * 検出ロジックの詳細な説明とステップ出力伝播の具体例を追加
  * スコープ制限事項を明確化

* **テスト**
  * クロスステップ処理に関する複数のテストケースを追加

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/468)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->