### PR TITLE
ci: add OSSF Scorecard workflow

### DIFF
--- a/.github/sisakulint.yaml
+++ b/.github/sisakulint.yaml
@@ -10,6 +10,8 @@ action-list:
   - github/codeql-action/analyze@*
   - github/codeql-action/autobuild@*
   - github/codeql-action/init@*
+  - github/codeql-action/upload-sarif@*
   - goreleaser/goreleaser-action@*
+  - ossf/scorecard-action@*
   - reviewdog/action-setup@*
   - actions/*

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "23 5 * * 6"
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/scorecard.yml` running OSSF Scorecard on a weekly schedule and on push to `main`, uploading SARIF to the GitHub code-scanning tab.
- Pins `ossf/scorecard-action@v2.4.3`, `actions/upload-artifact@v7.0.1`, and `github/codeql-action/upload-sarif@v3` by full commit SHA; checkout reuses the existing project pin.
- Adds the two new action names to `.github/sisakulint.yaml` so the `action-list` rule keeps passing.

## Test plan
- [x] `go build ./cmd/sisakulint && sisakulint .github/workflows/scorecard.yml` → exit 0
- [ ] After merge, confirm the first scheduled run uploads results to the Security tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プロジェクトのセキュリティスキャンインフラストラクチャを強化しました。OSSF Scorecard による定期的なセキュリティ評価と、Code QL を使用した静的解析が自動実行されるようになります。スキャン結果は security 機能を通じて追跡・管理されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->