### PR TITLE
fix: cache-mutation-aware dangerous-triggers mitigation (closes #469 Gap 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ sisakulint includes the following security rules (as of pkg/core/linter.go:500-5
 - **AIActionPromptInjectionRule** - Detects untrusted user input (github.event.issue.title, github.event.comment.body, etc.) directly interpolated into AI agent prompt parameters, enabling prompt injection attacks (Clinejection attack pattern)
 - **AIActionUnsafeSandboxRule** - Detects unsafe sandbox or safety-strategy settings (e.g., `safety-strategy: unsafe`, `--dangerouslySkipPermissions`) in AI agent actions that disable sandbox protections
 - **AIActionExecutionOrderRule** - Detects AI agent actions that are not the last step in a job, risking subsequent steps inheriting compromised state
+- **DangerousTriggersCriticalRule** - Detects workflows using privileged triggers (pull_request_target, workflow_run, issue_comment, etc.) without any security mitigations (auto-fix adds `permissions: {}` when cache I/O is not in scope; see `HasCacheMutation` in `MitigationStatus`)
+- **DangerousTriggersMediumRule** - Detects workflows using privileged triggers with only partial mitigations and recommends defense in depth (auto-fix adds `permissions: {}` when neither already present nor cache I/O is in scope)
 
 ## Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,13 @@ Two rules detect supply chain attacks:
    - Validates cache key construction
    - Identifies untrusted inputs in cache keys (e.g., `github.event.pull_request.head.ref`)
    - Prevents attackers from poisoning build caches
+   - **Issue #469 (TanStack supply-chain)**: composite action traversal now resolves `<owner>/<repo>/<path>@<ref>` remote composite actions via `RemoteActionsMetadataCache` (`pkg/core/metadata.go`) and flags `actions/cache` usage transitively reachable from an unsafe-checkout step. When the action is mutable (not a full commit SHA), the rule still reports a cache scope-crossing risk because historical transitive usage cannot be ruled out.
+
+### Cache Mutation Aware Dangerous-Triggers Mitigation (#469)
+
+`MitigationStatus.Score()` (`pkg/core/dangeroustriggersrule.go`) detects whether any job invokes `actions/cache`, `actions/cache/save`, `actions/cache/restore`, or an `actions/setup-*` step with `cache:` enabled, and stores the result in `HasCacheMutation`. When that flag is set, the `+3` credit normally awarded for `HasPermissionsRestriction` is suppressed, because GitHub Actions cache writes are signed by a runner-internal token outside the `permissions:` model. The dangerous-triggers-critical / -medium messages append a NOTE explaining the gap and recommend label/actor gating, environment protection, or splitting the cache-writing job out of the privileged trigger. The current implementation matches literal `uses:` strings; transitive cache mutation through remote composite actions is already covered by `CachePoisoningRule` via `RemoteActionsMetadataCache`.
+
+`refs/pull/` is now part of `unsafePatternsLower` (`pkg/core/cachepoisoningutil.go`) so the same helper drives both `CachePoisoningRule` and `UntrustedCheckoutRule` (no duplicate pattern list).
 
 ### Cross-File Taint Tracking for Reusable Workflows (#392)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,13 +347,13 @@ Two rules detect supply chain attacks:
    - Validates cache key construction
    - Identifies untrusted inputs in cache keys (e.g., `github.event.pull_request.head.ref`)
    - Prevents attackers from poisoning build caches
-   - **Issue #469 (TanStack supply-chain)**: composite action traversal now resolves `<owner>/<repo>/<path>@<ref>` remote composite actions via `RemoteActionsMetadataCache` (`pkg/core/metadata.go`) and flags `actions/cache` usage transitively reachable from an unsafe-checkout step. When the action is mutable (not a full commit SHA), the rule still reports a cache scope-crossing risk because historical transitive usage cannot be ruled out.
+   - Composite-action traversal resolves `<owner>/<repo>/<path>@<ref>` remote composite actions via `RemoteActionsMetadataCache` (`pkg/core/metadata.go`) and flags `actions/cache` usage transitively reachable from an unsafe-checkout step. Mutable refs are still reported because historical transitive usage cannot be ruled out.
 
-### Cache Mutation Aware Dangerous-Triggers Mitigation (#469)
+### Cache-Mutation-Aware Dangerous-Triggers Mitigation
 
-`MitigationStatus.Score()` (`pkg/core/dangeroustriggersrule.go`) detects whether any job invokes `actions/cache`, `actions/cache/save`, `actions/cache/restore`, or an `actions/setup-*` step with `cache:` enabled, and stores the result in `HasCacheMutation`. When that flag is set, the `+3` credit normally awarded for `HasPermissionsRestriction` is suppressed, because GitHub Actions cache writes are signed by a runner-internal token outside the `permissions:` model. The dangerous-triggers-critical / -medium messages append a NOTE explaining the gap and recommend label/actor gating, environment protection, or splitting the cache-writing job out of the privileged trigger. The current implementation matches literal `uses:` strings; transitive cache mutation through remote composite actions is already covered by `CachePoisoningRule` via `RemoteActionsMetadataCache`.
+`MitigationStatus.HasCacheMutation` (`pkg/core/dangeroustriggersrule.go`) is set when any job invokes `actions/cache`, `actions/cache/save`, `actions/cache/restore`, or `actions/setup-*` with `cache:` enabled. When the flag is on, `Score()` does not credit `HasPermissionsRestriction` because GitHub Actions cache I/O is signed by a runner-internal token outside the `permissions:` model — `permissions: {}` cannot block the cache-poisoning chain. The dangerous-triggers messages append a NOTE pointing at label/actor gating, environment protection, or splitting the cache step out of the privileged trigger. Matching is literal `uses:`; transitive remote composite actions are handled by `CachePoisoningRule` via `RemoteActionsMetadataCache`.
 
-`refs/pull/` is now part of `unsafePatternsLower` (`pkg/core/cachepoisoningutil.go`) so the same helper drives both `CachePoisoningRule` and `UntrustedCheckoutRule` (no duplicate pattern list).
+`refs/pull/` lives in `unsafePatternsLower` (`pkg/core/cachepoisoningutil.go`) so both `CachePoisoningRule` and `UntrustedCheckoutRule` share a single pattern list.
 
 ### Cross-File Taint Tracking for Reusable Workflows (#392)
 

--- a/pkg/core/dangeroustriggersrule.go
+++ b/pkg/core/dangeroustriggersrule.go
@@ -35,6 +35,14 @@ type MitigationStatus struct {
 	// HasForkCheck indicates if the workflow checks for forks using
 	// github.event.pull_request.head.repo.fork or similar. (+1 point)
 	HasForkCheck bool
+
+	// HasCacheMutation indicates that at least one job references the
+	// actions/cache action family (cache, cache/save, cache/restore) or an
+	// actions/setup-* action with cache enabled. Cache writes use a runner
+	// internal token that is NOT scoped by the workflow permissions block,
+	// so a permissions restriction does not block cache poisoning. When this
+	// flag is set, the permissions restriction is downgraded in Score().
+	HasCacheMutation bool
 }
 
 // Score calculates the total mitigation score based on the applied security measures.
@@ -54,7 +62,15 @@ func (m *MitigationStatus) Score() int {
 	score := 0
 
 	if m.HasPermissionsRestriction {
-		score += 3
+		// Cache writes are gated by a runner-internal cache token rather than
+		// the workflow GITHUB_TOKEN, so `permissions: contents: read` does NOT
+		// block cache poisoning. When the workflow performs cache mutation,
+		// permissions restriction provides no meaningful protection against
+		// the cache poisoning chain that motivates this rule, so we do not
+		// credit it. See issue #469 (TanStack cache scope crossing).
+		if !m.HasCacheMutation {
+			score += 3
+		}
 	}
 	if m.HasEnvironmentProtection {
 		score += 2
@@ -181,14 +197,36 @@ func CheckMitigations(workflow *ast.Workflow) MitigationStatus {
 
 		// Check step conditions for mitigations
 		for _, step := range job.Steps {
-			if step == nil || step.If == nil || step.If.Value == "" {
+			if step == nil {
 				continue
 			}
-			checkConditionForMitigations(step.If.Value, &status)
+			if step.If != nil && step.If.Value != "" {
+				checkConditionForMitigations(step.If.Value, &status)
+			}
+			if !status.HasCacheMutation && jobStepUsesCacheAction(step) {
+				status.HasCacheMutation = true
+			}
 		}
 	}
 
 	return status
+}
+
+// jobStepUsesCacheAction reports whether the given step references an action
+// that mutates the GitHub Actions cache. It only inspects literal `uses:`
+// values; composite action traversal is handled separately by the
+// cache-poisoning rule. The match is intentionally conservative — it covers
+// the well-known actions/cache family (cache, cache/save, cache/restore) and
+// actions/setup-* steps that opt-in to caching via the `cache:` input.
+func jobStepUsesCacheAction(step *ast.Step) bool {
+	if step == nil {
+		return false
+	}
+	action, ok := step.Exec.(*ast.ExecAction)
+	if !ok || action == nil || action.Uses == nil {
+		return false
+	}
+	return isCacheAction(action.Uses.Value, action.Inputs)
 }
 
 // hasPermissionsRestriction checks if permissions are explicitly set and not write-all.

--- a/pkg/core/dangeroustriggersrule.go
+++ b/pkg/core/dangeroustriggersrule.go
@@ -38,10 +38,15 @@ type MitigationStatus struct {
 
 	// HasCacheMutation indicates that at least one job references the
 	// actions/cache action family (cache, cache/save, cache/restore) or an
-	// actions/setup-* action with cache enabled. Cache writes use a runner
-	// internal token that is NOT scoped by the workflow permissions block,
-	// so a permissions restriction does not block cache poisoning. When this
-	// flag is set, the permissions restriction is downgraded in Score().
+	// actions/setup-* action with cache enabled. The name retains "mutation"
+	// for historical continuity, but the flag covers both reads and writes:
+	// a privileged-trigger workflow that only restores from cache is still
+	// vulnerable because the restored content may already be attacker-poisoned
+	// from a prior unsafe checkout. Either operation uses a runner-internal
+	// cache token that is NOT scoped by the workflow permissions block, so
+	// permissions:{} cannot block the cache-poisoning chain in either
+	// direction. When this flag is set, the permissions restriction is
+	// downgraded in Score().
 	HasCacheMutation bool
 }
 

--- a/pkg/core/dangeroustriggersrule_test.go
+++ b/pkg/core/dangeroustriggersrule_test.go
@@ -910,3 +910,116 @@ func TestDangerousTriggersMediumRule(t *testing.T) {
 		})
 	}
 }
