### PR TITLE
Detect composite action cache poisoning

### DIFF
--- a/docs/cachepoisoningrule.md
+++ b/docs/cachepoisoningrule.md
@@ -11,7 +11,7 @@ weight: 1
 
 ### Cache Poisoning Rule Overview
 
-This rule detects potential cache poisoning vulnerabilities in GitHub Actions workflows. It identifies two types of cache poisoning attacks:
+This rule detects potential cache poisoning vulnerabilities in GitHub Actions workflows. It covers direct cache actions, setup actions that enable caching, and composite actions that invoke cache actions directly or transitively.
 
 ### Security Impact
 
@@ -27,18 +27,22 @@ Cache poisoning vulnerabilities pose significant risks to CI/CD pipeline integri
 This vulnerability aligns with **OWASP CI/CD Security Risk CICD-SEC-9: Improper Artifact Integrity Validation**.
 
 1. **Indirect Cache Poisoning**: Dangerous combinations of untrusted triggers with unsafe checkout and cache operations
-2. **Direct Cache Poisoning**: Untrusted input in cache configuration (key, restore-keys, path) that can be exploited regardless of trigger type
+2. **Composite Action Cache Poisoning**: Unsafe checkout followed by a composite action that invokes `actions/cache` or a setup action with caching enabled
+3. **Direct Cache Poisoning**: Untrusted input in cache configuration (key, restore-keys, path) that can be exploited regardless of trigger type
 
-The rule detects three types of cache poisoning attacks:
+The rule detects four types of cache poisoning attacks:
 1. **Indirect Cache Poisoning**: Untrusted triggers + unsafe checkout + cache actions
-2. **Cache Hierarchy Exploitation**: Workflows that can write to default branch cache via external triggers
-3. **Cache Eviction Risk**: Multiple cache actions that could enable cache flooding attacks
+2. **Composite Action Cache Poisoning**: Untrusted triggers + unsafe checkout + local or remote composite actions that use cache
+3. **Cache Hierarchy Exploitation**: Workflows that can write to default branch cache via external triggers
+4. **Cache Eviction Risk**: Multiple cache actions that could enable cache flooding attacks
 
 #### Key Features
 
 - **Dual Detection Mode**: Detects both indirect (trigger-based) and direct (input-based) cache poisoning
 - **Multiple Trigger Detection**: Identifies `issue_comment`, `pull_request_target`, and `workflow_run` triggers
 - **Comprehensive Cache Detection**: Detects both `actions/cache` and setup-* actions with cache enabled
+- **Composite Action Metadata Resolution**: Resolves local and remote action metadata, including `owner/repo@ref` and `owner/repo/path@ref`, to find direct and bounded transitive cache usage
+- **Job-Level Trigger Scoping**: Honors job-level `if:` filters such as `github.event_name == 'push'` to avoid applying workflow-level unsafe triggers to jobs that cannot run on them
 - **Direct Cache Input Validation**: Checks for untrusted expressions in `key`, `restore-keys`, and `path` inputs
 - **Job Isolation**: Correctly scopes detection to individual jobs
 - **Smart Checkout Tracking**: Resets unsafe state when a safe checkout follows an unsafe one
@@ -77,6 +81,24 @@ The rule triggers when all three conditions are met
    - `actions/setup-python` with `cache` input
    - `actions/setup-go` with `cache` input
    - `actions/setup-java` with `cache` input
+   - A composite action that invokes one of the above directly or through another composite action
+
+#### Composite Action Cache Poisoning
+
+The rule also resolves action metadata for composite actions. This detects cases where the workflow itself does not contain `actions/cache`, but calls a composite action that does.
+
+This is important for workflows that use a privileged trigger, check out fork-controlled PR code, and then call a mutable remote composite action such as `owner/repo/path@main`. In that shape, cache writes may happen in the base repository cache scope even when the workflow appears to grant only read permissions.
+
+The rule reports when all conditions are met:
+
+1. The job can run on an unsafe trigger (`pull_request_target`, `issue_comment`, or `workflow_run`)
+2. The job checks out untrusted PR code
+3. A later step calls a composite action whose metadata resolves to:
+   - `actions/cache`
+   - `actions/setup-*` with `cache` enabled
+   - Another composite action that eventually invokes one of the above
+
+For mutable remote composite actions, the rule also warns when the action currently resolves as composite but the visible metadata does not show cache usage. This covers historical-cache-risk cases where the current `@main` state may no longer contain the exact vulnerable transitive cache call.
 
 #### Direct Cache Poisoning (Input-Based)
 
@@ -189,6 +211,32 @@ jobs:
             pip-${{ github.head_ref }}-
 ```
 
+#### Example 4: Composite Action Cache Poisoning (TanStack-Style)
+
+```yaml
+name: Bundle Size
+on:
+  pull_request_target:
+
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      # VULNERABLE: this remote composite action can invoke actions/cache transitively.
+      # In pull_request_target, cache writes happen in the base repository scope.
+      - uses: TanStack/config/.github/setup@main
+
+      - run: pnpm nx run @benchmarks/bundle-size:build
+```
+
+This pattern is risky even with `permissions: contents: read`. GitHub Actions cache writes are not controlled by the workflow `GITHUB_TOKEN` permissions in the same way as repository API access.
+
 ### Example Output
 
 #### Indirect Cache Poisoning Output
@@ -213,6 +261,15 @@ $ sisakulint ./cache-poisoning-direct.yaml
 
 ./cache-poisoning-direct.yaml:18:22: cache poisoning via untrusted input: 'github.head_ref' in cache restore-keys is potentially untrusted. An attacker can control the cache key to poison the cache. Use trusted inputs like github.sha, hashFiles(), or static values instead [cache-poisoning]
       18 👈|            pip-${{ github.head_ref }}-
+```
+
+#### Composite Action Cache Poisoning Output
+
+```bash
+$ sisakulint ./bundle-size.yaml
+
+./bundle-size.yaml:16:9: cache poisoning risk (critical): composite action 'TanStack/config/.github/setup@main' invokes 'actions/cache@v5' after checking out untrusted PR code (triggers: pull_request_target, chain: TanStack/config/.github/setup@main -> actions/cache@v5). This can persist attacker-controlled dependency state through GitHub Actions cache scope crossing; validate cached content or scope cache to PR level [cache-poisoning]
+      16 👈|      - uses: TanStack/config/.github/setup@main
 ```
 
 ### Safe Patterns
