### PR TITLE
Unify known vulnerable action GitHub token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,10 +231,16 @@ sisakulint -boilerplate
 # Enable an opt-in rule (currently available: missing-timeout-minutes)
 sisakulint -enable-rule missing-timeout-minutes
 
-# Authenticate the commit-sha resolver (issue #474). Priority order:
+# Authenticate the GitHub API rules (issues #474 and #484). Priority order:
 # -github-token > SISAKULINT_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN.
-# Without a token, `-fix on` warns up-front and exits non-zero (skipping
-# partial writes) if the unauthenticated 60 req/h limit is hit.
+# Used by both the commit-sha autofix and the known-vulnerable-actions rule
+# (advisory lookups). Without a token, sisakulint prints an up-front warning
+# at lint start, `-fix on` exits non-zero (skipping partial writes) if the
+# unauthenticated 60 req/h limit is hit during commit-sha resolution, and
+# advisory lookups for the known-vulnerable-actions rule are silently
+# skipped beyond that limit (per-run, with one debug line).
+# `gh auth token` / `git credential fill` are no longer probed implicitly;
+# pass the token via env or -github-token explicitly (issue #484).
 # Prefer env-based auth so the token does not appear in process args (ps).
 GITHUB_TOKEN=$(gh auth token) sisakulint -fix on
 # CLI flag form (highest priority; visible in `ps`, prefer env for shared hosts).

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -276,15 +276,6 @@ func (cmd *Command) Main(args []string) int {
 	token, source := ResolveGitHubToken(githubTokenFlag, nil)
 	linterOpts.GitHubToken = token
 	enableAutofix := autoFixMode == "on" || autoFixMode == FileFixDryRun
-	if enableAutofix {
-		if token == "" {
-			fmt.Fprintln(cmd.Stderr,
-				"sisakulint: no GitHub token detected; commit-sha resolution limited to 60 req/h. "+
-					"Set GITHUB_TOKEN, GH_TOKEN, SISAKULINT_GITHUB_TOKEN, or pass -github-token to lift the limit.")
-		} else if linterOpts.IsVerboseOutputEnabled {
-			fmt.Fprintf(cmd.Stderr, "sisakulint: using GitHub token from %s for commit-sha resolution.\n", source)
-		}
-	}
 
 	if generateActionList {
 		if err := GenerateActionListConfig("."); err != nil {
@@ -292,6 +283,14 @@ func (cmd *Command) Main(args []string) int {
 			return ExitStatusFailure
 		}
 		return ExitStatusSuccessNoProblem
+	}
+
+	if token == "" {
+		fmt.Fprintln(cmd.Stderr,
+			"sisakulint: no GitHub token detected; GitHub API checks (known-vulnerable-actions, commit-sha autofix) limited to 60 req/h. "+
+				"Set GITHUB_TOKEN, GH_TOKEN, SISAKULINT_GITHUB_TOKEN, or pass -github-token to lift the limit.")
+	} else if linterOpts.IsVerboseOutputEnabled {
+		fmt.Fprintf(cmd.Stderr, "sisakulint: using GitHub token from %s for GitHub API checks.\n", source)
 	}
 
 	if remoteInput != "" {

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -239,9 +239,9 @@ func (cmd *Command) Main(args []string) int {
 	flags.IntVar(&parallelism, "p", 3, "Number of parallel scans (-remote only)")
 	flags.IntVar(&limit, "l", 30, "Max repositories for search queries (-remote only)")
 	flags.StringVar(&githubTokenFlag, "github-token", "",
-		"GitHub API token used by -fix on/-fix dry-run to resolve commit SHAs. "+
+		"GitHub API token used by rules that call the GitHub API, including commit-sha autofix and known-vulnerable-actions. "+
 			"Falls back to SISAKULINT_GITHUB_TOKEN, GITHUB_TOKEN, then GH_TOKEN. "+
-			"Without a token, unauthenticated requests are limited to 60 req/h and may interrupt commit-sha autofix (issue #474)")
+			"Without a token, unauthenticated requests are limited to 60 req/h and may interrupt GitHub API checks")
 
 	flags.Usage = func() {
 		printingUsageHeader(cmd.Stderr)

--- a/pkg/core/known_vulnerable_actions.go
+++ b/pkg/core/known_vulnerable_actions.go
@@ -3,12 +3,10 @@ package core
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/google/go-github/v68/github"
 	"github.com/sisaku-security/sisakulint/pkg/ast"
@@ -21,6 +19,7 @@ import (
 // line per file. Keyed by an arbitrary string built from (owner, repo, ref,
 // version) so callers don't accidentally collide across log types.
 var loggedKnownVulnLines sync.Map
+var knownVulnerableRateLimitReported atomic.Bool
 
 // VulnerabilityInfo holds information about a detected vulnerability
 type VulnerabilityInfo struct {
@@ -37,86 +36,51 @@ type KnownVulnerableActionsRule struct {
 	BaseRule
 	client        *github.Client
 	clientOnce    sync.Once
+	gitHubToken   string
 	advisoryCache map[string][]*VulnerabilityInfo
 	cacheMu       sync.RWMutex
 }
 
 // NewKnownVulnerableActionsRule creates a new instance of KnownVulnerableActionsRule
-func NewKnownVulnerableActionsRule() *KnownVulnerableActionsRule {
+func NewKnownVulnerableActionsRule(gitHubToken ...string) *KnownVulnerableActionsRule {
+	var token string
+	if len(gitHubToken) > 0 {
+		token = gitHubToken[0]
+	}
 	return &KnownVulnerableActionsRule{
 		BaseRule: BaseRule{
 			RuleName: "known-vulnerable-actions",
 			RuleDesc: "Detects GitHub Actions with known security vulnerabilities using GitHub Security Advisories database.",
 		},
+		gitHubToken:   token,
 		advisoryCache: make(map[string][]*VulnerabilityInfo),
 	}
 }
 
-// getGitHubToken retrieves authentication token using a fallback chain
-// Priority: environment variable → gh CLI → git credential
-func getGitHubToken() string {
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		return token
-	}
-	if token := os.Getenv("GH_TOKEN"); token != "" {
-		return token
-	}
-	if token, err := getTokenFromGhCLI(); err == nil && token != "" {
-		return token
-	}
-	if token, err := getTokenFromGitCredential(); err == nil && token != "" {
-		return token
-	}
-	return ""
-}
-
-func getTokenFromGhCLI() (string, error) {
-	cmd := exec.CommandContext(context.Background(), "gh", "auth", "token")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(output)), nil
-}
-
-func getTokenFromGitCredential() (string, error) {
-	cmd := exec.CommandContext(context.Background(), "git", "credential", "fill")
-	cmd.Stdin = strings.NewReader("protocol=https\nhost=github.com\n")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	for _, line := range strings.Split(string(output), "\n") {
-		if strings.HasPrefix(line, "password=") {
-			return strings.TrimPrefix(line, "password="), nil
-		}
-	}
-	return "", fmt.Errorf("credential not found")
-}
-
-// tokenTransport is a Transport that adds token to GitHub API requests
-type tokenTransport struct {
-	token string
-}
-
-func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	clonedReq := req.Clone(req.Context())
-	clonedReq.Header.Set("Authorization", "Bearer "+t.token)
-	return http.DefaultTransport.RoundTrip(clonedReq)
+func getKnownVulnerableActionsGitHubToken(override string) string {
+	token, _ := ResolveGitHubToken(override, nil)
+	return token
 }
 
 // getClient initializes the GitHub client with authentication
 func (rule *KnownVulnerableActionsRule) getClient() *github.Client {
 	rule.clientOnce.Do(func() {
-		var httpClient *http.Client
-		if token := getGitHubToken(); token != "" {
-			httpClient = &http.Client{
-				Transport: &tokenTransport{token: token},
-			}
-		}
-		rule.client = github.NewClient(httpClient)
+		token := getKnownVulnerableActionsGitHubToken(rule.gitHubToken)
+		rule.client = NewGitHubClient(context.Background(), token)
 	})
 	return rule.client
+}
+
+func (rule *KnownVulnerableActionsRule) debugGitHubAPIError(format string, args ...interface{}) {
+	if len(args) > 0 {
+		if err, ok := args[len(args)-1].(error); ok && IsGitHubRateLimitError(err) {
+			if knownVulnerableRateLimitReported.CompareAndSwap(false, true) {
+				rule.Debug("GitHub API rate limit exceeded; skipping known vulnerable action checks for the rest of this run")
+			}
+			return
+		}
+	}
+	rule.Debug(format, args...)
 }
 
 // parseActionRef parses an action reference like "owner/repo@ref" or "owner/repo/path@ref"
@@ -484,7 +448,7 @@ func (rule *KnownVulnerableActionsRule) VisitStep(step *ast.Step) error {
 	if err != nil {
 		// Log as debug and skip (similar to commitsha.go pattern)
 		// This can happen for private repos, rate limiting, network errors, etc.
-		rule.Debug("failed to resolve version for %s/%s@%s: %v", owner, repo, ref, err)
+		rule.debugGitHubAPIError("failed to resolve version for %s/%s@%s: %v", owner, repo, ref, err)
 		return nil
 	}
 
@@ -498,7 +462,7 @@ func (rule *KnownVulnerableActionsRule) VisitStep(step *ast.Step) error {
 	if err != nil {
 		// Log as debug and skip (similar to commitsha.go pattern)
 		// This can happen for rate limiting, network errors, etc.
-		rule.Debug("failed to fetch advisories for %s/%s: %v", owner, repo, err)
+		rule.debugGitHubAPIError("failed to fetch advisories for %s/%s: %v", owner, repo, err)
 		return nil
 	}
 

--- a/pkg/core/known_vulnerable_actions.go
+++ b/pkg/core/known_vulnerable_actions.go
@@ -21,6 +21,21 @@ import (
 var loggedKnownVulnLines sync.Map
 var knownVulnerableRateLimitReported atomic.Bool
 
+// resetKnownVulnerableActionsRunState clears the package-global dedupe state
+// used by KnownVulnerableActionsRule. Callers must invoke this at the start
+// of each public Lint entry so that library users with repeated Lint() calls
+// in one process keep seeing per-run diagnostics — without a reset, a single
+// rate-limit hit suppresses the warning for the remaining lifetime of the
+// process (and `loggedKnownVulnLines` suppresses every action it has already
+// resolved). Tests rely on the same reset to isolate runs.
+func resetKnownVulnerableActionsRunState() {
+	knownVulnerableRateLimitReported.Store(false)
+	loggedKnownVulnLines.Range(func(key, _ any) bool {
+		loggedKnownVulnLines.Delete(key)
+		return true
+	})
+}
+
 // VulnerabilityInfo holds information about a detected vulnerability
 type VulnerabilityInfo struct {
 	GHSAID              string

--- a/pkg/core/known_vulnerable_actions_test.go
+++ b/pkg/core/known_vulnerable_actions_test.go
@@ -128,6 +128,39 @@ func TestKnownVulnerableActionsRuleClassifiesRateLimitErrors(t *testing.T) {
 	}
 }
 
+func TestResetKnownVulnerableActionsRunStateClearsDedupeAcrossRuns(t *testing.T) {
+	t.Cleanup(func() {
+		knownVulnerableRateLimitReported.Store(false)
+		loggedKnownVulnLines.Range(func(key, _ any) bool {
+			loggedKnownVulnLines.Delete(key)
+			return true
+		})
+	})
+
+	knownVulnerableRateLimitReported.Store(true)
+	loggedKnownVulnLines.Store("resolve:owner/repo@v1->v1", struct{}{})
+
+	resetKnownVulnerableActionsRunState()
+
+	if knownVulnerableRateLimitReported.Load() {
+		t.Fatal("knownVulnerableRateLimitReported should be reset to false")
+	}
+	if _, ok := loggedKnownVulnLines.Load("resolve:owner/repo@v1->v1"); ok {
+		t.Fatal("loggedKnownVulnLines should be cleared after reset")
+	}
+
+	// Simulate a second run: the rate-limit diagnostic must fire again
+	// instead of being suppressed by the previous run's state.
+	var buf bytes.Buffer
+	rule := NewKnownVulnerableActionsRule()
+	rule.EnableDebugOutput(&buf)
+	rule.debugGitHubAPIError("failed to fetch advisories for actions/checkout", fmt.Errorf("wrapped: %w", ErrGitHubRateLimit))
+
+	if !strings.Contains(buf.String(), "GitHub API rate limit exceeded") {
+		t.Fatalf("after reset, expected rate-limit diagnostic in second run, got %q", buf.String())
+	}
+}
+
 func TestParseActionRef(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/core/known_vulnerable_actions_test.go
+++ b/pkg/core/known_vulnerable_actions_test.go
@@ -1,6 +1,13 @@
 package core
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -12,6 +19,112 @@ func TestNewKnownVulnerableActionsRule(t *testing.T) {
 	}
 	if rule.RuleDesc == "" {
 		t.Error("RuleDesc should not be empty")
+	}
+}
+
+func TestKnownVulnerableActionsRuleUsesUnifiedGitHubTokenResolution(t *testing.T) {
+	t.Setenv("SISAKULINT_GITHUB_TOKEN", "sisaku-token")
+	t.Setenv("GITHUB_TOKEN", "ci-token")
+	t.Setenv("GH_TOKEN", "gh-token")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	rule := NewKnownVulnerableActionsRule()
+	client := rule.getClient()
+	baseURL, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	client.BaseURL = baseURL
+
+	req, err := client.NewRequest(http.MethodGet, "rate_limit", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if _, err := client.Do(context.Background(), req, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if gotAuth != "Bearer sisaku-token" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer sisaku-token")
+	}
+}
+
+func TestKnownVulnerableActionsRuleExplicitTokenOverridesEnvironment(t *testing.T) {
+	t.Setenv("SISAKULINT_GITHUB_TOKEN", "sisaku-token")
+	t.Setenv("GITHUB_TOKEN", "ci-token")
+	t.Setenv("GH_TOKEN", "gh-token")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	rule := NewKnownVulnerableActionsRule("flag-token")
+	client := rule.getClient()
+	baseURL, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	client.BaseURL = baseURL
+
+	req, err := client.NewRequest(http.MethodGet, "rate_limit", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if _, err := client.Do(context.Background(), req, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if gotAuth != "Bearer flag-token" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer flag-token")
+	}
+}
+
+func TestMakeRulesPassesGitHubTokenToKnownVulnerableActionsRule(t *testing.T) {
+	rules := makeRules(".github/workflows/ci.yml", false, "flag-token", nil, nil)
+
+	for _, rule := range rules {
+		known, ok := rule.(*KnownVulnerableActionsRule)
+		if !ok {
+			continue
+		}
+		if known.gitHubToken != "flag-token" {
+			t.Fatalf("KnownVulnerableActionsRule gitHubToken = %q, want %q", known.gitHubToken, "flag-token")
+		}
+		return
+	}
+
+	t.Fatal("KnownVulnerableActionsRule not found in makeRules output")
+}
+
+func TestKnownVulnerableActionsRuleClassifiesRateLimitErrors(t *testing.T) {
+	knownVulnerableRateLimitReported.Store(false)
+	t.Cleanup(func() {
+		knownVulnerableRateLimitReported.Store(false)
+	})
+
+	var buf bytes.Buffer
+	rule := NewKnownVulnerableActionsRule()
+	rule.EnableDebugOutput(&buf)
+
+	rule.debugGitHubAPIError("failed to fetch advisories for actions/checkout", fmt.Errorf("wrapped: %w", ErrGitHubRateLimit))
+
+	got := buf.String()
+	if !strings.Contains(got, "GitHub API rate limit exceeded") {
+		t.Fatalf("debug output = %q, want rate-limit message", got)
+	}
+	if strings.Contains(got, "failed to fetch advisories") {
+		t.Fatalf("debug output = %q, should not use generic error message for rate limits", got)
 	}
 }
 

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -359,6 +359,8 @@ func (l *Linter) LintFiles(filepaths []string, project *Project) ([]*ValidateRes
 		return []*ValidateResult{result}, nil
 	}
 
+	resetKnownVulnerableActionsRunState()
+
 	l.log("getting started linting", fileCount, pluralize(fileCount, "workflow file...", "workflow files..."))
 
 	currentDir := l.currentWorkingDirectory
@@ -479,6 +481,8 @@ func (l *Linter) LintFiles(filepaths []string, project *Project) ([]*ValidateRes
 // LintFileは、指定されたyaml workflowをlintしてエラーを返す
 // projectパラメタはnilにできる。その場合、ファイルパスからプロジェクトが検出される
 func (l *Linter) LintFile(file string, project *Project) (*ValidateResult, error) {
+	resetKnownVulnerableActionsRunState()
+
 	if project == nil {
 		pa, err := l.projectInformation.GetProjectForPath(file)
 		if err != nil {
@@ -535,6 +539,8 @@ func (l *Linter) LintFile(file string, project *Project) (*ValidateResult, error
 // pathパラメタに<stdin>を入力すると出力がSTDINから来たことを示す
 // projectパラメタはnilにできる。その場合、ファイルパスからプロジェクトが検出される
 func (l *Linter) Lint(filepath string, content []byte, project *Project) (*ValidateResult, error) {
+	resetKnownVulnerableActionsRunState()
+
 	if project == nil && filepath != "<stdin>" {
 		if _, err := os.Stat(filepath); !errors.Is(err, fs.ErrNotExist) {
 			p, err := l.projectInformation.GetProjectForPath(filepath)

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -81,8 +81,8 @@ type LinterOptions struct {
 	// EnabledOptInRules は、CLI -enable-rule で指定された
 	// オプトインルール名のリスト。空の場合、opt-in なルールはすべて無効。
 	EnabledOptInRules []string
-	// GitHubToken は commit-sha 自動修正で GitHub API に提示するトークン
-	// (issue #474)。空文字なら未認証 60 req/h 制限が適用される。
+	// GitHubToken は GitHub API を呼ぶルールに提示するトークン。
+	// 空文字なら未認証 60 req/h 制限が適用される。
 	GitHubToken string
 }
 
@@ -114,7 +114,7 @@ type Linter struct {
 	isRemote bool
 	// enabledOptInRules は、有効化されたオプトインルール名のリスト。
 	enabledOptInRules []string
-	// gitHubToken は commit-sha 自動修正で GitHub API に提示するトークン (issue #474)。
+	// gitHubToken は GitHub API を呼ぶルールに提示するトークン。
 	// 空文字なら未認証 60 req/h 制限が適用される。
 	gitHubToken string
 	// loggedConfigs は、`setting configuration: ...` をすでに出力済みの *Config を
@@ -620,7 +620,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 		NewUntrustedCheckoutTOCTOUHighRule(),                          // Detects TOCTOU with deployment environment and mutable refs
 		NewRefConfusionRule(),                                         // Detects ref confusion attacks (same name branch and tag)
 		NewObfuscationRule(),                                          // Detects obfuscated workflow patterns
-		NewKnownVulnerableActionsRule(),                               // Detects actions with known security vulnerabilities
+		NewKnownVulnerableActionsRule(gitHubToken),                    // Detects actions with known security vulnerabilities
 		NewBotConditionsRule(),                                        // Detects spoofable bot detection conditions
 		NewArtipackedRule(),                                           // Detects credential leakage via artifact upload
 		NewUnsoundContainsRule(),                                      // Detects bypassable contains() function usage in conditions


### PR DESCRIPTION
## Summary

- Route `KnownVulnerableActionsRule` through the shared GitHub token resolver and client helper.
- Pass the CLI-resolved GitHub token from `makeRules()` into `known-vulnerable-actions`, so `-github-token` and `SISAKULINT_GITHUB_TOKEN` now apply consistently.
- Reuse common GitHub rate-limit classification for known-vulnerable action API failures.
- Update the `-github-token` help text so it is no longer described as commit-sha-only.

## Why

Issue #484 identified that `KnownVulnerableActionsRule` had its own token lookup chain (`GITHUB_TOKEN`, `GH_TOKEN`, `gh auth token`, `git credential fill`) while `CommitShaRule` used the newer shared resolver. This meant `SISAKULINT_GITHUB_TOKEN` and `-github-token` were ignored for advisory lookups.

## Validation

- `go test ./pkg/core -run 'TestKnownVulnerableActionsRule|TestMakeRulesPassesGitHubTokenToKnownVulnerableActionsRule|TestResolveGitHubToken|TestNewGitHubClient|TestIsGitHubRateLimitError' -count=1 -v`
- `go test ./pkg/core`
- `go test ./...`
- `git diff --cached --check`

Refs #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * GitHub トークンパラメータのドキュメントを更新し、API チェックへの影響をより明確に説明しました

* **改善**
  * GitHub API レート制限エラーの処理を改善し、重複するエラーメッセージの出力を削減しました
  * GitHub トークン解決処理を統一し、一貫性のあるトークン処理を実現しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->