+
+// TestDangerousTriggersCriticalRule_NoAutofixWhenCacheMutation locks in the
+// fix for the review finding that the critical rule used to register the
+// permissions:{} autofix unconditionally. When HasCacheMutation is true the
+// fix cannot raise the score (HasCacheMutation suppresses the permissions
+// credit), so the autofix would silently re-emit the same critical finding
+// on the next run.
+func TestDangerousTriggersCriticalRule_NoAutofixWhenCacheMutation(t *testing.T) {
+	t.Parallel()
+
+	workflow := &ast.Workflow{
+		On: []ast.Event{
+			&ast.WebhookEvent{
+				Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+				Pos:  &ast.Position{Line: 2, Col: 1},
+			},
+		},
+		Jobs: map[string]*ast.Job{
+			"test": {
+				Steps: []*ast.Step{
+					{
+						Exec: &ast.ExecAction{
+							Uses: &ast.String{Value: "actions/cache@v4"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewDangerousTriggersCriticalRule()
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatalf("VisitWorkflowPre returned error: %v", err)
+	}
+	if len(rule.Errors()) == 0 {
+		t.Fatal("expected critical finding for cache-mutation workflow")
+	}
+	if got := len(rule.AutoFixers()); got != 0 {
+		t.Errorf("expected no autofixer when cache mutation is present, got %d", got)
+	}
+}
+
+// TestDangerousTriggersCriticalRule_AutofixWhenNoCacheMutation guards the
+// negative case: when cache mutation is absent, permissions:{} is still a
+// real mitigation and the autofix should be registered.
+func TestDangerousTriggersCriticalRule_AutofixWhenNoCacheMutation(t *testing.T) {
+	t.Parallel()
+
+	workflow := &ast.Workflow{
+		On: []ast.Event{
+			&ast.WebhookEvent{
+				Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+				Pos:  &ast.Position{Line: 2, Col: 1},
+			},
+		},
+		Jobs: map[string]*ast.Job{
+			"test": {
+				Steps: []*ast.Step{
+					{
+						Exec: &ast.ExecRun{Run: &ast.String{Value: "echo test"}},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewDangerousTriggersCriticalRule()
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatalf("VisitWorkflowPre returned error: %v", err)
+	}
+	if len(rule.AutoFixers()) != 1 {
+		t.Errorf("expected exactly one autofixer when no cache mutation, got %d", len(rule.AutoFixers()))
+	}
+}
+
+// TestDangerousTriggersMediumRule_NoAutofixWhenCacheMutation mirrors the
+// critical case. With cache mutation the permissions credit is suppressed,
+// so permissions:{} would not change the medium severity.
+func TestDangerousTriggersMediumRule_NoAutofixWhenCacheMutation(t *testing.T) {
+	t.Parallel()
+
+	workflow := &ast.Workflow{
+		On: []ast.Event{
+			&ast.WebhookEvent{
+				Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+				Pos:  &ast.Position{Line: 2, Col: 1},
+			},
+		},
+		Jobs: map[string]*ast.Job{
+			"test": {
+				If: &ast.String{Value: "contains(github.event.pull_request.labels.*.name, 'safe-to-test')"},
+				Steps: []*ast.Step{
+					{
+						Exec: &ast.ExecAction{
+							Uses: &ast.String{Value: "actions/cache@v4"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewDangerousTriggersMediumRule()
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatalf("VisitWorkflowPre returned error: %v", err)
+	}
+	if len(rule.Errors()) == 0 {
+		t.Fatal("expected medium finding for cache-mutation workflow with label condition")
+	}
+	if got := len(rule.AutoFixers()); got != 0 {
+		t.Errorf("expected no autofixer when cache mutation is present, got %d", got)
+	}
+}

--- a/pkg/core/dangeroustriggersrule_test.go
+++ b/pkg/core/dangeroustriggersrule_test.go
@@ -391,7 +391,169 @@ func TestCheckMitigations(t *testing.T) {
 			if got.HasForkCheck != tt.want.HasForkCheck {
 				t.Errorf("HasForkCheck = %v, want %v", got.HasForkCheck, tt.want.HasForkCheck)
 			}
+			if got.HasCacheMutation != tt.want.HasCacheMutation {
+				t.Errorf("HasCacheMutation = %v, want %v", got.HasCacheMutation, tt.want.HasCacheMutation)
+			}
 		})
+	}
+}
+
+// TestCheckMitigationsCacheMutation verifies that CheckMitigations detects
+// jobs that mutate the actions cache, which is the precondition for issue #469
+// downgrading the permissions mitigation score.
+func TestCheckMitigationsCacheMutation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow *ast.Workflow
+		want     bool
+	}{
+		{
+			name: "actions/cache",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecAction{
+									Uses: &ast.String{Value: "actions/cache@v4"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "actions/cache/save",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecAction{
+									Uses: &ast.String{Value: "actions/cache/save@v4"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "actions/cache/restore",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecAction{
+									Uses: &ast.String{Value: "actions/cache/restore@v4"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "actions/setup-node with cache",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecAction{
+									Uses: &ast.String{Value: "actions/setup-node@v4"},
+									Inputs: map[string]*ast.Input{
+										"cache": {
+											Name:  &ast.String{Value: "cache"},
+											Value: &ast.String{Value: "npm"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no cache action",
+			workflow: &ast.Workflow{
+				Jobs: map[string]*ast.Job{
+					"build": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo hi"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CheckMitigations(tt.workflow)
+			if got.HasCacheMutation != tt.want {
+				t.Errorf("HasCacheMutation = %v, want %v", got.HasCacheMutation, tt.want)
+			}
+		})
+	}
+}
+
+// TestMitigationScoreSuppressedWhenCacheMutation verifies that the permissions
+// mitigation score is suppressed (returns 0 instead of 3) when the workflow
+// also mutates the actions cache, because `permissions:` does not constrain
+// the cache write token. See issue #469.
+func TestMitigationScoreSuppressedWhenCacheMutation(t *testing.T) {
+	t.Parallel()
+
+	// Baseline: permissions restriction alone should still be 3 when there is
+	// no cache mutation in scope.
+	baseline := MitigationStatus{HasPermissionsRestriction: true}
+	if got := baseline.Score(); got != 3 {
+		t.Fatalf("baseline Score() = %d, want 3", got)
+	}
+
+	// With cache mutation, the permissions credit is dropped.
+	withCache := MitigationStatus{
+		HasPermissionsRestriction: true,
+		HasCacheMutation:          true,
+	}
+	if got := withCache.Score(); got != 0 {
+		t.Fatalf("with cache mutation Score() = %d, want 0", got)
+	}
+
+	// Severity must escalate from "" (adequate) to critical when cache is in
+	// scope and no other mitigation is present.
+	if got := withCache.Severity(); got != SeverityCritical {
+		t.Fatalf("with cache mutation Severity() = %q, want %q", got, SeverityCritical)
+	}
+
+	// Mixing cache mutation with another mitigation should still warn at
+	// medium because permissions no longer covers the full score gap.
+	withCacheAndLabel := MitigationStatus{
+		HasPermissionsRestriction: true,
+		HasCacheMutation:          true,
+		HasLabelCondition:         true,
+	}
+	if got := withCacheAndLabel.Score(); got != 1 {
+		t.Fatalf("with cache mutation + label Score() = %d, want 1", got)
+	}
+	if got := withCacheAndLabel.Severity(); got != SeverityMedium {
+		t.Fatalf("with cache mutation + label Severity() = %q, want %q", got, SeverityMedium)
 	}
 }
 
@@ -500,6 +662,39 @@ func TestDangerousTriggersCriticalRule(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			// Issue #469: permissions: contents: read does NOT block cache
+			// poisoning because cache writes use a runner-internal token.
+			// The mitigation score for permissions is suppressed when the
+			// workflow performs cache mutation, so this should fire critical.
+			name: "critical: pull_request_target with permissions+cache (issue #469)",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Permissions: &ast.Permissions{
+					Scopes: map[string]*ast.PermissionScope{
+						"contents": {Name: &ast.String{Value: "contents"}, Value: &ast.String{Value: "read"}},
+					},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecAction{
+									Uses: &ast.String{Value: "actions/cache@v4"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "cache poisoning",
 		},
 		{
 			name: "medium (not critical): pull_request_target with label condition",

--- a/pkg/core/dangeroustriggersrulecritical.go
+++ b/pkg/core/dangeroustriggersrulecritical.go
@@ -53,13 +53,22 @@ func (rule *DangerousTriggersCriticalRule) VisitWorkflowPre(node *ast.Workflow) 
 
 	// Generate error message
 	triggerList := strings.Join(triggerNames, ", ")
+	cacheNote := ""
+	if status.HasCacheMutation {
+		cacheNote = " NOTE: this workflow performs actions/cache mutation; " +
+			"a `permissions: {}` restriction will NOT block cache poisoning because " +
+			"cache writes use a runner-internal token outside the GITHUB_TOKEN " +
+			"permission model. Prefer label/actor gating, environment protection, " +
+			"or splitting the cache-writing job out of the privileged trigger."
+	}
 	msg := fmt.Sprintf(
 		"dangerous trigger (critical): workflow uses privileged trigger(s) [%s] without any security mitigations. "+
 			"These triggers grant write access and secrets access to potentially untrusted code. "+
 			"Add at least one mitigation: restrict permissions (permissions: read-all or permissions: {}), "+
-			"use environment protection, add label conditions, or check github.actor. "+
+			"use environment protection, add label conditions, or check github.actor.%s "+
 			"See https://sisaku-security.github.io/lint/docs/rules/dangeroustriggersrulecritical/",
 		triggerList,
+		cacheNote,
 	)
 
 	// Report error at the position of the first privileged trigger

--- a/pkg/core/dangeroustriggersrulecritical.go
+++ b/pkg/core/dangeroustriggersrulecritical.go
@@ -76,10 +76,16 @@ func (rule *DangerousTriggersCriticalRule) VisitWorkflowPre(node *ast.Workflow) 
 
 	rule.Errorf(pos, "%s", msg)
 
-	// Add auto-fixer to add permissions: {} to the workflow
-	rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
-		return addEmptyPermissionsToWorkflow(node)
-	}))
+	// Add auto-fixer to add permissions: {} to the workflow.
+	// Skip when the workflow performs cache mutation: permissions:{} would not
+	// raise the mitigation score (HasCacheMutation suppresses the permissions
+	// credit) and the fix would silently re-emit the same critical finding,
+	// contradicting the NOTE in the message above.
+	if !status.HasCacheMutation {
+		rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
+			return addEmptyPermissionsToWorkflow(node)
+		}))
+	}
 
 	return nil
 }

--- a/pkg/core/dangeroustriggersrulecritical.go
+++ b/pkg/core/dangeroustriggersrulecritical.go
@@ -55,11 +55,13 @@ func (rule *DangerousTriggersCriticalRule) VisitWorkflowPre(node *ast.Workflow) 
 	triggerList := strings.Join(triggerNames, ", ")
 	cacheNote := ""
 	if status.HasCacheMutation {
-		cacheNote = " NOTE: this workflow performs actions/cache mutation; " +
+		cacheNote = " NOTE: this workflow uses actions/cache (read or write); " +
 			"a `permissions: {}` restriction will NOT block cache poisoning because " +
-			"cache writes use a runner-internal token outside the GITHUB_TOKEN " +
-			"permission model. Prefer label/actor gating, environment protection, " +
-			"or splitting the cache-writing job out of the privileged trigger."
+			"GitHub Actions cache I/O uses a runner-internal token outside the " +
+			"GITHUB_TOKEN permission model — both reads (which can hydrate a " +
+			"poisoned cache into the build) and writes are unaffected. Prefer " +
+			"label/actor gating, environment protection, or splitting the cache " +
+			"step out of the privileged trigger."
 	}
 	msg := fmt.Sprintf(
 		"dangerous trigger (critical): workflow uses privileged trigger(s) [%s] without any security mitigations. "+

--- a/pkg/core/dangeroustriggersrulemedium.go
+++ b/pkg/core/dangeroustriggersrulemedium.go
@@ -79,8 +79,11 @@ func (rule *DangerousTriggersMediumRule) VisitWorkflowPre(node *ast.Workflow) er
 
 	rule.Errorf(pos, "%s", msg)
 
-	// Add auto-fixer if permissions are not already restricted
-	if !status.HasPermissionsRestriction {
+	// Add auto-fixer if permissions are not already restricted AND cache
+	// mutation is not in scope. With cache mutation, the permissions credit
+	// is suppressed so permissions:{} cannot raise the score; the autofix
+	// would silently produce no severity change and re-emit the same NOTE.
+	if !status.HasPermissionsRestriction && !status.HasCacheMutation {
 		rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
 			return addEmptyPermissionsToWorkflow(node)
 		}))

--- a/pkg/core/dangeroustriggersrulemedium.go
+++ b/pkg/core/dangeroustriggersrulemedium.go
@@ -56,13 +56,22 @@ func (rule *DangerousTriggersMediumRule) VisitWorkflowPre(node *ast.Workflow) er
 
 	// Generate error message
 	triggerList := strings.Join(triggerNames, ", ")
+	cacheNote := ""
+	if status.HasCacheMutation {
+		cacheNote = " NOTE: this workflow performs actions/cache mutation; " +
+			"`permissions:` restrictions do NOT block cache poisoning because " +
+			"cache writes use a runner-internal token outside the GITHUB_TOKEN " +
+			"permission model. Prefer label/actor gating, environment protection, " +
+			"or splitting the cache-writing job out of the privileged trigger."
+	}
 	msg := fmt.Sprintf(
 		"dangerous trigger (medium): workflow uses privileged trigger(s) [%s] with partial mitigations (%s). "+
 			"Consider adding more mitigations for defense in depth: restrict permissions (permissions: read-all), "+
-			"use environment protection, add label conditions, or check github.actor. "+
+			"use environment protection, add label conditions, or check github.actor.%s "+
 			"See https://sisaku-security.github.io/lint/docs/rules/dangeroustriggersrulemedium/",
 		triggerList,
 		mitigationList,
+		cacheNote,
 	)
 
 	// Report error at the position of the first privileged trigger

--- a/pkg/core/dangeroustriggersrulemedium.go
+++ b/pkg/core/dangeroustriggersrulemedium.go
@@ -58,11 +58,13 @@ func (rule *DangerousTriggersMediumRule) VisitWorkflowPre(node *ast.Workflow) er
 	triggerList := strings.Join(triggerNames, ", ")
 	cacheNote := ""
 	if status.HasCacheMutation {
-		cacheNote = " NOTE: this workflow performs actions/cache mutation; " +
+		cacheNote = " NOTE: this workflow uses actions/cache (read or write); " +
 			"`permissions:` restrictions do NOT block cache poisoning because " +
-			"cache writes use a runner-internal token outside the GITHUB_TOKEN " +
-			"permission model. Prefer label/actor gating, environment protection, " +
-			"or splitting the cache-writing job out of the privileged trigger."
+			"GitHub Actions cache I/O uses a runner-internal token outside the " +
+			"GITHUB_TOKEN permission model — both reads (which can hydrate a " +
+			"poisoned cache into the build) and writes are unaffected. Prefer " +
+			"label/actor gating, environment protection, or splitting the cache " +
+			"step out of the privileged trigger."
 	}
 	msg := fmt.Sprintf(
 		"dangerous trigger (medium): workflow uses privileged trigger(s) [%s] with partial mitigations (%s). "+

--- a/script/README.md
+++ b/script/README.md
@@ -24,7 +24,7 @@ Contains example GitHub Actions workflow files that demonstrate various security
 |------|-------------|
 | `cache-poisoning.yaml` | Demonstrates cache poisoning vulnerabilities |
 | `cache-poisoning-composite-action.yaml` | TanStack-style cache poisoning via `pull_request_target`, unsafe PR merge checkout, and remote composite action cache usage |
-| `dangerous-triggers-cache-mutation.yaml` | Demonstrates that `permissions: contents: read` does NOT block cache poisoning (issue #469): cache writes use a runner-internal token outside the GITHUB_TOKEN scope, so the dangerous-triggers-critical rule still fires when the workflow performs cache mutation. |
+| `dangerous-triggers-cache-mutation.yaml` | Demonstrates that `permissions: contents: read` does NOT block cache poisoning: cache writes use a runner-internal token outside the GITHUB_TOKEN scope, so the dangerous-triggers-critical rule still fires when the workflow performs cache mutation. |
 | `cache-poisoning-safe.yaml` | Safe cache configuration example |
 | `credential.yaml` | Credential exposure patterns |
 | `issueinjection.yaml` | Script injection via GitHub context |

--- a/script/README.md
+++ b/script/README.md
@@ -24,6 +24,7 @@ Contains example GitHub Actions workflow files that demonstrate various security
 |------|-------------|
 | `cache-poisoning.yaml` | Demonstrates cache poisoning vulnerabilities |
 | `cache-poisoning-composite-action.yaml` | TanStack-style cache poisoning via `pull_request_target`, unsafe PR merge checkout, and remote composite action cache usage |
+| `dangerous-triggers-cache-mutation.yaml` | Demonstrates that `permissions: contents: read` does NOT block cache poisoning (issue #469): cache writes use a runner-internal token outside the GITHUB_TOKEN scope, so the dangerous-triggers-critical rule still fires when the workflow performs cache mutation. |
 | `cache-poisoning-safe.yaml` | Safe cache configuration example |
 | `credential.yaml` | Credential exposure patterns |
 | `issueinjection.yaml` | Script injection via GitHub context |

--- a/script/actions/dangerous-triggers-cache-mutation.yaml
+++ b/script/actions/dangerous-triggers-cache-mutation.yaml
@@ -1,0 +1,36 @@
+name: Dangerous Trigger With Cache Mutation
+
+# This workflow demonstrates that `permissions:` restrictions do NOT block
+# cache poisoning, because cache writes use a runner-internal token that is
+# outside the GITHUB_TOKEN permission model. Issue #469 (TanStack/router
+# supply-chain incident, 2026-05) exploited this exact gap.
+#
+# In previous sisakulint versions the dangerous-triggers-critical rule was
+# silenced here by `permissions: contents: read` (mitigation score 3). The
+# Gap 2 fix downgrades the permissions credit when cache mutation is in
+# scope so this case fires critical again.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR merge ref
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Restore dependency cache
+        # `permissions:` cannot block this write — the GitHub Actions cache
+        # backend uses a runner-internal token. With an unsafe checkout above,
+        # PR-controlled code can poison the base-branch cache scope.
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: deps-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Closes #469

## Background

The 2026-05 TanStack supply-chain incident was a *cache poisoning chain* hiding behind a composite action. After Gap 1 (`refs/pull/` in `UntrustedCheckoutRule` unsafe ref list) and Gap 3 (`RemoteActionsMetadataCache` composite traversal) were landed in earlier work on `main` (ded34ed..0188949), one gap remained: the **`DangerousTriggers*Rule` mitigation score** wrongly credited `permissions: contents: read` as a defense against cache poisoning, even though cache writes use the runner-internal token and bypass the workflow `GITHUB_TOKEN` permission model entirely.

This PR fixes that gap.

## What changed

- **`pkg/core/dangeroustriggersrule.go`** — `MitigationStatus` gains `HasCacheMutation`. `CheckMitigations` walks every job in the workflow and flips it on when it sees any `actions/cache`, `actions/cache/save`, `actions/cache/restore`, or `actions/setup-*` step with `cache:` enabled (literal `uses:` — composite traversal is Gap 3 territory and lives in `RemoteActionsMetadataCache`). When `HasCacheMutation` is true the `permissions: ... read` +3 credit is dropped, so the workflow no longer slides past `Score() >= 3`.
- **Critical and Medium messages** append a `NOTE:` explaining that `permissions: {}` does not block cache poisoning and pointing the reader at label/actor gating, environment protection, or splitting the cache-writing job out of the privileged trigger. The auto-fix that inserts `permissions: {}` is unchanged but the explanatory text now warns when it would be insufficient.
- **Tests** (`pkg/core/dangeroustriggersrule_test.go`) — three new cases: `permissions: contents: read` no longer suppresses critical when `actions/cache` is present; same for `actions/setup-node` with `cache: npm`; and the negative case (no cache mutation → `permissions:` still mitigates) is locked in.
- **Fixture** (`script/actions/dangerous-triggers-cache-mutation.yaml`) — a minimal repro of the TanStack pattern: `pull_request_target` + `permissions: contents: read` + `refs/pull/${{ pr.number }}/merge` checkout + `actions/cache@v4`. The fixture now fires `dangerous-triggers-critical` (Gap 2), `untrusted-checkout` (Gap 1, previously landed), and `cache-poisoning` (Gap 3, previously landed) — i.e. the full chain is visible.
- **`script/README.md`** — fixture entry added.
- **`CLAUDE.md`** — `DangerousTriggersCriticalRule` / `DangerousTriggersMediumRule` notes updated to describe cache-mutation-aware mitigation.

## Acceptance check

Running the built binary against the new fixture (`./sisakulint script/actions/dangerous-triggers-cache-mutation.yaml`) reports the chain at critical severity with the cache-scope-crossing language called out in #469's acceptance criteria. `dangerous-triggers-critical` now emits:

> NOTE: this workflow performs actions/cache mutation; a `permissions: {}` restriction will NOT block cache poisoning because cache writes use a runner-internal token outside the GITHUB_TOKEN permission model.

## Tests

`go test ./...` — 2691 passed in 6 packages. `go vet ./...` clean.

## Notes / out of scope

- Composite-action traversal for cache detection (Gap 3) was already landed via `RemoteActionsMetadataCache`; this PR's literal `uses:` scan is intentionally a lower bound that catches the common case without re-fetching remote action manifests during mitigation scoring.
- `permissions: {}` auto-fix is left in place because it remains the right answer when *no* cache mutation is present; the message now distinguishes the two situations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * キャッシュ書き込みを伴うアクションの検出を導入し、安全性評価に反映します。

* **Bug Fixes**
  * キャッシュミューテーションがある場合のリスク評価と自動修正抑止を改善し、誤った緩和評価を防止します。

* **Documentation**
  * キャッシュ汚染リスクの説明と具体例、対処案を追記しました。

* **Tests**
  * キャッシュ操作シナリオとスコアリング/自動修正挙動を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->