@@ -280,6 +337,20 @@ jobs:
       - uses: actions/cache@v3  # Safe: cache operates on base branch code
 ```
 
+5. Job Filtered to Safe Trigger
+```yaml
+on: [pull_request_target, push]
+
+jobs:
+  push-only:
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/cache@v4  # Safe for this rule: this job cannot run on pull_request_target
+```
+
 ### Auto-fix Support
 
 The cache-poisoning rule supports auto-fixing for both types of vulnerabilities:
@@ -338,6 +409,9 @@ After fix
 2. **Scope Cache to PR**: Use PR-specific cache keys to isolate caches
 3. **Isolate Workflows**: Separate untrusted code execution from privileged operations
 4. **Use Safe Checkout**: Avoid checking out PR code in workflows with untrusted triggers and caching
+5. **Audit Composite Actions**: Treat remote composite actions as part of the workflow. Review their `action.yml` and nested `uses` steps for cache writes.
+6. **Pin Remote Actions**: Pin third-party or cross-repository composite actions to a full commit SHA rather than mutable refs such as `@main`.
+7. **Avoid Cache Writes in Privileged PR Jobs**: Prefer read-only cache restore or disable caching when a `pull_request_target` job must inspect untrusted PR code.
 
 #### For Direct Cache Poisoning
 
@@ -508,6 +582,9 @@ sisakulint uses a **conservative detection strategy** for maximum security:
 
 - **Direct patterns**: Detects explicit PR head references like `github.head_ref` and `github.event.pull_request.head.sha`
 - **Indirect patterns**: Detects step outputs that may contain PR head references (e.g., `steps.*.outputs.head_sha`)
+- **PR merge refs**: Detects `refs/pull/.../merge` checkout refs as untrusted PR code in privileged workflows
+- **Composite metadata**: Resolves composite action metadata to find direct and transitive cache usage hidden behind `uses:` steps
+- **Job-level filtering**: Uses job-level trigger analysis so jobs restricted to safe events do not inherit unrelated unsafe workflow triggers
 - **Unknown expressions**: Any unknown expression in `ref` with untrusted triggers is treated as potentially unsafe
 
 This conservative approach may result in some false positives but ensures that subtle attack vectors are not missed.
@@ -520,6 +597,8 @@ This conservative approach may result in some false positives but ensures that s
 | Label guards | Considers `if: contains(labels)` as safe | Reports warning (conservative) |
 | Multiple checkouts | May not handle correctly | Resets state on safe checkout |
 | Step outputs | Limited detection | Comprehensive pattern matching |
+| Composite actions | Limited to visible workflow steps | Resolves local and remote composite metadata |
+| Job-level trigger filters | Limited | Honors analyzable `github.event_name` conditions |
 
 **Example difference**: CodeQL may consider workflows with label guards safe, but sisakulint still reports warnings because label-based protection depends on operational procedures that may fail.
 
@@ -533,6 +612,8 @@ This rule addresses CICD-SEC-9: Improper Artifact Integrity Validation and helps
 - [GitHub Actions Security: Preventing Pwn Requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
 - [OWASP CI/CD Top 10: CICD-SEC-9](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation)
 - [The Monsters in Your Build Cache - GitHub Actions Cache Poisoning](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/) - Detailed analysis of cache hierarchy exploitation
+- [TanStack npm supply-chain compromise postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)
+- [StepSecurity: Mini Shai-Hulud supply-chain attack report](https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem)
 
 {{< popup_link2 href="https://codeql.github.com/codeql-query-help/actions/actions-cache-poisoning-direct-cache/" >}}
 
@@ -541,3 +622,7 @@ This rule addresses CICD-SEC-9: Improper Artifact Integrity Validation and helps
 {{< popup_link2 href="https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation" >}}
 
 {{< popup_link2 href="https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/" >}}
+
+{{< popup_link2 href="https://tanstack.com/blog/npm-supply-chain-compromise-postmortem" >}}
+
+{{< popup_link2 href="https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem" >}}

--- a/pkg/core/cachepoisoningrule.go
+++ b/pkg/core/cachepoisoningrule.go
@@ -20,6 +20,7 @@ import (
 type CachePoisoningRule struct {
 	BaseRule
 	unsafeTriggers      []string
+	jobUnsafeTriggers   []string
 	checkoutUnsafeRef   bool
 	unsafeCheckoutStep  *ast.Step
 	autoFixerRegistered bool
@@ -192,6 +193,27 @@ func (rule *CachePoisoningRule) VisitJobPre(node *ast.Job) error {
 	rule.checkoutUnsafeRef = false
 	rule.unsafeCheckoutStep = nil
 	rule.autoFixerRegistered = false
+	rule.jobUnsafeTriggers = nil
+
+	if len(rule.unsafeTriggers) == 0 {
+		return nil
+	}
+
+	analyzer := NewJobTriggerAnalyzer(rule.workflowTriggers)
+	for _, trigger := range analyzer.AnalyzeJobTriggers(node) {
+		if IsUnsafeTrigger(trigger) {
+			rule.jobUnsafeTriggers = append(rule.jobUnsafeTriggers, trigger)
+		}
+	}
+
+	if len(rule.jobUnsafeTriggers) == 0 {
+		jobID := "<nil>"
+		if node.ID != nil {
+			jobID = node.ID.Value
+		}
+		rule.Debug("Job '%s' filtered out unsafe triggers via if condition", jobID)
+	}
+
 	return nil
 }
 
@@ -213,7 +235,7 @@ func (rule *CachePoisoningRule) VisitStep(node *ast.Step) error {
 	}
 
 	// Check for checkout with unsafe ref (only with unsafe triggers)
-	if actionName == "actions/checkout" && len(rule.unsafeTriggers) > 0 {
+	if actionName == "actions/checkout" && len(rule.jobUnsafeTriggers) > 0 {
 		if refInput, ok := action.Inputs["ref"]; ok && refInput != nil && refInput.Value != nil {
 			if IsUnsafeCheckoutRef(refInput.Value.Value) {
 				rule.checkoutUnsafeRef = true
@@ -247,31 +269,33 @@ func (rule *CachePoisoningRule) VisitStep(node *ast.Step) error {
 
 		// Check for indirect cache poisoning (unsafe checkout + cache action)
 		// This only applies with unsafe triggers
-		if len(rule.unsafeTriggers) > 0 && rule.checkoutUnsafeRef {
+		if len(rule.jobUnsafeTriggers) > 0 && rule.checkoutUnsafeRef {
 			rule.reportIndirectCachePoisoning(node, uses)
 		}
 		return nil
 	}
 
-	if len(rule.unsafeTriggers) > 0 && rule.checkoutUnsafeRef {
-		if cacheUses, ok := rule.findCompositeCacheAction(uses); ok {
+	if len(rule.jobUnsafeTriggers) > 0 && rule.checkoutUnsafeRef {
+		inspection := rule.inspectCompositeAction(uses)
+		if inspection.cacheFound {
 			rule.cacheActionCount++
-			triggers := strings.Join(rule.unsafeTriggers, ", ")
+			triggers := strings.Join(rule.jobUnsafeTriggers, ", ")
 			rule.Errorf(
 				node.Pos,
-				"cache poisoning risk (critical): composite action '%s' invokes '%s' after checking out untrusted PR code (triggers: %s). "+
+				"cache poisoning risk (critical): composite action '%s' invokes '%s' after checking out untrusted PR code (triggers: %s, chain: %s). "+
 					"This can persist attacker-controlled dependency state through GitHub Actions cache scope crossing; validate cached content or scope cache to PR level",
 				uses,
-				cacheUses,
+				inspection.cacheUses,
 				triggers,
+				strings.Join(inspection.chain, " -> "),
 			)
 			rule.registerIndirectCachePoisoningFixer()
-		} else if isMutableRemoteSubpathAction(uses) {
-			triggers := strings.Join(rule.unsafeTriggers, ", ")
+		} else if inspection.resolvedComposite && isMutableRemoteAction(uses) {
+			triggers := strings.Join(rule.jobUnsafeTriggers, ", ")
 			rule.Errorf(
 				node.Pos,
 				"cache poisoning risk: mutable remote composite action '%s' runs after checking out untrusted PR code (triggers: %s). "+
-					"Because the action ref is not pinned to a full commit SHA, historical transitive actions/cache usage and GitHub Actions cache scope crossing cannot be ruled out from the current repository state; pin the action to a full commit SHA or avoid unsafe checkout under privileged triggers",
+					"The action currently resolves as a composite action, but because the ref is not pinned to a full commit SHA, historical transitive actions/cache usage and GitHub Actions cache scope crossing cannot be ruled out from the current repository state; pin the action to a full commit SHA or avoid unsafe checkout under privileged triggers",
 				uses,
 				triggers,
 			)
@@ -282,7 +306,7 @@ func (rule *CachePoisoningRule) VisitStep(node *ast.Step) error {
 	return nil
 }
 
-func isMutableRemoteSubpathAction(uses string) bool {
+func isMutableRemoteAction(uses string) bool {
 	if uses == "" || strings.HasPrefix(uses, "./") || strings.HasPrefix(uses, ".\\") || strings.HasPrefix(uses, "docker://") {
 		return false
 	}
@@ -293,11 +317,11 @@ func isMutableRemoteSubpathAction(uses string) bool {
 	if !ok {
 		return false
 	}
-	return len(strings.Split(actionPath, "/")) >= 3
+	return len(strings.Split(actionPath, "/")) >= 2
 }
 
 func (rule *CachePoisoningRule) reportIndirectCachePoisoning(node *ast.Step, uses string) {
-	triggers := strings.Join(rule.unsafeTriggers, ", ")
+	triggers := strings.Join(rule.jobUnsafeTriggers, ", ")
 	rule.Errorf(
 		node.Pos,
 		"cache poisoning risk: '%s' used after checking out untrusted PR code (triggers: %s). Validate cached content or scope cache to PR level",
@@ -314,38 +338,64 @@ func (rule *CachePoisoningRule) registerIndirectCachePoisoningFixer() {
 	}
 }
 
-func (rule *CachePoisoningRule) findCompositeCacheAction(uses string) (string, bool) {
+const maxCompositeActionDepth = 4
+
+type compositeActionInspection struct {
+	cacheUses         string
+	chain             []string
+	cacheFound        bool
+	resolvedComposite bool
+}
+
+func (rule *CachePoisoningRule) inspectCompositeAction(uses string) compositeActionInspection {
 	if rule.actionMetadata == nil || uses == "" {
-		return "", false
+		return compositeActionInspection{}
 	}
+	return rule.inspectCompositeActionRecursive(uses, nil, make(map[string]bool), 0)
+}
+
+func (rule *CachePoisoningRule) inspectCompositeActionRecursive(uses string, chain []string, visited map[string]bool, depth int) compositeActionInspection {
+	if uses == "" || depth > maxCompositeActionDepth {
+		return compositeActionInspection{}
+	}
+	if visited[uses] {
+		return compositeActionInspection{}
+	}
+	visited[uses] = true
 
 	meta, err := rule.actionMetadata.FindMetadata(uses)
 	if err != nil {
 		rule.Debug("failed to resolve action metadata for %s: %v", uses, err)
-		return "", false
+		return compositeActionInspection{}
 	}
 
-	return firstCompositeCacheAction(meta)
-}
-
-func firstCompositeCacheAction(meta *ActionMetadata) (string, bool) {
 	if meta == nil || meta.Runs == nil || !strings.EqualFold(meta.Runs.Using, "composite") {
-		return "", false
+		return compositeActionInspection{}
 	}
 
+	nextChain := append(append([]string{}, chain...), uses)
 	for _, step := range meta.Runs.Steps {
 		if step == nil || step.Uses == "" {
 			continue
 		}
 		if isCacheAction(step.Uses, metadataStepInputs(step.With)) {
-			return step.Uses, true
+			return compositeActionInspection{
+				cacheUses:         step.Uses,
+				chain:             append(append([]string{}, nextChain...), step.Uses),
+				cacheFound:        true,
+				resolvedComposite: true,
+			}
+		}
+		child := rule.inspectCompositeActionRecursive(step.Uses, nextChain, visited, depth+1)
+		if child.cacheFound {
+			return child
 		}
 	}
 
-	return "", false
+	return compositeActionInspection{chain: nextChain, resolvedComposite: true}
 }
 
-func metadataStepInputs(with map[string]string) map[string]*ast.Input {
+func metadataStepInputs(with ActionStepWithMetadata) map[string]*ast.Input {
 	if len(with) == 0 {
 		return nil
 	}

--- a/pkg/core/cachepoisoningrule.go
+++ b/pkg/core/cachepoisoningrule.go
@@ -23,6 +23,7 @@ type CachePoisoningRule struct {
 	checkoutUnsafeRef   bool
 	unsafeCheckoutStep  *ast.Step
 	autoFixerRegistered bool
+	actionMetadata      ActionMetadataResolver
 	directCacheFixSteps []*directCacheFixInfo
 	// New fields for extended detection
 	isReleaseWorkflow      bool
@@ -41,12 +42,17 @@ type directCacheFixInfo struct {
 }
 
 // NewCachePoisoningRule creates a new cache poisoning detection rule.
-func NewCachePoisoningRule() *CachePoisoningRule {
+func NewCachePoisoningRule(actionMetadata ...ActionMetadataResolver) *CachePoisoningRule {
+	var resolver ActionMetadataResolver
+	if len(actionMetadata) > 0 {
+		resolver = actionMetadata[0]
+	}
 	return &CachePoisoningRule{
 		BaseRule: BaseRule{
 			RuleName: "cache-poisoning",
 			RuleDesc: "Detects potential cache poisoning vulnerabilities when using cache with untrusted triggers or untrusted inputs in cache configuration",
 		},
+		actionMetadata:      resolver,
 		directCacheFixSteps: make([]*directCacheFixInfo, 0),
 	}
 }
@@ -242,21 +248,117 @@ func (rule *CachePoisoningRule) VisitStep(node *ast.Step) error {
 		// Check for indirect cache poisoning (unsafe checkout + cache action)
 		// This only applies with unsafe triggers
 		if len(rule.unsafeTriggers) > 0 && rule.checkoutUnsafeRef {
+			rule.reportIndirectCachePoisoning(node, uses)
+		}
+		return nil
+	}
+
+	if len(rule.unsafeTriggers) > 0 && rule.checkoutUnsafeRef {
+		if cacheUses, ok := rule.findCompositeCacheAction(uses); ok {
+			rule.cacheActionCount++
 			triggers := strings.Join(rule.unsafeTriggers, ", ")
 			rule.Errorf(
 				node.Pos,
-				"cache poisoning risk: '%s' used after checking out untrusted PR code (triggers: %s). Validate cached content or scope cache to PR level",
+				"cache poisoning risk (critical): composite action '%s' invokes '%s' after checking out untrusted PR code (triggers: %s). "+
+					"This can persist attacker-controlled dependency state through GitHub Actions cache scope crossing; validate cached content or scope cache to PR level",
+				uses,
+				cacheUses,
+				triggers,
+			)
+			rule.registerIndirectCachePoisoningFixer()
+		} else if isMutableRemoteSubpathAction(uses) {
+			triggers := strings.Join(rule.unsafeTriggers, ", ")
+			rule.Errorf(
+				node.Pos,
+				"cache poisoning risk: mutable remote composite action '%s' runs after checking out untrusted PR code (triggers: %s). "+
+					"Because the action ref is not pinned to a full commit SHA, historical transitive actions/cache usage and GitHub Actions cache scope crossing cannot be ruled out from the current repository state; pin the action to a full commit SHA or avoid unsafe checkout under privileged triggers",
 				uses,
 				triggers,
 			)
-			if rule.unsafeCheckoutStep != nil && !rule.autoFixerRegistered {
-				rule.AddAutoFixer(NewStepFixer(rule.unsafeCheckoutStep, rule))
-				rule.autoFixerRegistered = true
-			}
+			rule.registerIndirectCachePoisoningFixer()
 		}
 	}
 
 	return nil
+}
+
+func isMutableRemoteSubpathAction(uses string) bool {
+	if uses == "" || strings.HasPrefix(uses, "./") || strings.HasPrefix(uses, ".\\") || strings.HasPrefix(uses, "docker://") {
+		return false
+	}
+	if isFullLengthSha(uses) {
+		return false
+	}
+	actionPath, _, ok := strings.Cut(uses, "@")
+	if !ok {
+		return false
+	}
+	return len(strings.Split(actionPath, "/")) >= 3
+}
+
+func (rule *CachePoisoningRule) reportIndirectCachePoisoning(node *ast.Step, uses string) {
+	triggers := strings.Join(rule.unsafeTriggers, ", ")
+	rule.Errorf(
+		node.Pos,
+		"cache poisoning risk: '%s' used after checking out untrusted PR code (triggers: %s). Validate cached content or scope cache to PR level",
+		uses,
+		triggers,
+	)
+	rule.registerIndirectCachePoisoningFixer()
+}
+
+func (rule *CachePoisoningRule) registerIndirectCachePoisoningFixer() {
+	if rule.unsafeCheckoutStep != nil && !rule.autoFixerRegistered {
+		rule.AddAutoFixer(NewStepFixer(rule.unsafeCheckoutStep, rule))
+		rule.autoFixerRegistered = true
+	}
+}
+
+func (rule *CachePoisoningRule) findCompositeCacheAction(uses string) (string, bool) {
+	if rule.actionMetadata == nil || uses == "" {
+		return "", false
+	}
+
+	meta, err := rule.actionMetadata.FindMetadata(uses)
+	if err != nil {
+		rule.Debug("failed to resolve action metadata for %s: %v", uses, err)
+		return "", false
+	}
+
+	return firstCompositeCacheAction(meta)
+}
+
+func firstCompositeCacheAction(meta *ActionMetadata) (string, bool) {
+	if meta == nil || meta.Runs == nil || !strings.EqualFold(meta.Runs.Using, "composite") {
+		return "", false
+	}
+
+	for _, step := range meta.Runs.Steps {
+		if step == nil || step.Uses == "" {
+			continue
+		}
+		if isCacheAction(step.Uses, metadataStepInputs(step.With)) {
+			return step.Uses, true
+		}
+	}
+
+	return "", false
+}
+
+func metadataStepInputs(with map[string]string) map[string]*ast.Input {
+	if len(with) == 0 {
+		return nil
+	}
+
+	inputs := make(map[string]*ast.Input, len(with))
+	for name, value := range with {
+		key := strings.ToLower(name)
+		inputs[key] = &ast.Input{
+			Name:  &ast.String{Value: name},
+			Value: &ast.String{Value: value},
+		}
+	}
+	return inputs
 }
 
 // checkDirectCachePoisoning checks for untrusted inputs in cache key/restore-keys/path

--- a/pkg/core/cachepoisoningrule.go
+++ b/pkg/core/cachepoisoningrule.go
@@ -68,7 +68,9 @@ func isCacheAction(uses string, inputs map[string]*ast.Input) bool {
 		actionName = uses[:idx]
 	}
 
-	if actionName == "actions/cache" {
+	if actionName == "actions/cache" ||
+		actionName == "actions/cache/save" ||
+		actionName == "actions/cache/restore" {
 		return true
 	}
 

--- a/pkg/core/cachepoisoningrule.go
+++ b/pkg/core/cachepoisoningrule.go
@@ -46,7 +46,7 @@ type directCacheFixInfo struct {
 func NewCachePoisoningRule(actionMetadata ...ActionMetadataResolver) *CachePoisoningRule {
 	var resolver ActionMetadataResolver
 	if len(actionMetadata) > 0 {
-		resolver = actionMetadata[0]
+		resolver = NewMultiActionMetadataResolver(actionMetadata...)
 	}
 	return &CachePoisoningRule{
 		BaseRule: BaseRule{
@@ -279,6 +279,7 @@ func (rule *CachePoisoningRule) VisitStep(node *ast.Step) error {
 		inspection := rule.inspectCompositeAction(uses)
 		if inspection.cacheFound {
 			rule.cacheActionCount++
+			rule.checkCacheHierarchyExploitation(node, inspection.cacheUses)
 			triggers := strings.Join(rule.jobUnsafeTriggers, ", ")
 			rule.Errorf(
 				node.Pos,

--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -156,6 +156,18 @@ func TestIsCacheAction(t *testing.T) {
 			want:   true,
 		},
 		{
+			name:   "actions/cache/save is cache action",
+			uses:   "actions/cache/save@v4",
+			inputs: nil,
+			want:   true,
+		},
+		{
+			name:   "actions/cache/restore is cache action",
+			uses:   "actions/cache/restore@v4",
+			inputs: nil,
+			want:   true,
+		},
+		{
 			name: "actions/setup-node with cache: npm",
 			uses: "actions/setup-node@v4",
 			inputs: map[string]*ast.Input{
@@ -280,6 +292,61 @@ jobs:
 		"actions/cache@v5",
 		"cache scope crossing",
 		"critical",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error description %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestCachePoisoningRuleDetectsRemoteCompositeCacheSaveAfterUnsafeCheckout(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: pull_request_target
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	resolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{Uses: "actions/cache/save@v4"},
+				},
+			},
+		},
+	}
+	rule := NewCachePoisoningRule(resolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	ruleErrs := rule.Errors()
+	if len(ruleErrs) != 1 {
+		t.Fatalf("len(rule.Errors()) = %d, want 1: %#v", len(ruleErrs), ruleErrs)
+	}
+
+	got := ruleErrs[0].Description
+	for _, want := range []string{
+		"TanStack/config/.github/setup@main",
+		"actions/cache/save@v4",
+		"cache scope crossing",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("error description %q does not contain %q", got, want)

--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -252,7 +252,7 @@ jobs:
 				Steps: []*ActionStepMetadata{
 					{
 						Uses: "actions/cache@v5",
-						With: map[string]string{
+						With: ActionStepWithMetadata{
 							"path": "~/.pnpm-store",
 							"key":  "Linux-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}",
 						},
@@ -280,6 +280,70 @@ jobs:
 		"actions/cache@v5",
 		"cache scope crossing",
 		"critical",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error description %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestCachePoisoningRuleDetectsTransitiveRemoteCompositeCacheAfterUnsafeCheckout(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: pull_request_target
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	resolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{Uses: "owner/nested-action@main"},
+				},
+			},
+		},
+		"owner/nested-action@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{Uses: "actions/setup-node@v4", With: ActionStepWithMetadata{"cache": "pnpm"}},
+				},
+			},
+		},
+	}
+	rule := NewCachePoisoningRule(resolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	ruleErrs := rule.Errors()
+	if len(ruleErrs) != 1 {
+		t.Fatalf("len(rule.Errors()) = %d, want 1: %#v", len(ruleErrs), ruleErrs)
+	}
+
+	got := ruleErrs[0].Description
+	for _, want := range []string{
+		"TanStack/config/.github/setup@main",
+		"owner/nested-action@main",
+		"actions/setup-node@v4",
+		"chain:",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("error description %q does not contain %q", got, want)
@@ -340,6 +404,88 @@ jobs:
 		if !strings.Contains(got, want) {
 			t.Fatalf("error description %q does not contain %q", got, want)
 		}
+	}
+}
+
+func TestCachePoisoningRuleSkipsJobFilteredToSafeTrigger(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: [pull_request_target, push]
+jobs:
+  push-only:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	resolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{Uses: "actions/cache@v5"},
+				},
+			},
+		},
+	}
+	rule := NewCachePoisoningRule(resolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("len(rule.Errors()) = %d, want 0: %#v", got, rule.Errors())
+	}
+}
+
+func TestCachePoisoningRuleDoesNotReportMutableRemoteNonCompositeAction(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: pull_request_target
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	resolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{Using: "node20"},
+		},
+	}
+	rule := NewCachePoisoningRule(resolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("len(rule.Errors()) = %d, want 0: %#v", got, rule.Errors())
 	}
 }
 

--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -219,6 +219,130 @@ func TestIsCacheAction(t *testing.T) {
 	}
 }
 
+type fakeActionMetadataResolver map[string]*ActionMetadata
+
+func (f fakeActionMetadataResolver) FindMetadata(spec string) (*ActionMetadata, error) {
+	return f[spec], nil
+}
+
+func TestCachePoisoningRuleDetectsRemoteCompositeCacheAfterUnsafeCheckout(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: pull_request_target
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	resolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{
+						Uses: "actions/cache@v5",
+						With: map[string]string{
+							"path": "~/.pnpm-store",
+							"key":  "Linux-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}",
+						},
+					},
+				},
+			},
+		},
+	}
+	rule := NewCachePoisoningRule(resolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	ruleErrs := rule.Errors()
+	if len(ruleErrs) != 1 {
+		t.Fatalf("len(rule.Errors()) = %d, want 1: %#v", len(ruleErrs), ruleErrs)
+	}
+
+	got := ruleErrs[0].Description
+	for _, want := range []string{
+		"TanStack/config/.github/setup@main",
+		"actions/cache@v5",
+		"cache scope crossing",
+		"critical",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error description %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestCachePoisoningRuleDetectsMutableRemoteCompositeAfterUnsafeCheckout(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: pull_request_target
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	resolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{Uses: "pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0"},
+				},
+			},
+		},
+	}
+	rule := NewCachePoisoningRule(resolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	ruleErrs := rule.Errors()
+	if len(ruleErrs) != 1 {
+		t.Fatalf("len(rule.Errors()) = %d, want 1: %#v", len(ruleErrs), ruleErrs)
+	}
+
+	got := ruleErrs[0].Description
+	for _, want := range []string{
+		"TanStack/config/.github/setup@main",
+		"mutable remote composite action",
+		"cache scope crossing",
+		"cannot be ruled out",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error description %q does not contain %q", got, want)
+		}
+	}
+}
+
 func TestCachePoisoningRule_VisitWorkflowPre(t *testing.T) {
 	rule := NewCachePoisoningRule()
 

--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -287,6 +287,54 @@ jobs:
 	}
 }
 
+func TestCachePoisoningRuleUsesAllProvidedMetadataResolvers(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: pull_request_target
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	emptyResolver := fakeActionMetadataResolver{}
+	cacheResolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{Uses: "actions/cache@v5"},
+				},
+			},
+		},
+	}
+	rule := NewCachePoisoningRule(emptyResolver, cacheResolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	ruleErrs := rule.Errors()
+	if len(ruleErrs) != 1 {
+		t.Fatalf("len(rule.Errors()) = %d, want 1: %#v", len(ruleErrs), ruleErrs)
+	}
+	if got := ruleErrs[0].Description; !strings.Contains(got, "actions/cache@v5") {
+		t.Fatalf("error description %q does not contain actions/cache@v5", got)
+	}
+}
+
 func TestCachePoisoningRuleDetectsTransitiveRemoteCompositeCacheAfterUnsafeCheckout(t *testing.T) {
 	t.Parallel()
 
@@ -348,6 +396,61 @@ jobs:
 		if !strings.Contains(got, want) {
 			t.Fatalf("error description %q does not contain %q", got, want)
 		}
+	}
+}
+
+func TestCachePoisoningRuleChecksHierarchyForCompositeCacheAction(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: Bundle Size
+on: [pull_request_target, workflow_dispatch]
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: TanStack/config/.github/setup@main
+`
+	workflow, errs := Parse([]byte(workflowYAML))
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+
+	resolver := fakeActionMetadataResolver{
+		"TanStack/config/.github/setup@main": {
+			Runs: &ActionRunsMetadata{
+				Using: "composite",
+				Steps: []*ActionStepMetadata{
+					{Uses: "actions/cache@v5"},
+				},
+			},
+		},
+	}
+	rule := NewCachePoisoningRule(resolver)
+
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+
+	var foundComposite, foundHierarchy bool
+	for _, ruleErr := range rule.Errors() {
+		if strings.Contains(ruleErr.Description, "composite action") {
+			foundComposite = true
+		}
+		if strings.Contains(ruleErr.Description, "cache hierarchy exploitation risk") {
+			foundHierarchy = true
+		}
+	}
+	if !foundComposite {
+		t.Fatalf("expected composite cache poisoning error, got %#v", rule.Errors())
+	}
+	if !foundHierarchy {
+		t.Fatalf("expected hierarchy exploitation error for composite cache action, got %#v", rule.Errors())
 	}
 }
 

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -545,6 +545,11 @@ func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadat
 	// CodeInjection, EnvVarInjection, ArgumentInjection, and RequestForgery rules
 	// to enable cross-job taint propagation tracking via needs.*.outputs.*
 	wfTaintMap := NewWorkflowTaintMap()
