### PR TITLE
fix: authenticate commit-sha resolver with GITHUB_TOKEN to stop silent rate-limit truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ sisakulint -fix on -github-token "$(gh auth token)"
 - **0** - Success, no problems found
 - **1** - Success, problems found
 - **2** - Invalid command-line options
-- **3** - Fatal error
+- **3** - Fatal error (also returned when `-fix on` aborts because the GitHub API rate limit was exceeded during commit-sha resolution; see issue #474)
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,8 +235,10 @@ sisakulint -enable-rule missing-timeout-minutes
 # -github-token > SISAKULINT_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN.
 # Without a token, `-fix on` warns up-front and exits non-zero (skipping
 # partial writes) if the unauthenticated 60 req/h limit is hit.
-sisakulint -fix on -github-token "$(gh auth token)"
+# Prefer env-based auth so the token does not appear in process args (ps).
 GITHUB_TOKEN=$(gh auth token) sisakulint -fix on
+# CLI flag form (highest priority; visible in `ps`, prefer env for shared hosts).
+sisakulint -fix on -github-token "$(gh auth token)"
 ```
 
 ## Exit Codes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,13 @@ sisakulint -boilerplate
 
 # Enable an opt-in rule (currently available: missing-timeout-minutes)
 sisakulint -enable-rule missing-timeout-minutes
+
+# Authenticate the commit-sha resolver (issue #474). Priority order:
+# -github-token > SISAKULINT_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN.
+# Without a token, `-fix on` warns up-front and exits non-zero (skipping
+# partial writes) if the unauthenticated 60 req/h limit is hit.
+sisakulint -fix on -github-token "$(gh auth token)"
+GITHUB_TOKEN=$(gh auth token) sisakulint -fix on
 ```
 
 ## Exit Codes

--- a/README.md
+++ b/README.md
@@ -589,7 +589,13 @@ $ git diff .github/workflows/
 
 - **Always review changes**: Even though autofix is automated, always review the changes made to your workflow files before committing them
 - **Commit SHA fixes require internet**: The `commit-sha` rule needs to fetch commit information from GitHub, so it requires an active internet connection
-- **Rate limiting**: The commit SHA autofix makes GitHub API calls, which are subject to rate limiting. For unauthenticated requests, the limit is 60 requests per hour
+- **Rate limiting**: The commit SHA autofix makes GitHub API calls, which are subject to rate limiting. Unauthenticated requests are capped at **60 requests per hour**, which silently truncates `-fix on` once exceeded. Set a token to lift the limit to 5,000 req/h:
+   - `SISAKULINT_GITHUB_TOKEN` (preferred — scoped to this tool)
+   - `GITHUB_TOKEN` (set automatically inside GitHub Actions)
+   - `GH_TOKEN` (set by `gh auth login`)
+   - `-github-token "$(gh auth token)"` (CLI flag, highest priority)
+
+   A fine-grained PAT with `public_repo` (or just `Metadata: Read-only` on the targets you pin) is sufficient. When sisakulint detects no token at startup, it now prints a warning. If the rate limit is exhausted mid-run, sisakulint aborts with a non-zero exit and skips writing partial output for the affected file rather than leaving a mix of pinned and unpinned actions on disk.
 - **Backup your files**: Consider committing your changes or backing up your workflow files before running autofix
 - **Not all rules support autofix**: Some rules like `expression`, `permissions`, `issue-injection`, `cache-poisoning`, and `deprecated-commands` require manual fixes as they depend on your specific use case
 - **Auto-fix capabilities**: Currently, `timeout-minutes`, `commit-sha`, `credentials`, `untrusted-checkout`, and `artifact-poisoning` rules support auto-fix. More rules will support auto-fix in future releases

--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ $ git diff .github/workflows/
 
 - **Always review changes**: Even though autofix is automated, always review the changes made to your workflow files before committing them
 - **Commit SHA fixes require internet**: The `commit-sha` rule needs to fetch commit information from GitHub, so it requires an active internet connection
-- **Rate limiting**: The commit SHA autofix makes GitHub API calls, which are subject to rate limiting. Unauthenticated requests are capped at **60 requests per hour**, which silently truncates `-fix on` once exceeded. Set a token to lift the limit to 5,000 req/h:
+- **Rate limiting**: The commit SHA autofix makes GitHub API calls, which are subject to rate limiting. Unauthenticated requests are capped at **60 requests per hour**. Set a token to lift the limit to 5,000 req/h:
    - `SISAKULINT_GITHUB_TOKEN` (preferred — scoped to this tool)
    - `GITHUB_TOKEN` (read from the process environment; inside a GitHub Actions step you must map it explicitly, e.g. `env: GITHUB_TOKEN: ${{ github.token }}` — the runner does not export `secrets.GITHUB_TOKEN` to `run:` steps automatically)
    - `GH_TOKEN` (set by `gh auth login`)

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ $ git diff .github/workflows/
 - **Commit SHA fixes require internet**: The `commit-sha` rule needs to fetch commit information from GitHub, so it requires an active internet connection
 - **Rate limiting**: The commit SHA autofix makes GitHub API calls, which are subject to rate limiting. Unauthenticated requests are capped at **60 requests per hour**, which silently truncates `-fix on` once exceeded. Set a token to lift the limit to 5,000 req/h:
    - `SISAKULINT_GITHUB_TOKEN` (preferred — scoped to this tool)
-   - `GITHUB_TOKEN` (set automatically inside GitHub Actions)
+   - `GITHUB_TOKEN` (read from the process environment; inside a GitHub Actions step you must map it explicitly, e.g. `env: GITHUB_TOKEN: ${{ github.token }}` — the runner does not export `secrets.GITHUB_TOKEN` to `run:` steps automatically)
    - `GH_TOKEN` (set by `gh auth login`)
    - `-github-token "$(gh auth token)"` (CLI flag, highest priority)
 

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -239,9 +239,9 @@ func (cmd *Command) Main(args []string) int {
 	flags.IntVar(&parallelism, "p", 3, "Number of parallel scans (-remote only)")
 	flags.IntVar(&limit, "l", 30, "Max repositories for search queries (-remote only)")
 	flags.StringVar(&githubTokenFlag, "github-token", "",
-		"GitHub API token used by -fix on to resolve commit SHAs. "+
+		"GitHub API token used by -fix on/-fix dry-run to resolve commit SHAs. "+
 			"Falls back to SISAKULINT_GITHUB_TOKEN, GITHUB_TOKEN, then GH_TOKEN. "+
-			"Without a token the unauthenticated 60 req/h limit may truncate fixes silently (issue #474)")
+			"Without a token, unauthenticated requests are limited to 60 req/h and may interrupt commit-sha autofix (issue #474)")
 
 	flags.Usage = func() {
 		printingUsageHeader(cmd.Stderr)

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -126,13 +126,25 @@ func (cmd *Command) runLint(args []string, linterOpts *LinterOptions, initConfig
 	return l.LintFiles(args, nil)
 }
 
-func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool) {
+// runAutofix returns true if any fixer aborted because of a GitHub API
+// rate-limit. The caller uses that signal to surface a non-zero-exit
+// warning to the user instead of silently shipping a partially-fixed tree
+// (issue #474). Per-file rate-limit failures additionally suppress writing
+// that file, since the on-disk result would otherwise mix freshly-pinned
+// SHAs with leftover @vN tags and the user has no way to tell which is
+// which from the exit code alone.
+func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool) (rateLimited bool) {
 	for _, res := range results {
 		if len(res.AutoFixers) == 0 {
 			continue
 		}
+		fileRateLimited := false
 		for _, fixer := range res.AutoFixers {
 			if err := fixer.Fix(); err != nil {
+				if IsGitHubRateLimitError(err) {
+					fileRateLimited = true
+					rateLimited = true
+				}
 				var lintErr *LintingError
 				if errors.As(err, &lintErr) {
 					lintErr.FilePath = res.FilePath
@@ -152,19 +164,28 @@ func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool) {
 		data := buf.Bytes()
 		if isDryRun {
 			fmt.Fprintf(cmd.Stdout, "Fixed workflow %s:\n%s\n", res.FilePath, string(data))
-		} else {
-			err := os.WriteFile(res.FilePath, data, 0644) //nolint:gosec // auto-fix overwrites existing workflow files; preserving 0644 for git and CI compatibility
+			continue
+		}
+		if fileRateLimited {
+			// Skip writing partial output. Some fixers in this file succeeded,
+			// but a rate-limited commit-sha resolver would leave a mix of
+			// SHA-pinned and tag-pinned actions on disk that is harder to
+			// recover from than the original file.
+			fmt.Fprintf(cmd.Stderr, "Skipping write for %s due to GitHub API rate limit; re-run after authenticating to complete the fix.\n", res.FilePath)
+			continue
+		}
+		err = os.WriteFile(res.FilePath, data, 0644) //nolint:gosec // auto-fix overwrites existing workflow files; preserving 0644 for git and CI compatibility
+		if err != nil {
+			fmt.Fprintf(cmd.Stderr, "Error while writing the fixed workflow: %v\n", err)
+			err := os.WriteFile(res.FilePath, res.Source, 0644) //nolint:gosec // restore original workflow file
 			if err != nil {
-				fmt.Fprintf(cmd.Stderr, "Error while writing the fixed workflow: %v\n", err)
-				err := os.WriteFile(res.FilePath, res.Source, 0644) //nolint:gosec // restore original workflow file
-				if err != nil {
-					fmt.Fprintf(cmd.Stderr, "Error while restoring the original workflow: %v\n", err)
-				}
-			} else {
-				fmt.Fprintf(cmd.Stdout, "Fixed workflow %s\n", res.FilePath)
+				fmt.Fprintf(cmd.Stderr, "Error while restoring the original workflow: %v\n", err)
 			}
+		} else {
+			fmt.Fprintf(cmd.Stdout, "Fixed workflow %s\n", res.FilePath)
 		}
 	}
+	return rateLimited
 }
 
 type ignorePatternFlags []string
@@ -202,6 +223,7 @@ func (cmd *Command) Main(args []string) int {
 	var maxDepth int
 	var parallelism int
 	var limit int
+	var githubTokenFlag string
 
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flags.SetOutput(cmd.Stderr)
@@ -224,6 +246,10 @@ func (cmd *Command) Main(args []string) int {
 	flags.IntVar(&maxDepth, "D", 3, "Max recursion depth for recursive scanning (-remote only)")
 	flags.IntVar(&parallelism, "p", 3, "Number of parallel scans (-remote only)")
 	flags.IntVar(&limit, "l", 30, "Max repositories for search queries (-remote only)")
+	flags.StringVar(&githubTokenFlag, "github-token", "",
+		"GitHub API token used by -fix on to resolve commit SHAs. "+
+			"Falls back to SISAKULINT_GITHUB_TOKEN, GITHUB_TOKEN, then GH_TOKEN. "+
+			"Without a token the unauthenticated 60 req/h limit may truncate fixes silently (issue #474)")
 
 	flags.Usage = func() {
 		printingUsageHeader(cmd.Stderr)
@@ -254,6 +280,24 @@ func (cmd *Command) Main(args []string) int {
 	linterOpts.ErrorIgnorePatterns = ignorePats
 	linterOpts.EnabledOptInRules = enabledRules
 	linterOpts.LogOutputDestination = cmd.Stderr
+
+	// Resolve the GitHub token used by commit-sha autofix. Even when the
+	// caller did not request -fix on, surfacing the source up-front (or the
+	// missing-token warning) keeps the behaviour observable: users discover
+	// the unauthenticated 60 req/h ceiling before it bites mid-fix
+	// (issue #474).
+	token, source := ResolveGitHubToken(githubTokenFlag, nil)
+	linterOpts.GitHubToken = token
+	enableAutofix := autoFixMode == "on" || autoFixMode == FileFixDryRun
+	if enableAutofix {
+		if token == "" {
+			fmt.Fprintln(cmd.Stderr,
+				"sisakulint: no GitHub token detected; commit-sha resolution limited to 60 req/h. "+
+					"Set GITHUB_TOKEN, GH_TOKEN, SISAKULINT_GITHUB_TOKEN, or pass -github-token to lift the limit.")
+		} else if linterOpts.IsVerboseOutputEnabled {
+			fmt.Fprintf(cmd.Stderr, "sisakulint: using GitHub token from %s for commit-sha resolution.\n", source)
+		}
+	}
 
 	if generateActionList {
 		if err := GenerateActionListConfig("."); err != nil {
@@ -287,9 +331,13 @@ func (cmd *Command) Main(args []string) int {
 		}
 	}
 	if hasErrors {
-		enableAutofix := autoFixMode == "on" || autoFixMode == FileFixDryRun
 		if enableAutofix {
-			cmd.runAutofix(errs, autoFixMode == FileFixDryRun)
+			if rateLimited := cmd.runAutofix(errs, autoFixMode == FileFixDryRun); rateLimited {
+				fmt.Fprintln(cmd.Stderr,
+					"sisakulint: commit-sha autofix aborted because the GitHub API rate limit was exceeded. "+
+						"Re-run with GITHUB_TOKEN / GH_TOKEN / SISAKULINT_GITHUB_TOKEN set or with -github-token to complete the fix.")
+				return ExitStatusFailure
+			}
 		}
 		return ExitStatusSuccessProblemFound
 	}

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -126,13 +126,9 @@ func (cmd *Command) runLint(args []string, linterOpts *LinterOptions, initConfig
 	return l.LintFiles(args, nil)
 }
 
-// runAutofix returns true if any fixer aborted because of a GitHub API
-// rate-limit. The caller uses that signal to surface a non-zero-exit
-// warning to the user instead of silently shipping a partially-fixed tree
-// (issue #474). Per-file rate-limit failures additionally suppress writing
-// that file, since the on-disk result would otherwise mix freshly-pinned
-// SHAs with leftover @vN tags and the user has no way to tell which is
-// which from the exit code alone.
+// runAutofix returns true if any fixer hit the GitHub API rate limit, so
+// Main can surface a non-zero exit and skip the affected file's write
+// (issue #474).
 func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool) (rateLimited bool) {
 	for _, res := range results {
 		if len(res.AutoFixers) == 0 {
@@ -167,10 +163,6 @@ func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool) (rateLi
 			continue
 		}
 		if fileRateLimited {
-			// Skip writing partial output. Some fixers in this file succeeded,
-			// but a rate-limited commit-sha resolver would leave a mix of
-			// SHA-pinned and tag-pinned actions on disk that is harder to
-			// recover from than the original file.
 			fmt.Fprintf(cmd.Stderr, "Skipping write for %s due to GitHub API rate limit; re-run after authenticating to complete the fix.\n", res.FilePath)
 			continue
 		}
@@ -281,11 +273,6 @@ func (cmd *Command) Main(args []string) int {
 	linterOpts.EnabledOptInRules = enabledRules
 	linterOpts.LogOutputDestination = cmd.Stderr
 
-	// Resolve the GitHub token used by commit-sha autofix. Even when the
-	// caller did not request -fix on, surfacing the source up-front (or the
-	// missing-token warning) keeps the behaviour observable: users discover
-	// the unauthenticated 60 req/h ceiling before it bites mid-fix
-	// (issue #474).
 	token, source := ResolveGitHubToken(githubTokenFlag, nil)
 	linterOpts.GitHubToken = token
 	enableAutofix := autoFixMode == "on" || autoFixMode == FileFixDryRun

--- a/pkg/core/commitsha.go
+++ b/pkg/core/commitsha.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 	"sync"
@@ -14,14 +13,26 @@ import (
 
 type CommitSha struct {
 	BaseRule
+	// githubToken carries the authenticated token resolved at command startup.
+	// Empty means the unauthenticated 60 req/h limit applies and -fix on may
+	// truncate silently on workflows with many actions (issue #474).
+	githubToken string
+	// clientOnce guards lazy construction so that workflows whose actions are
+	// already pinned never instantiate an HTTP client.
+	clientOnce sync.Once
+	client     *github.Client
 }
 
-func CommitShaRule() *CommitSha {
+// CommitShaRule constructs the commit-sha rule. The token is forwarded to the
+// GitHub client used by FixStep when sisakulint is invoked with -fix on; pass
+// "" when no token is available (the resolver will then run unauthenticated).
+func CommitShaRule(token string) *CommitSha {
 	return &CommitSha{
 		BaseRule: BaseRule{
 			RuleName: "commit-sha",
 			RuleDesc: "Warn if the action ref is not a full length commit SHA and not an official GitHub Action.",
 		},
+		githubToken: token,
 	}
 }
 
@@ -82,18 +93,23 @@ func getLongVersion(cl *github.Client, owner, repo, sha string, expectedTag stri
 	return "", nil
 }
 
-var ghOnce sync.Once
-var ghClient *github.Client
+// githubClient lazily constructs the *github.Client, wiring in the OAuth2
+// transport when a token was resolved at startup. Returning the client per
+// rule (rather than a package-level singleton) ensures different sisakulint
+// invocations in the same process — e.g. the test suite — pick up the
+// token configured for that run.
+func (rule *CommitSha) githubClient() *github.Client {
+	rule.clientOnce.Do(func() {
+		rule.client = NewGitHubClient(context.Background(), rule.githubToken)
+	})
+	return rule.client
+}
 
 func (rule *CommitSha) FixStep(step *ast.Step) error {
 	// at here, we can assume that the action ref is not a full length commit SHA
 	action := step.Exec.(*ast.ExecAction)
 	usesValue := action.Uses.Value
-	ghOnce.Do(func() {
-		// TODO(on-keyday): make this configurable
-		ghClient = github.NewClient(http.DefaultClient)
-	})
-	gh := ghClient
+	gh := rule.githubClient()
 	splitTag := strings.Split(usesValue, "@")
 	if len(splitTag) != 2 {
 		// Create a LintingError with position information
@@ -112,22 +128,30 @@ func (rule *CommitSha) FixStep(step *ast.Step) error {
 	//tagComment := action.Uses.BaseNode.LineComment
 	sha, _, err := gh.Repositories.GetCommitSHA1(context.TODO(), ownerRepo[0], ownerRepo[1], tag, "")
 	if err != nil {
-		// Create a LintingError with position information
-		// Using error.Error() to include the full error message
-		lintErr := FormattedError(step.Pos, rule.RuleName, "failed to get commit SHA1: %s at step '%s'", err.Error(), step.String())
-		return lintErr
+		return rule.wrapAPIError(step, "failed to get commit SHA1", err)
 	}
 	if !isSemver && isShortTag {
 		longVersion, err := getLongVersion(gh, ownerRepo[0], ownerRepo[1], sha, splitTag[1])
 		if err != nil {
-			// Create a LintingError with position information
-			// Using error.Error() to include the full error message
-			lintErr := FormattedError(step.Pos, rule.RuleName, "failed to get long version: %s at step '%s'", err.Error(), step.String())
-			return lintErr
+			return rule.wrapAPIError(step, "failed to get long version", err)
 		}
 		tag = longVersion
 	}
 	action.Uses.BaseNode.Value = splitTag[0] + "@" + sha
 	action.Uses.BaseNode.LineComment = tag
 	return nil
+}
+
+// wrapAPIError converts a go-github failure into a LintingError. Rate-limit
+// failures are additionally wrapped with ErrGitHubRateLimit so that
+// runAutofix can recognise the silent-truncation case and skip writing
+// any partially-fixed workflow file.
+func (rule *CommitSha) wrapAPIError(step *ast.Step, prefix string, err error) error {
+	if IsGitHubRateLimitError(err) {
+		lintErr := FormattedError(step.Pos, rule.RuleName,
+			"%s: %s at step '%s' (set GITHUB_TOKEN, GH_TOKEN, SISAKULINT_GITHUB_TOKEN, or pass -github-token to lift the unauthenticated 60 req/h limit)",
+			prefix, err.Error(), step.String())
+		return fmt.Errorf("%w: %w", ErrGitHubRateLimit, lintErr)
+	}
+	return FormattedError(step.Pos, rule.RuleName, "%s: %s at step '%s'", prefix, err.Error(), step.String())
 }

--- a/pkg/core/commitsha.go
+++ b/pkg/core/commitsha.go
@@ -13,19 +13,11 @@ import (
 
 type CommitSha struct {
 	BaseRule
-	// githubToken carries the authenticated token resolved at command startup.
-	// Empty means the unauthenticated 60 req/h limit applies and -fix on may
-	// truncate silently on workflows with many actions (issue #474).
 	githubToken string
-	// clientOnce guards lazy construction so that workflows whose actions are
-	// already pinned never instantiate an HTTP client.
-	clientOnce sync.Once
-	client     *github.Client
+	clientOnce  sync.Once
+	client      *github.Client
 }
 
-// CommitShaRule constructs the commit-sha rule. The token is forwarded to the
-// GitHub client used by FixStep when sisakulint is invoked with -fix on; pass
-// "" when no token is available (the resolver will then run unauthenticated).
 func CommitShaRule(token string) *CommitSha {
 	return &CommitSha{
 		BaseRule: BaseRule{
@@ -93,11 +85,6 @@ func getLongVersion(cl *github.Client, owner, repo, sha string, expectedTag stri
 	return "", nil
 }
 
-// githubClient lazily constructs the *github.Client, wiring in the OAuth2
-// transport when a token was resolved at startup. Returning the client per
-// rule (rather than a package-level singleton) ensures different sisakulint
-// invocations in the same process — e.g. the test suite — pick up the
-// token configured for that run.
 func (rule *CommitSha) githubClient() *github.Client {
 	rule.clientOnce.Do(func() {
 		rule.client = NewGitHubClient(context.Background(), rule.githubToken)
@@ -142,10 +129,8 @@ func (rule *CommitSha) FixStep(step *ast.Step) error {
 	return nil
 }
 
-// wrapAPIError converts a go-github failure into a LintingError. Rate-limit
-// failures are additionally wrapped with ErrGitHubRateLimit so that
-// runAutofix can recognise the silent-truncation case and skip writing
-// any partially-fixed workflow file.
+// wrapAPIError wraps rate-limit failures with ErrGitHubRateLimit so the
+// caller can skip writing a partially-fixed workflow (issue #474).
 func (rule *CommitSha) wrapAPIError(step *ast.Step, prefix string, err error) error {
 	if IsGitHubRateLimitError(err) {
 		lintErr := FormattedError(step.Pos, rule.RuleName,

--- a/pkg/core/commitsha.go
+++ b/pkg/core/commitsha.go
@@ -14,8 +14,12 @@ import (
 type CommitSha struct {
 	BaseRule
 	githubToken string
-	clientOnce  sync.Once
-	client      *github.Client
+	// clientMu guards lazy initialization of client. Using sync.Mutex + nil
+	// check (rather than sync.Once) keeps the test path simple: tests can
+	// assign a fake client directly and githubClient() will skip the lazy
+	// constructor instead of depending on sync.Once internals.
+	clientMu sync.Mutex
+	client   *github.Client
 }
 
 func CommitShaRule(token string) *CommitSha {
@@ -86,9 +90,11 @@ func getLongVersion(cl *github.Client, owner, repo, sha string, expectedTag stri
 }
 
 func (rule *CommitSha) githubClient() *github.Client {
-	rule.clientOnce.Do(func() {
+	rule.clientMu.Lock()
+	defer rule.clientMu.Unlock()
+	if rule.client == nil {
 		rule.client = NewGitHubClient(context.Background(), rule.githubToken)
-	})
+	}
 	return rule.client
 }
 

--- a/pkg/core/commitsha_test.go
+++ b/pkg/core/commitsha_test.go
@@ -1,15 +1,21 @@
 package core
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/google/go-github/v68/github"
 	"github.com/sisaku-security/sisakulint/pkg/ast"
 	"gopkg.in/yaml.v3"
 )
 
 // TestCommitShaRule tests the CommitShaRule constructor function.
 func TestCommitShaRule(t *testing.T) {
-	rule := CommitShaRule()
+	rule := CommitShaRule("")
 
 	if rule.RuleName != "commit-sha" {
 		t.Errorf("Expected RuleName to be 'commit-sha', got '%s'", rule.RuleName)
@@ -271,7 +277,7 @@ func TestCommitSha_VisitStep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := CommitShaRule()
+			rule := CommitShaRule("")
 			err := rule.VisitStep(tt.step)
 
 			if err != nil {
@@ -347,7 +353,7 @@ func TestCommitSha_VisitStep_AutoFixer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := CommitShaRule()
+			rule := CommitShaRule("")
 			_ = rule.VisitStep(tt.step)
 
 			autoFixerCount := len(rule.AutoFixers())
@@ -396,7 +402,7 @@ func TestCommitSha_VisitStep_NilChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := CommitShaRule()
+			rule := CommitShaRule("")
 			// Should not panic
 			err := rule.VisitStep(tt.step)
 			if err != nil {
@@ -473,7 +479,7 @@ func TestCommitSha_FixStep_InvalidFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := CommitShaRule()
+			rule := CommitShaRule("")
 			err := rule.FixStep(tt.step)
 
 			if tt.wantError && err == nil {
@@ -488,7 +494,7 @@ func TestCommitSha_FixStep_InvalidFormat(t *testing.T) {
 
 // TestCommitSha_MultipleSteps tests processing multiple steps.
 func TestCommitSha_MultipleSteps(t *testing.T) {
-	rule := CommitShaRule()
+	rule := CommitShaRule("")
 
 	steps := []*ast.Step{
 		{
@@ -551,7 +557,7 @@ func TestCommitSha_MultipleSteps(t *testing.T) {
 
 // TestCommitSha_ErrorMessage tests that error messages are properly formatted.
 func TestCommitSha_ErrorMessage(t *testing.T) {
-	rule := CommitShaRule()
+	rule := CommitShaRule("")
 
 	step := &ast.Step{
 		ID: &ast.String{Value: "test-step"},
@@ -580,6 +586,103 @@ func TestCommitSha_ErrorMessage(t *testing.T) {
 	}
 	if !stringContains(errMsg, "full length commit SHA") {
 		t.Error("Error message should contain 'full length commit SHA'")
+	}
+}
+
+// TestCommitSha_FixStep_RateLimit verifies the silent-truncation guard from
+// issue #474. When the GitHub API responds with 403 + a rate-limit header,
+// FixStep must wrap the failure with ErrGitHubRateLimit so runAutofix can
+// recognise it, skip writing the partial file, and surface a non-zero exit.
+func TestCommitSha_FixStep_RateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "60")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "9999999999")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"API rate limit exceeded","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}`))
+	}))
+	defer srv.Close()
+
+	rule := CommitShaRule("")
+	// Force lazy initialisation so we can swap in the test base URL before
+	// any request is dispatched. clientOnce ensures FixStep reuses this
+	// client instead of constructing a fresh unauthenticated one.
+	rule.client = github.NewClient(nil)
+	baseURL, _ := url.Parse(srv.URL + "/")
+	rule.client.BaseURL = baseURL
+	rule.clientOnce.Do(func() {})
+
+	step := &ast.Step{
+		ID: &ast.String{Value: "checkout"},
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{
+				Value:    "actions/checkout@v3",
+				BaseNode: &yaml.Node{},
+			},
+		},
+		Pos: &ast.Position{Line: 10, Col: 5},
+	}
+
+	err := rule.FixStep(step)
+	if err == nil {
+		t.Fatal("expected rate-limit error, got nil")
+	}
+	if !errors.Is(err, ErrGitHubRateLimit) {
+		t.Errorf("expected error to wrap ErrGitHubRateLimit, got %v", err)
+	}
+	if !IsGitHubRateLimitError(err) {
+		t.Error("IsGitHubRateLimitError should return true for the wrapped failure")
+	}
+	var lintErr *LintingError
+	if !errors.As(err, &lintErr) {
+		t.Fatal("expected wrapped *LintingError so runAutofix can format the message")
+	}
+	if !strings.Contains(lintErr.Description, "GITHUB_TOKEN") {
+		t.Errorf("expected hint about GITHUB_TOKEN in description, got %q", lintErr.Description)
+	}
+}
+
+// TestCommitSha_FixStep_NonRateLimitError verifies that a 404 (or any
+// non-rate-limit failure) still returns a plain *LintingError without the
+// ErrGitHubRateLimit wrapper. Otherwise runAutofix would skip writing files
+// for unrelated lookup failures and silently regress the auto-fix flow.
+func TestCommitSha_FixStep_NonRateLimitError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	rule := CommitShaRule("")
+	rule.client = github.NewClient(nil)
+	baseURL, _ := url.Parse(srv.URL + "/")
+	rule.client.BaseURL = baseURL
+	rule.clientOnce.Do(func() {})
+
+	step := &ast.Step{
+		ID: &ast.String{Value: "checkout"},
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{
+				Value:    "actions/does-not-exist@v3",
+				BaseNode: &yaml.Node{},
+			},
+		},
+		Pos: &ast.Position{Line: 10, Col: 5},
+	}
+
+	err := rule.FixStep(step)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrGitHubRateLimit) {
+		t.Errorf("404 should not be classified as a rate-limit failure: %v", err)
+	}
+	if IsGitHubRateLimitError(err) {
+		t.Error("IsGitHubRateLimitError must remain false for non-rate-limit errors")
+	}
+	var lintErr *LintingError
+	if !errors.As(err, &lintErr) {
+		t.Fatal("expected *LintingError")
 	}
 }
 

--- a/pkg/core/commitsha_test.go
+++ b/pkg/core/commitsha_test.go
@@ -604,13 +604,12 @@ func TestCommitSha_FixStep_RateLimit(t *testing.T) {
 	defer srv.Close()
 
 	rule := CommitShaRule("")
-	// Force lazy initialisation so we can swap in the test base URL before
-	// any request is dispatched. clientOnce ensures FixStep reuses this
-	// client instead of constructing a fresh unauthenticated one.
+	// Inject the test base URL before any request is dispatched.
+	// githubClient() short-circuits when rule.client is already set, so the
+	// lazy NewGitHubClient constructor is skipped.
 	rule.client = github.NewClient(nil)
 	baseURL, _ := url.Parse(srv.URL + "/")
 	rule.client.BaseURL = baseURL
-	rule.clientOnce.Do(func() {})
 
 	step := &ast.Step{
 		ID: &ast.String{Value: "checkout"},
@@ -657,7 +656,6 @@ func TestCommitSha_FixStep_NonRateLimitError(t *testing.T) {
 	rule.client = github.NewClient(nil)
 	baseURL, _ := url.Parse(srv.URL + "/")
 	rule.client.BaseURL = baseURL
-	rule.clientOnce.Do(func() {})
 
 	step := &ast.Step{
 		ID: &ast.String{Value: "checkout"},

--- a/pkg/core/github_token.go
+++ b/pkg/core/github_token.go
@@ -10,19 +10,14 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// GitHubTokenEnvVars lists the environment variables consulted for a GitHub
-// API token, in priority order. SISAKULINT_GITHUB_TOKEN takes precedence so
-// that a tool-specific token can override an ambient CI token whose scope is
-// inappropriate for sisakulint.
+// SISAKULINT_GITHUB_TOKEN is listed first so a tool-scoped token can override
+// an ambient CI token whose scope is inappropriate for sisakulint.
 var GitHubTokenEnvVars = []string{
 	"SISAKULINT_GITHUB_TOKEN",
 	"GITHUB_TOKEN",
 	"GH_TOKEN",
 }
 
-// ResolveGitHubToken returns the first non-empty token in (override,
-// SISAKULINT_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN) along with the source
-// label for diagnostics. An empty source means no token was found.
 func ResolveGitHubToken(override string, lookup func(string) (string, bool)) (token, source string) {
 	if override != "" {
 		return override, "-github-token"
@@ -38,11 +33,6 @@ func ResolveGitHubToken(override string, lookup func(string) (string, bool)) (to
 	return "", ""
 }
 
-// NewGitHubClient builds a *github.Client. When token is non-empty the
-// client is wrapped with an oauth2 source so every request carries
-// Authorization: Bearer <token>, lifting the unauthenticated 60 req/h limit
-// to the authenticated 5,000 req/h limit. An empty token returns a plain
-// client that uses http.DefaultClient.
 func NewGitHubClient(ctx context.Context, token string) *github.Client {
 	if token == "" {
 		return github.NewClient(http.DefaultClient)
@@ -51,17 +41,11 @@ func NewGitHubClient(ctx context.Context, token string) *github.Client {
 	return github.NewClient(oauth2.NewClient(ctx, src))
 }
 
-// ErrGitHubRateLimit is returned by autofixers that abort because the
-// GitHub API rate limit has been exhausted. Callers can match it with
-// errors.Is to distinguish the silent-truncation failure mode from a
-// per-action lookup failure (404, malformed ref, etc.) and skip writing
-// any partially-fixed file to disk.
 var ErrGitHubRateLimit = errors.New("github api rate limit exceeded")
 
-// IsGitHubRateLimitError reports whether err originates from a GitHub API
-// 403/429 rate-limit response. It accepts both go-github's typed
-// *github.RateLimitError / *github.AbuseRateLimitError and our sentinel
-// ErrGitHubRateLimit so callers can wrap freely.
+// IsGitHubRateLimitError covers both go-github's typed primary/secondary
+// limit errors and plain 429 ErrorResponse fall-throughs that go-github does
+// not classify (issue #474 codex review).
 func IsGitHubRateLimitError(err error) bool {
 	if err == nil {
 		return false
@@ -76,6 +60,17 @@ func IsGitHubRateLimitError(err error) bool {
 	var abuseErr *github.AbuseRateLimitError
 	if errors.As(err, &abuseErr) {
 		return true
+	}
+	var errResp *github.ErrorResponse
+	if errors.As(err, &errResp) && errResp.Response != nil {
+		switch errResp.Response.StatusCode {
+		case http.StatusTooManyRequests:
+			return true
+		case http.StatusForbidden:
+			if errResp.Response.Header.Get("X-RateLimit-Remaining") == "0" {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/pkg/core/github_token.go
+++ b/pkg/core/github_token.go
@@ -11,8 +11,10 @@ import (
 )
 
 // SISAKULINT_GITHUB_TOKEN is listed first so a tool-scoped token can override
-// an ambient CI token whose scope is inappropriate for sisakulint.
-var GitHubTokenEnvVars = []string{
+// an ambient CI token whose scope is inappropriate for sisakulint. Fixed-size
+// array (unexported) so the resolution order is immutable from outside the
+// package — preventing accidental reordering or extension at runtime.
+var gitHubTokenEnvVars = [...]string{
 	"SISAKULINT_GITHUB_TOKEN",
 	"GITHUB_TOKEN",
 	"GH_TOKEN",
@@ -25,7 +27,7 @@ func ResolveGitHubToken(override string, lookup func(string) (string, bool)) (to
 	if lookup == nil {
 		lookup = os.LookupEnv
 	}
-	for _, name := range GitHubTokenEnvVars {
+	for _, name := range gitHubTokenEnvVars {
 		if v, ok := lookup(name); ok && v != "" {
 			return v, name
 		}

--- a/pkg/core/github_token.go
+++ b/pkg/core/github_token.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/google/go-github/v68/github"
+	"golang.org/x/oauth2"
+)
+
+// GitHubTokenEnvVars lists the environment variables consulted for a GitHub
+// API token, in priority order. SISAKULINT_GITHUB_TOKEN takes precedence so
+// that a tool-specific token can override an ambient CI token whose scope is
+// inappropriate for sisakulint.
+var GitHubTokenEnvVars = []string{
+	"SISAKULINT_GITHUB_TOKEN",
+	"GITHUB_TOKEN",
+	"GH_TOKEN",
+}
+
+// ResolveGitHubToken returns the first non-empty token in (override,
+// SISAKULINT_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN) along with the source
+// label for diagnostics. An empty source means no token was found.
+func ResolveGitHubToken(override string, lookup func(string) (string, bool)) (token, source string) {
+	if override != "" {
+		return override, "-github-token"
+	}
+	if lookup == nil {
+		lookup = os.LookupEnv
+	}
+	for _, name := range GitHubTokenEnvVars {
+		if v, ok := lookup(name); ok && v != "" {
+			return v, name
+		}
+	}
+	return "", ""
+}
+
+// NewGitHubClient builds a *github.Client. When token is non-empty the
+// client is wrapped with an oauth2 source so every request carries
+// Authorization: Bearer <token>, lifting the unauthenticated 60 req/h limit
+// to the authenticated 5,000 req/h limit. An empty token returns a plain
+// client that uses http.DefaultClient.
+func NewGitHubClient(ctx context.Context, token string) *github.Client {
+	if token == "" {
+		return github.NewClient(http.DefaultClient)
+	}
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	return github.NewClient(oauth2.NewClient(ctx, src))
+}
+
+// ErrGitHubRateLimit is returned by autofixers that abort because the
+// GitHub API rate limit has been exhausted. Callers can match it with
+// errors.Is to distinguish the silent-truncation failure mode from a
+// per-action lookup failure (404, malformed ref, etc.) and skip writing
+// any partially-fixed file to disk.
+var ErrGitHubRateLimit = errors.New("github api rate limit exceeded")
+
+// IsGitHubRateLimitError reports whether err originates from a GitHub API
+// 403/429 rate-limit response. It accepts both go-github's typed
+// *github.RateLimitError / *github.AbuseRateLimitError and our sentinel
+// ErrGitHubRateLimit so callers can wrap freely.
+func IsGitHubRateLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrGitHubRateLimit) {
+		return true
+	}
+	var rateErr *github.RateLimitError
+	if errors.As(err, &rateErr) {
+		return true
+	}
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) {
+		return true
+	}
+	return false
+}

--- a/pkg/core/github_token_test.go
+++ b/pkg/core/github_token_test.go
@@ -142,6 +142,26 @@ func TestNewGitHubClient_NoTokenSendsNoAuthHeader(t *testing.T) {
 }
 
 func TestIsGitHubRateLimitError(t *testing.T) {
+	errResp429 := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}},
+		Message:  "rate limit",
+	}
+	errResp403Exhausted := &github.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{"X-Ratelimit-Remaining": []string{"0"}},
+		},
+		Message: "rate limit",
+	}
+	errResp403Other := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{}},
+		Message:  "forbidden for some other reason",
+	}
+	errResp404 := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound, Header: http.Header{}},
+		Message:  "not found",
+	}
+
 	tests := []struct {
 		name string
 		err  error
@@ -154,6 +174,10 @@ func TestIsGitHubRateLimitError(t *testing.T) {
 		{name: "RateLimitError", err: &github.RateLimitError{Message: "rate limit"}, want: true},
 		{name: "wrapped RateLimitError", err: fmt.Errorf("context: %w", &github.RateLimitError{Message: "rate limit"}), want: true},
 		{name: "AbuseRateLimitError", err: &github.AbuseRateLimitError{Message: "abuse"}, want: true},
+		{name: "ErrorResponse 429", err: errResp429, want: true},
+		{name: "ErrorResponse 403 with X-RateLimit-Remaining: 0", err: errResp403Exhausted, want: true},
+		{name: "ErrorResponse 403 unrelated", err: errResp403Other, want: false},
+		{name: "ErrorResponse 404", err: errResp404, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/core/github_token_test.go
+++ b/pkg/core/github_token_test.go
@@ -1,0 +1,165 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v68/github"
+)
+
+func TestResolveGitHubToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		override   string
+		env        map[string]string
+		wantToken  string
+		wantSource string
+	}{
+		{
+			name:       "override beats every env var",
+			override:   "flag-token",
+			env:        map[string]string{"SISAKULINT_GITHUB_TOKEN": "sisaku", "GITHUB_TOKEN": "ci", "GH_TOKEN": "gh"},
+			wantToken:  "flag-token",
+			wantSource: "-github-token",
+		},
+		{
+			name:       "SISAKULINT_GITHUB_TOKEN preferred over GITHUB_TOKEN and GH_TOKEN",
+			env:        map[string]string{"SISAKULINT_GITHUB_TOKEN": "sisaku", "GITHUB_TOKEN": "ci", "GH_TOKEN": "gh"},
+			wantToken:  "sisaku",
+			wantSource: "SISAKULINT_GITHUB_TOKEN",
+		},
+		{
+			name:       "GITHUB_TOKEN preferred over GH_TOKEN",
+			env:        map[string]string{"GITHUB_TOKEN": "ci", "GH_TOKEN": "gh"},
+			wantToken:  "ci",
+			wantSource: "GITHUB_TOKEN",
+		},
+		{
+			name:       "GH_TOKEN used when only one set",
+			env:        map[string]string{"GH_TOKEN": "gh"},
+			wantToken:  "gh",
+			wantSource: "GH_TOKEN",
+		},
+		{
+			name:       "empty env value treated as unset (skip to next)",
+			env:        map[string]string{"SISAKULINT_GITHUB_TOKEN": "", "GITHUB_TOKEN": "ci"},
+			wantToken:  "ci",
+			wantSource: "GITHUB_TOKEN",
+		},
+		{
+			name:       "no token anywhere returns empty source",
+			wantToken:  "",
+			wantSource: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookup := func(key string) (string, bool) {
+				v, ok := tt.env[key]
+				return v, ok
+			}
+			gotToken, gotSource := ResolveGitHubToken(tt.override, lookup)
+			if gotToken != tt.wantToken {
+				t.Errorf("token = %q, want %q", gotToken, tt.wantToken)
+			}
+			if gotSource != tt.wantSource {
+				t.Errorf("source = %q, want %q", gotSource, tt.wantSource)
+			}
+		})
+	}
+}
+
+// TestResolveGitHubToken_DefaultLookupUsesProcessEnv verifies that passing a
+// nil lookup falls back to os.LookupEnv. We assert by setting a per-test env
+// var; the t.Setenv call also restores the prior value on teardown.
+func TestResolveGitHubToken_DefaultLookupUsesProcessEnv(t *testing.T) {
+	t.Setenv("SISAKULINT_GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "from-process")
+	got, source := ResolveGitHubToken("", nil)
+	if got != "from-process" {
+		t.Errorf("token = %q, want %q", got, "from-process")
+	}
+	if source != "GITHUB_TOKEN" {
+		t.Errorf("source = %q, want %q", source, "GITHUB_TOKEN")
+	}
+}
+
+func TestNewGitHubClient_AttachesAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(context.Background(), "secret-token")
+	baseURL, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = baseURL
+
+	req, err := client.NewRequest(http.MethodGet, "rate_limit", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if _, err := client.Do(context.Background(), req, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if gotAuth != "Bearer secret-token" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer secret-token")
+	}
+}
+
+func TestNewGitHubClient_NoTokenSendsNoAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(context.Background(), "")
+	baseURL, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = baseURL
+
+	req, err := client.NewRequest(http.MethodGet, "rate_limit", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if _, err := client.Do(context.Background(), req, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header, got %q", gotAuth)
+	}
+}
+
+func TestIsGitHubRateLimitError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "sentinel", err: ErrGitHubRateLimit, want: true},
+		{name: "wrapped sentinel", err: fmt.Errorf("context: %w", ErrGitHubRateLimit), want: true},
+		{name: "RateLimitError", err: &github.RateLimitError{Message: "rate limit"}, want: true},
+		{name: "wrapped RateLimitError", err: fmt.Errorf("context: %w", &github.RateLimitError{Message: "rate limit"}), want: true},
+		{name: "AbuseRateLimitError", err: &github.AbuseRateLimitError{Message: "abuse"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGitHubRateLimitError(tt.err); got != tt.want {
+				t.Errorf("IsGitHubRateLimitError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -113,6 +113,8 @@ type Linter struct {
 	isRemote bool
 	// enabledOptInRules は、有効化されたオプトインルール名のリスト。
 	enabledOptInRules []string
+	// gitHubToken は commit-sha 自動修正で GitHub API に提示するトークン (issue #474)。
+	// 空文字なら未認証 60 req/h 制限が適用される。
 	gitHubToken string
 }
 

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -80,11 +80,8 @@ type LinterOptions struct {
 	// EnabledOptInRules は、CLI -enable-rule で指定された
 	// オプトインルール名のリスト。空の場合、opt-in なルールはすべて無効。
 	EnabledOptInRules []string
-	// GitHubToken は、commit-sha 自動修正で uses: 参照を SHA に解決する際に
-	// GitHub API へ提示するアクセストークン。空文字の場合は未認証で 60 req/h
-	// 制限が適用され、中規模以上のリポジトリで -fix on が途中で打ち切られる
-	// (issue #474)。command 層が SISAKULINT_GITHUB_TOKEN / GITHUB_TOKEN /
-	// GH_TOKEN / -github-token から優先順に解決して設定する。
+	// GitHubToken は commit-sha 自動修正で GitHub API に提示するトークン
+	// (issue #474)。空文字なら未認証 60 req/h 制限が適用される。
 	GitHubToken string
 }
 
@@ -116,7 +113,6 @@ type Linter struct {
 	isRemote bool
 	// enabledOptInRules は、有効化されたオプトインルール名のリスト。
 	enabledOptInRules []string
-	// gitHubToken は commit-sha 自動修正用の GitHub API トークン (issue #474)。
 	gitHubToken string
 }
 

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -80,6 +80,12 @@ type LinterOptions struct {
 	// EnabledOptInRules は、CLI -enable-rule で指定された
 	// オプトインルール名のリスト。空の場合、opt-in なルールはすべて無効。
 	EnabledOptInRules []string
+	// GitHubToken は、commit-sha 自動修正で uses: 参照を SHA に解決する際に
+	// GitHub API へ提示するアクセストークン。空文字の場合は未認証で 60 req/h
+	// 制限が適用され、中規模以上のリポジトリで -fix on が途中で打ち切られる
+	// (issue #474)。command 層が SISAKULINT_GITHUB_TOKEN / GITHUB_TOKEN /
+	// GH_TOKEN / -github-token から優先順に解決して設定する。
+	GitHubToken string
 }
 
 // Linterは、workflowをlintするための構造体
@@ -110,6 +116,8 @@ type Linter struct {
 	isRemote bool
 	// enabledOptInRules は、有効化されたオプトインルール名のリスト。
 	enabledOptInRules []string
+	// gitHubToken は commit-sha 自動修正用の GitHub API トークン (issue #474)。
+	gitHubToken string
 }
 
 // NewLinterは新しいLinterインスタンスを作成する
@@ -200,6 +208,7 @@ func NewLinter(errorOutput io.Writer, options *LinterOptions) (*Linter, error) {
 		modifyCheckRules:         options.OnCheckRulesModified,
 		isRemote:                 options.IsRemote,
 		enabledOptInRules:        options.EnabledOptInRules,
+		gitHubToken:              options.GitHubToken,
 	}, nil
 }
 
@@ -540,7 +549,7 @@ func (l *Linter) Lint(filepath string, content []byte, project *Project) (*Valid
 	return result, nil
 }
 
-func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadataCache, localReusableWorkflow *LocalReusableWorkflowCache) []Rule {
+func makeRules(filePath string, isRemote bool, gitHubToken string, localActions *LocalActionsMetadataCache, localReusableWorkflow *LocalReusableWorkflowCache) []Rule {
 	// WorkflowTaintMap is shared between Critical and Medium variants of
 	// CodeInjection, EnvVarInjection, ArgumentInjection, and RequestForgery rules
 	// to enable cross-job taint propagation tracking via needs.*.outputs.*
@@ -573,7 +582,7 @@ func makeRules(filePath string, isRemote bool, localActions *LocalActionsMetadat
 		EnvPathInjectionMediumRule(),            // Detects PATH injection in normal workflow triggers
 		OutputClobberingCriticalRule(),          // Detects output clobbering in privileged workflow triggers
 		OutputClobberingMediumRule(),            // Detects output clobbering in normal workflow triggers
-		CommitShaRule(),
+		CommitShaRule(gitHubToken),
 		NewDependabotGitHubActionsRule(filePath, isRemote), // Checks dependabot.yaml has github-actions ecosystem when unpinned actions found
 		ArtifactPoisoningRule(),
 		NewArtifactPoisoningMediumRule(),
@@ -676,7 +685,7 @@ func (l *Linter) validate(
 	// dependabot config / composite action / unparseable workflow would
 	// silently skip the rule-name check and the user's CLI typo would not
 	// be reported until a parseable workflow happened to reach validate().
-	rules := makeRules(filePath, l.isRemote, localActions, localReusableWorkflow)
+	rules := makeRules(filePath, l.isRemote, l.gitHubToken, localActions, localReusableWorkflow)
 	filteredRules, optErr := applyOptInRules(rules, l.enabledOptInRules)
 	if optErr != nil {
 		return nil, optErr


### PR DESCRIPTION
Closes #474.

## Problem

`sisakulint -fix on` constructs an unauthenticated GitHub client via `github.NewClient(http.DefaultClient)` in `pkg/core/commitsha.go`. That client is capped at the 60 req/h anonymous limit, so a workflow with more than ~60 pinnable actions silently truncates: the CLI reports success, the file is partially rewritten, and remaining `@vN` tags stay unpinned with no error. Re-running after the hourly reset eventually finishes — fragile and silent.

`GITHUB_TOKEN` / `GH_TOKEN` in the environment had no effect because the client never read them.

## Change

### 1. Token resolution (priority order)

| Source                       | Notes                                                       |
|------------------------------|-------------------------------------------------------------|
| `-github-token <token>`      | Explicit CLI flag, highest priority                          |
| `SISAKULINT_GITHUB_TOKEN`    | Tool-scoped override beats ambient CI/dev tokens             |
| `GITHUB_TOKEN`               | Populated automatically inside GitHub Actions                |
| `GH_TOKEN`                   | Populated by `gh auth login` (gh CLI convention)             |

Resolved at command startup in `Main`; wired into `LinterOptions.GitHubToken`, then `Linter.gitHubToken`, then `makeRules(... gitHubToken, ...)` → `CommitShaRule(token)`. The rule lazily builds the GitHub client with `oauth2.StaticTokenSource` (already in the dependency closure via `google/go-github`), so non-fix runs and the unauthenticated fallback remain side-effect free.

### 2. Surface the rate-limit state

A new sentinel `ErrGitHubRateLimit` is wrapped around 403/429 responses (detected via `*github.RateLimitError` and `*github.AbuseRateLimitError`). When `runAutofix` sees that wrapper it:

- **Skips writing the affected file.** Otherwise the disk would hold a mix of SHA-pinned and `@vN` entries with no signal which is which.
- **Returns the rate-limit flag up the stack** so `Main` exits with `ExitStatusFailure` (3) and CI can react.

Non-rate-limit failures (404, malformed ref, etc.) still flow through the existing `*LintingError` path — they only suppress that single fixer, not the file write.

### 3. Soft warnings

- At the top of any `-fix on/dry-run` run with no token, sisakulint prints a one-line warning citing the 60 req/h ceiling and the four sources the resolver checks.
- In `-verbose` mode it logs the resolved source name (`-github-token`, `GITHUB_TOKEN`, …).

## Tests

`pkg/core/github_token_test.go` (new):
- `TestResolveGitHubToken` — full table of priority/fallback cases, including empty env values and a no-token negative.
- `TestResolveGitHubToken_DefaultLookupUsesProcessEnv` — verifies `nil` lookup falls back to `os.LookupEnv`.
- `TestNewGitHubClient_AttachesAuthorizationHeader` / `TestNewGitHubClient_NoTokenSendsNoAuthHeader` — assert the OAuth2 round-tripper attaches `Authorization: Bearer <token>` only when a token is set, using a real `httptest.Server`.
- `TestIsGitHubRateLimitError` — classification table covering sentinel, wrapped sentinel, typed `*github.RateLimitError`, wrapped typed error, and `*github.AbuseRateLimitError`.

`pkg/core/commitsha_test.go` (extended):
- `TestCommitSha_FixStep_RateLimit` — drives FixStep against an httptest server returning `403 + X-RateLimit-Remaining: 0`. Asserts `errors.Is(err, ErrGitHubRateLimit)`, `IsGitHubRateLimitError(err) == true`, the wrapped `*LintingError` is still recoverable via `errors.As`, and the description hints at `GITHUB_TOKEN`.
- `TestCommitSha_FixStep_NonRateLimitError` — 404 path remains a plain `*LintingError`, must not classify as a rate-limit failure (otherwise `runAutofix` would regress and skip writes for unrelated lookup failures).
- All existing tests updated to the new `CommitShaRule("")` signature.

`go test ./...` passes locally.

## Compatibility

- No behavioural change when a token is present (existing happy path).
- No behavioural change when both no token *and* no rate limit (still works exactly as today).
- Behavioural change is limited to: a soft warning line on stderr, plus a non-zero exit and skipped write when the rate limit fires — which is the documented goal of the issue.

## Out of scope (follow-ups)

- Forwarding `${{ github.token }}` from `sisakulint-action` (tracked on the action repo per the issue).
- Token-scope guidance beyond the README note (a fine-grained PAT with `public_repo`, or `Metadata: Read-only` on the targeted repos, is sufficient).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * `-github-token` フラグとトークン解決を追加。トークン指定により認証付きAPI呼び出しが可能に。

* **Bug Fixes**
  * GitHub APIのレート制限発生時は該当ファイルの書き込みをスキップし、処理を中断して非ゼロ終了を返すように変更。

* **Documentation**
  * README/CLAUDE にトークン優先順、指定例、未指定時の警告とレート制限時の動作（部分出力を行わない旨）を追記。

* **Tests**
  * トークン解決・認証ヘッダ付与・レート制限判定・CommitShaのレート制限挙動を検証するテストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->