+	var debugOut io.Writer
+	if localActions != nil {
+		debugOut = localActions.dbg
+	}
+	actionMetadata := NewMultiActionMetadataResolver(localActions, NewRemoteActionsMetadataCache(debugOut))
 
 	return []Rule{
 		// MatrixRule(),
@@ -574,7 +579,7 @@ func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadat
 		NewArtifactPoisoningMediumRule(),
 		NewActionListRule(),
 		NewUntrustedCheckoutRule(),
-		NewCachePoisoningRule(),
+		NewCachePoisoningRule(actionMetadata),
 		NewCachePoisoningPoisonableStepRule(),
 		NewSecretExposureRule(),                                       // Detects toJSON(secrets) and secrets[dynamic-access]
 		NewUnmaskedSecretExposureRule(),                               // Detects fromJson(secrets.XXX).yyy unmasked exposure

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -114,6 +114,8 @@ func (with *ActionStepWithMetadata) UnmarshalYAML(n *yaml.Node) error {
 			md[strings.ToLower(name)] = value.Value
 			continue
 		}
+		// Cache detection only needs key presence and simple scalar values; complex
+		// structures are intentionally normalized without expression parsing.
 		md[strings.ToLower(name)] = ""
 	}
 	*with = md
@@ -278,6 +280,9 @@ type remoteActionSpec struct {
 func NewRemoteActionsMetadataCache(dbg io.Writer) *RemoteActionsMetadataCache {
 	fetcher, err := remote.NewFetcher(1)
 	if err != nil {
+		if dbg != nil {
+			fmt.Fprintf(dbg, "[RemoteActionsMetadataCache] failed to create remote fetcher: %v; FindMetadata remote resolution will be disabled\n", err)
+		}
 		return &RemoteActionsMetadataCache{cache: make(map[string]*ActionMetadata), dbg: dbg}
 	}
 	return &RemoteActionsMetadataCache{fetcher: fetcher, cache: make(map[string]*ActionMetadata), dbg: dbg}
@@ -373,7 +378,7 @@ func parseRemoteActionSpec(spec string) (*remoteActionSpec, bool) {
 	dir := "."
 	if len(parts) > 2 {
 		dir = pathpkg.Clean(strings.Join(parts[2:], "/"))
-		if dir == "." || strings.HasPrefix(dir, "../") || dir == ".." {
+		if dir == "." || strings.HasPrefix(dir, "/") || strings.HasPrefix(dir, "../") || dir == ".." {
 			return nil, false
 		}
 	}

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -94,9 +94,30 @@ type ActionRunsMetadata struct {
 // ActionStepMetadata is the subset of composite action step metadata needed by
 // rules that reason about transitive action calls.
 type ActionStepMetadata struct {
-	Uses string            `yaml:"uses" json:"uses"`
-	If   string            `yaml:"if" json:"if"`
-	With map[string]string `yaml:"with" json:"with"`
+	Uses string                 `yaml:"uses" json:"uses"`
+	If   string                 `yaml:"if" json:"if"`
+	With ActionStepWithMetadata `yaml:"with" json:"with"`
+}
+
+type ActionStepWithMetadata map[string]string
+
+func (with *ActionStepWithMetadata) UnmarshalYAML(n *yaml.Node) error {
+	if n.Kind != yaml.MappingNode {
+		return expectedMapping("with", n)
+	}
+
+	md := make(ActionStepWithMetadata, len(n.Content)/2)
+	for i := 0; i < len(n.Content); i += 2 {
+		name := n.Content[i].Value
+		value := n.Content[i+1]
+		if value.Kind == yaml.ScalarNode {
+			md[strings.ToLower(name)] = value.Value
+			continue
+		}
+		md[strings.ToLower(name)] = ""
+	}
+	*with = md
+	return nil
 }
 
 // GitHub Actionsの全体的なメタデータ構造体
@@ -345,13 +366,16 @@ func parseRemoteActionSpec(spec string) (*remoteActionSpec, bool) {
 	actionPath := spec[:at]
 	ref := spec[at+1:]
 	parts := strings.Split(actionPath, "/")
-	if len(parts) < 3 {
+	if len(parts) < 2 {
 		return nil, false
 	}
 
-	dir := pathpkg.Clean(strings.Join(parts[2:], "/"))
-	if dir == "." || strings.HasPrefix(dir, "../") || dir == ".." {
-		return nil, false
+	dir := "."
+	if len(parts) > 2 {
+		dir = pathpkg.Clean(strings.Join(parts[2:], "/"))
+		if dir == "." || strings.HasPrefix(dir, "../") || dir == ".." {
+			return nil, false
+		}
 	}
 
 	return &remoteActionSpec{

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -264,10 +264,12 @@ func (c *LocalActionsMetadataCache) readLocalActionMetadataFile(dir string) ([]b
 }
 
 type RemoteActionsMetadataCache struct {
-	mu      sync.RWMutex
-	fetcher *remote.Fetcher
-	cache   map[string]*ActionMetadata
-	dbg     io.Writer
+	mu          sync.RWMutex
+	fetcherOnce sync.Once
+	fetcher     *remote.Fetcher
+	fetcherErr  error
+	cache       map[string]*ActionMetadata
+	dbg         io.Writer
 }
 
 type remoteActionSpec struct {
@@ -278,14 +280,28 @@ type remoteActionSpec struct {
 }
 
 func NewRemoteActionsMetadataCache(dbg io.Writer) *RemoteActionsMetadataCache {
-	fetcher, err := remote.NewFetcher(1)
-	if err != nil {
-		if dbg != nil {
-			fmt.Fprintf(dbg, "[RemoteActionsMetadataCache] failed to create remote fetcher: %v; FindMetadata remote resolution will be disabled\n", err)
+	return &RemoteActionsMetadataCache{cache: make(map[string]*ActionMetadata), dbg: dbg}
+}
+
+// ensureFetcher constructs the underlying remote.Fetcher on first use. The
+// constructor of remote.Fetcher resolves a GitHub token, which in the absence
+// of GITHUB_TOKEN/GH_TOKEN spawns external `gh auth token` and
+// `git credential fill` processes. Deferring construction until a spec that
+// actually requires network resolution is observed avoids that cost for files
+// that never reach a remote composite-action lookup.
+func (c *RemoteActionsMetadataCache) ensureFetcher() *remote.Fetcher {
+	c.fetcherOnce.Do(func() {
+		fetcher, err := remote.NewFetcher(1)
+		if err != nil {
+			c.fetcherErr = err
+			if c.dbg != nil {
+				fmt.Fprintf(c.dbg, "[RemoteActionsMetadataCache] failed to create remote fetcher: %v; FindMetadata remote resolution will be disabled\n", err)
+			}
+			return
 		}
-		return &RemoteActionsMetadataCache{cache: make(map[string]*ActionMetadata), dbg: dbg}
-	}
-	return &RemoteActionsMetadataCache{fetcher: fetcher, cache: make(map[string]*ActionMetadata), dbg: dbg}
+		c.fetcher = fetcher
+	})
+	return c.fetcher
 }
 
 func (c *RemoteActionsMetadataCache) debug(format string, args ...interface{}) {
@@ -310,9 +326,6 @@ func (c *RemoteActionsMetadataCache) writeCache(key string, val *ActionMetadata)
 }
 
 func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata, error) {
-	if c.fetcher == nil {
-		return nil, nil
-	}
 	if m, ok := c.readCache(spec); ok {
 		c.debug("cache hit @ %s: %v", spec, m)
 		return m, nil
@@ -320,6 +333,11 @@ func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata,
 
 	actionSpec, ok := parseRemoteActionSpec(spec)
 	if !ok {
+		return nil, nil
+	}
+
+	fetcher := c.ensureFetcher()
+	if fetcher == nil {
 		return nil, nil
 	}
 
@@ -332,7 +350,7 @@ func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata,
 	var lastErr error
 	for _, metadataPath := range remoteActionMetadataPaths(actionSpec.dir) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		b, err := c.fetcher.FetchFile(ctx, repo, metadataPath, actionSpec.ref)
+		b, err := fetcher.FetchFile(ctx, repo, metadataPath, actionSpec.ref)
 		cancel()
 		if err != nil {
 			lastErr = err

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -1,13 +1,17 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/sisaku-security/sisakulint/pkg/remote"
 	"gopkg.in/yaml.v3"
 )
 
@@ -79,14 +83,64 @@ func (outputs *ActionOutputsMetadata) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
+// ActionRunsMetadata represents the "runs" section in GitHub Action metadata.
+// For this linter, only composite-action steps are needed so rules can inspect
+// transitive uses such as actions/cache.
+type ActionRunsMetadata struct {
+	Using string                `yaml:"using" json:"using"`
+	Steps []*ActionStepMetadata `yaml:"steps" json:"steps"`
+}
+
+// ActionStepMetadata is the subset of composite action step metadata needed by
+// rules that reason about transitive action calls.
+type ActionStepMetadata struct {
+	Uses string            `yaml:"uses" json:"uses"`
+	If   string            `yaml:"if" json:"if"`
+	With map[string]string `yaml:"with" json:"with"`
+}
+
 // GitHub Actionsの全体的なメタデータ構造体
 // *https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
 type ActionMetadata struct {
 	Name        string                `yaml:"name" json:"name"`
 	Inputs      ActionInputsMetadata  `yaml:"inputs" json:"inputs"`
 	Outputs     ActionOutputsMetadata `yaml:"outputs" json:"outputs"`
+	Runs        *ActionRunsMetadata   `yaml:"runs" json:"runs"`
 	SkipInputs  bool                  `json:"skip_inputs"`
 	SkipOutputs bool                  `json:"skip_outputs"`
+}
+
+type ActionMetadataResolver interface {
+	FindMetadata(spec string) (*ActionMetadata, error)
+}
+
+type MultiActionMetadataResolver struct {
+	resolvers []ActionMetadataResolver
+}
+
+func NewMultiActionMetadataResolver(resolvers ...ActionMetadataResolver) *MultiActionMetadataResolver {
+	filtered := make([]ActionMetadataResolver, 0, len(resolvers))
+	for _, resolver := range resolvers {
+		if resolver != nil {
+			filtered = append(filtered, resolver)
+		}
+	}
+	return &MultiActionMetadataResolver{resolvers: filtered}
+}
+
+func (r *MultiActionMetadataResolver) FindMetadata(spec string) (*ActionMetadata, error) {
+	var lastErr error
+	for _, resolver := range r.resolvers {
+		meta, err := resolver.FindMetadata(spec)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if meta != nil {
+			return meta, nil
+		}
+	}
+	return nil, lastErr
 }
 
 // ローカルアクションのメタデータキャッシュ構造体
@@ -184,6 +238,136 @@ func (c *LocalActionsMetadataCache) readLocalActionMetadataFile(dir string) ([]b
 		}
 	}
 	return nil, false
+}
+
+type RemoteActionsMetadataCache struct {
+	mu      sync.RWMutex
+	fetcher *remote.Fetcher
+	cache   map[string]*ActionMetadata
+	dbg     io.Writer
+}
+
+type remoteActionSpec struct {
+	owner string
+	repo  string
+	dir   string
+	ref   string
+}
+
+func NewRemoteActionsMetadataCache(dbg io.Writer) *RemoteActionsMetadataCache {
+	fetcher, err := remote.NewFetcher(1)
+	if err != nil {
+		return &RemoteActionsMetadataCache{cache: make(map[string]*ActionMetadata), dbg: dbg}
+	}
+	return &RemoteActionsMetadataCache{fetcher: fetcher, cache: make(map[string]*ActionMetadata), dbg: dbg}
+}
+
+func (c *RemoteActionsMetadataCache) debug(format string, args ...interface{}) {
+	if c.dbg == nil {
+		return
+	}
+	format = "[RemoteActionsMetadataCache] " + format + "\n"
+	fmt.Fprintf(c.dbg, format, args...)
+}
+
+func (c *RemoteActionsMetadataCache) readCache(key string) (*ActionMetadata, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.cache[key]
+	return m, ok
+}
+
+func (c *RemoteActionsMetadataCache) writeCache(key string, val *ActionMetadata) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache[key] = val
+}
+
+func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata, error) {
+	if c.fetcher == nil {
+		return nil, nil
+	}
+	if m, ok := c.readCache(spec); ok {
+		c.debug("cache hit @ %s: %v", spec, m)
+		return m, nil
+	}
+
+	actionSpec, ok := parseRemoteActionSpec(spec)
+	if !ok {
+		return nil, nil
+	}
+
+	repo := &remote.RepositoryInfo{
+		Owner:    actionSpec.owner,
+		Name:     actionSpec.repo,
+		FullName: actionSpec.owner + "/" + actionSpec.repo,
+	}
+
+	var lastErr error
+	for _, metadataPath := range remoteActionMetadataPaths(actionSpec.dir) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		b, err := c.fetcher.FetchFile(ctx, repo, metadataPath, actionSpec.ref)
+		cancel()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		var meta ActionMetadata
+		if err := yaml.Unmarshal(b, &meta); err != nil {
+			c.writeCache(spec, nil)
+			msg := strings.ReplaceAll(err.Error(), "\n", " ")
+			return nil, fmt.Errorf("failed to parse remote action metadata file %q: %s", metadataPath, msg)
+		}
+
+		c.debug("detected remote action metadata @ %s: %v", spec, meta)
+		c.writeCache(spec, &meta)
+		return &meta, nil
+	}
+
+	c.writeCache(spec, nil)
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed to fetch remote action metadata for %q: %w", spec, lastErr)
+	}
+	return nil, nil
+}
+
+func parseRemoteActionSpec(spec string) (*remoteActionSpec, bool) {
+	if spec == "" || strings.HasPrefix(spec, "./") || strings.HasPrefix(spec, ".\\") || strings.HasPrefix(spec, "docker://") {
+		return nil, false
+	}
+
+	at := strings.LastIndex(spec, "@")
+	if at <= 0 || at == len(spec)-1 {
+		return nil, false
+	}
+
+	actionPath := spec[:at]
+	ref := spec[at+1:]
+	parts := strings.Split(actionPath, "/")
+	if len(parts) < 3 {
+		return nil, false
+	}
+
+	dir := pathpkg.Clean(strings.Join(parts[2:], "/"))
+	if dir == "." || strings.HasPrefix(dir, "../") || dir == ".." {
+		return nil, false
+	}
+
+	return &remoteActionSpec{
+		owner: parts[0],
+		repo:  parts[1],
+		dir:   dir,
+		ref:   ref,
+	}, true
+}
+
+func remoteActionMetadataPaths(dir string) []string {
+	cleanDir := pathpkg.Clean(dir)
+	return []string{
+		pathpkg.Join(cleanDir, "action.yml"),
+		pathpkg.Join(cleanDir, "action.yaml"),
+	}
 }
 
 // ローカルアクションのメタデータキャッシュファクトリ構造体

--- a/pkg/core/metadata_test.go
+++ b/pkg/core/metadata_test.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestActionMetadataParsesCompositeRunsSteps(t *testing.T) {
+	t.Parallel()
+
+	content := []byte(`
+name: setup
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v5
+      if: always()
+      with:
+        path: ~/.pnpm-store
+        key: Linux-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+`)
+
+	var meta ActionMetadata
+	if err := yaml.Unmarshal(content, &meta); err != nil {
+		t.Fatalf("yaml.Unmarshal returned error: %v", err)
+	}
+
+	if meta.Runs == nil {
+		t.Fatal("Runs metadata is nil")
+	}
+	if meta.Runs.Using != "composite" {
+		t.Fatalf("Runs.Using = %q, want %q", meta.Runs.Using, "composite")
+	}
+	if len(meta.Runs.Steps) != 1 {
+		t.Fatalf("len(Runs.Steps) = %d, want 1", len(meta.Runs.Steps))
+	}
+
+	step := meta.Runs.Steps[0]
+	if step.Uses != "actions/cache@v5" {
+		t.Fatalf("step.Uses = %q, want actions/cache@v5", step.Uses)
+	}
+	if step.If != "always()" {
+		t.Fatalf("step.If = %q, want always()", step.If)
+	}
+	if got := step.With["key"]; got != "Linux-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}" {
+		t.Fatalf("step.With[key] = %q", got)
+	}
+}

--- a/pkg/core/metadata_test.go
+++ b/pkg/core/metadata_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -19,6 +20,7 @@ runs:
       with:
         path: ~/.pnpm-store
         key: Linux-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        fail-on-cache-miss: true
 `)
 
 	var meta ActionMetadata
@@ -45,5 +47,62 @@ runs:
 	}
 	if got := step.With["key"]; got != "Linux-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}" {
 		t.Fatalf("step.With[key] = %q", got)
+	}
+	if got := step.With["fail-on-cache-miss"]; got != "true" {
+		t.Fatalf("step.With[fail-on-cache-miss] = %q, want true", got)
+	}
+}
+
+func TestParseRemoteActionSpecSupportsRootAndSubpathActions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec string
+		dir  string
+	}{
+		{
+			name: "root action",
+			spec: "owner/repo@main",
+			dir:  ".",
+		},
+		{
+			name: "subpath action",
+			spec: "TanStack/config/.github/setup@main",
+			dir:  ".github/setup",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseRemoteActionSpec(tt.spec)
+			if !ok {
+				t.Fatalf("parseRemoteActionSpec(%q) returned !ok", tt.spec)
+			}
+			if got.owner != strings.Split(tt.spec, "/")[0] {
+				t.Fatalf("owner = %q", got.owner)
+			}
+			if got.dir != tt.dir {
+				t.Fatalf("dir = %q, want %q", got.dir, tt.dir)
+			}
+			if got.ref != "main" {
+				t.Fatalf("ref = %q, want main", got.ref)
+			}
+		})
+	}
+}
+
+func TestRemoteActionMetadataPathsSupportsRootAction(t *testing.T) {
+	t.Parallel()
+
+	got := remoteActionMetadataPaths(".")
+	want := []string{"action.yml", "action.yaml"}
+	if len(got) != len(want) {
+		t.Fatalf("len(remoteActionMetadataPaths(.)) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteActionMetadataPaths(.)[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }

--- a/pkg/core/metadata_test.go
+++ b/pkg/core/metadata_test.go
@@ -106,3 +106,11 @@ func TestRemoteActionMetadataPathsSupportsRootAction(t *testing.T) {
 		}
 	}
 }
+
+func TestParseRemoteActionSpecRejectsAbsoluteActionPath(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := parseRemoteActionSpec("owner/repo//absolute/path@main"); ok {
+		t.Fatalf("parseRemoteActionSpec returned ok with absolute path: %#v", got)
+	}
+}

--- a/pkg/core/metadata_test.go
+++ b/pkg/core/metadata_test.go
@@ -114,3 +114,27 @@ func TestParseRemoteActionSpecRejectsAbsoluteActionPath(t *testing.T) {
 		t.Fatalf("parseRemoteActionSpec returned ok with absolute path: %#v", got)
 	}
 }
+
+func TestRemoteActionsMetadataCacheDeferFetcherConstruction(t *testing.T) {
+	t.Parallel()
+
+	c := NewRemoteActionsMetadataCache(nil)
+	if c.fetcher != nil {
+		t.Fatal("fetcher should not be constructed eagerly by NewRemoteActionsMetadataCache")
+	}
+
+	// Local / docker / malformed specs must short-circuit before fetcher construction.
+	for _, spec := range []string{
+		"./local-action",
+		"docker://alpine:3.18",
+		"no-at-sign",
+		"",
+	} {
+		if _, err := c.FindMetadata(spec); err != nil {
+			t.Fatalf("FindMetadata(%q) returned error: %v", spec, err)
+		}
+		if c.fetcher != nil {
+			t.Fatalf("fetcher must remain nil after FindMetadata(%q)", spec)
+		}
+	}
+}

--- a/pkg/core/untrustedcheckout.go
+++ b/pkg/core/untrustedcheckout.go
@@ -156,23 +156,10 @@ func (rule *UntrustedCheckoutRule) VisitStep(step *ast.Step) error {
 
 // isUntrustedPRRef checks if a ref value points to untrusted PR code
 func (rule *UntrustedCheckoutRule) isUntrustedPRRef(refValue *ast.String) bool {
-	// Check if the value contains expressions
-	if !refValue.ContainsExpression() {
-		// No expression - literal ref is safe
+	if refValue == nil {
 		return false
 	}
-
-	// Extract and parse all expressions in the ref value
-	exprs := rule.extractAndParseRefExpressions(refValue)
-
-	// Check each expression for untrusted PR references
-	for _, expr := range exprs {
-		if rule.isUntrustedPRExpression(expr.node, expr.raw) {
-			return true
-		}
-	}
-
-	return false
+	return IsUnsafeCheckoutRef(refValue.Value)
 }
 
 // refParsedExpression represents a parsed expression with its position and AST node

--- a/pkg/core/untrustedcheckout.go
+++ b/pkg/core/untrustedcheckout.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/sisaku-security/sisakulint/pkg/ast"
-	"github.com/sisaku-security/sisakulint/pkg/expressions"
 )
 
 // UntrustedCheckoutRule checks for dangerous combinations of privileged triggers
@@ -160,117 +159,6 @@ func (rule *UntrustedCheckoutRule) isUntrustedPRRef(refValue *ast.String) bool {
 		return false
 	}
 	return IsUnsafeCheckoutRef(refValue.Value)
-}
-
-// refParsedExpression represents a parsed expression with its position and AST node
-type refParsedExpression struct {
-	raw  string               // Original expression content
-	node expressions.ExprNode // Parsed AST node
-	pos  *ast.Position        // Position in source
-}
-
-// extractAndParseRefExpressions extracts all expressions from a string and parses them
-//
-// NOTE: This implementation is similar to extractAndParseExpressions in issueinjection.go.
-// Future work could extract this into a shared utility function in pkg/expressions/ or pkg/core/util.go
-// to reduce code duplication and ensure consistent expression parsing across rules.
-func (rule *UntrustedCheckoutRule) extractAndParseRefExpressions(str *ast.String) []refParsedExpression {
-	if str == nil {
-		return nil
-	}
-
-	value := str.Value
-	var result []refParsedExpression
-	offset := 0
-
-	for {
-		// Find next expression start
-		idx := strings.Index(value[offset:], "${{")
-		if idx == -1 {
-			break
-		}
-
-		start := offset + idx
-		// Find closing }}
-		endIdx := strings.Index(value[start:], "}}")
-		if endIdx == -1 {
-			break
-		}
-
-		// Extract expression content (between ${{ and }})
-		exprContent := value[start+3 : start+endIdx]
-		exprContent = strings.TrimSpace(exprContent)
-
-		// Parse the expression
-		expr, parseErr := rule.parseExpression(exprContent)
-		if parseErr == nil && expr != nil {
-			// Calculate position
-			lineIdx := strings.Count(value[:start], "\n")
-			col := start
-			if lastNewline := strings.LastIndex(value[:start], "\n"); lastNewline != -1 {
-				col = start - lastNewline - 1
-			}
-
-			pos := &ast.Position{
-				Line: str.Pos.Line + lineIdx,
-				Col:  str.Pos.Col + col,
-			}
-
-			result = append(result, refParsedExpression{
-				raw:  exprContent,
-				node: expr,
-				pos:  pos,
-			})
-		}
-
-		offset = start + endIdx + 2
-	}
-
-	return result
-}
-
-// parseExpression parses a single expression string into an AST node
-func (rule *UntrustedCheckoutRule) parseExpression(exprStr string) (expressions.ExprNode, *expressions.ExprError) {
-	// The tokenizer expects the expression to end with }}
-	if !strings.HasSuffix(exprStr, "}}") {
-		exprStr = exprStr + "}}"
-	}
-	l := expressions.NewTokenizer(exprStr)
-	p := expressions.NewMiniParser()
-	return p.Parse(l)
-}
-
-// isUntrustedPRExpression checks if an expression accesses untrusted PR data
-//
-// NOTE: The ExprNode parameter is currently unused but reserved for future AST-based detection.
-// Currently using string-based matching which is simpler and covers the most common attack patterns.
-//
-// SCOPE: This rule focuses on github.event.pull_request.head.* patterns which are the most
-// common and dangerous patterns for checkout actions. Other untrusted inputs like:
-// - github.event.issue.* (issue context)
-// - github.event.comment.* (comment body)
-// - github.event.workflow_run.head_branch (workflow_run context)
-// are potential attack vectors but are less commonly used with checkout actions.
-// These patterns could be detected in a future enhancement or by the issue-injection rule.
-//
-// See: https://github.com/sisaku-security/sisakulint/pull/226#discussion_r2658869719
-func (rule *UntrustedCheckoutRule) isUntrustedPRExpression(_ expressions.ExprNode, rawExpr string) bool {
-	// Simple string-based check for common dangerous patterns
-	// These patterns access pull request HEAD code which is untrusted
-	dangerousPatterns := []string{
-		"github.event.pull_request.head.sha",
-		"github.event.pull_request.head.ref",
-		"github.event.pull_request.head.", // Catches head.number, head.label, etc.
-	}
-
-	for _, pattern := range dangerousPatterns {
-		if strings.Contains(rawExpr, pattern) {
-			rule.Debug("Found untrusted PR reference in expression: %s", rawExpr)
-			return true
-		}
-	}
-
-	return false
 }
 
 // VisitWorkflowPost resets state after workflow processing

--- a/pkg/core/untrustedcheckout_test.go
+++ b/pkg/core/untrustedcheckout_test.go
@@ -346,6 +346,22 @@ jobs:
 			wantErr: true,
 			errMsg:  "checking out untrusted code from pull request",
 		},
+		{
+			name: "Vulnerable: pull_request_target with refs pull merge ref",
+			yaml: `
+name: Test
+on: pull_request_target
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+`,
+			wantErr: true,
+			errMsg:  "checking out untrusted code from pull request",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/remote/fetcher.go
+++ b/pkg/remote/fetcher.go
@@ -209,25 +209,35 @@ func (f *Fetcher) FetchWorkflows(ctx context.Context, repo *RepositoryInfo) ([]*
 
 // FetchSingleWorkflow retrieves a single workflow file
 func (f *Fetcher) FetchSingleWorkflow(ctx context.Context, repo *RepositoryInfo, workflowPath, ref string) (*WorkflowFile, error) {
-	fileContent, _, _, err := f.client.Repositories.GetContents(
-		ctx,
-		repo.Owner,
-		repo.Name,
-		workflowPath,
-		&github.RepositoryContentGetOptions{Ref: ref},
-	)
+	decodedContent, err := f.FetchFile(ctx, repo, workflowPath, ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch workflow file %s: %w", workflowPath, err)
-	}
-
-	decodedContent, err := fileContent.GetContent()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get content for file %s: %w", workflowPath, err)
+		return nil, err
 	}
 
 	return &WorkflowFile{
 		Path:     workflowPath,
-		Content:  []byte(decodedContent),
+		Content:  decodedContent,
 		RepoInfo: repo,
 	}, nil
+}
+
+// FetchFile retrieves a single file from a repository at the given ref.
+func (f *Fetcher) FetchFile(ctx context.Context, repo *RepositoryInfo, filePath, ref string) ([]byte, error) {
+	fileContent, _, _, err := f.client.Repositories.GetContents(
+		ctx,
+		repo.Owner,
+		repo.Name,
+		filePath,
+		&github.RepositoryContentGetOptions{Ref: ref},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch file %s: %w", filePath, err)
+	}
+
+	decodedContent, err := fileContent.GetContent()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get content for file %s: %w", filePath, err)
+	}
+
+	return []byte(decodedContent), nil
 }

--- a/script/README.md
+++ b/script/README.md
@@ -23,6 +23,7 @@ Contains example GitHub Actions workflow files that demonstrate various security
 | File | Description |
 |------|-------------|
 | `cache-poisoning.yaml` | Demonstrates cache poisoning vulnerabilities |
+| `cache-poisoning-composite-action.yaml` | TanStack-style cache poisoning via `pull_request_target`, unsafe PR merge checkout, and remote composite action cache usage |
 | `cache-poisoning-safe.yaml` | Safe cache configuration example |
 | `credential.yaml` | Credential exposure patterns |
 | `issueinjection.yaml` | Script injection via GitHub context |

--- a/script/actions/cache-poisoning-composite-action.yaml
+++ b/script/actions/cache-poisoning-composite-action.yaml
@@ -1,0 +1,27 @@
+name: Cache Poisoning via Remote Composite Action
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR merge ref
+        uses: actions/checkout@v6.0.2
+        with:
+          # VULNERABLE: pull_request_target runs in the base repository context,
+          # but this checks out fork-controlled PR code.
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Setup tools
+        # VULNERABLE: a mutable remote composite action can invoke actions/cache
+        # directly or transitively. Cache writes can persist in the base repo
+        # cache scope even though GITHUB_TOKEN permissions are read-only.
+        uses: TanStack/config/.github/setup@main
+
+      - name: Build benchmark
+        run: pnpm nx run @benchmarks/bundle-size:build


### PR DESCRIPTION
## Summary

- Detect `refs/pull/.../merge` checkout refs as untrusted PR code in privileged workflows.
- Parse local and remote composite action metadata, including root actions such as `owner/repo@main`, so `cache-poisoning` can see direct and bounded transitive `actions/cache` usage.
- Scope indirect cache poisoning detection to the job's effective triggers, so jobs filtered to safe triggers by job-level `if:` do not inherit workflow-level `pull_request_target` risk.
- Add a cache-specific warning for unsafe checkout followed by mutable remote composite actions such as `TanStack/config/.github/setup@main`, while avoiding that fallback for unresolved or non-composite actions.
- Document the TanStack-style risk and add `script/actions/cache-poisoning-composite-action.yaml` as a runnable sample workflow.

## Why

Issue #469 documents a TanStack-style supply-chain chain where `pull_request_target` checked out PR merge code and then called a remote composite action that transitively used `actions/cache`. The existing rules saw only generic pinning and checkout signals; they did not identify the cache scope crossing risk.

## Test Plan

- `go test ./pkg/core -run 'Test(CachePoisoningRule(DetectsRemoteCompositeCacheAfterUnsafeCheckout|DetectsTransitiveRemoteCompositeCacheAfterUnsafeCheckout|DetectsMutableRemoteCompositeAfterUnsafeCheckout|SkipsJobFilteredToSafeTrigger|DoesNotReportMutableRemoteNonCompositeAction)|ParseRemoteActionSpecSupportsRootAndSubpathActions|RemoteActionMetadataPathsSupportsRootAction|ActionMetadataParsesCompositeRunsSteps)' -count=1`
- `go test ./... -count=1`
- `go run ./cmd/sisakulint script/actions/cache-poisoning-composite-action.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * キャッシュポイズニング攻撃の検出を拡張し、リモートの合成アクションやミュータブルなリモートアクションを検出するようになりました
  * ジョブレベルのトリガースコープに基づいた検出精度を向上

* **ドキュメント**
  * キャッシュポイズニングルールのドキュメントを更新し、合成アクション経由の攻撃パターンと例を追加

* **Tests**
  * 合成アクションおよびリモートアクションのメタデータ解析に関する包括的なテストカバレッジを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/470)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->