### PR TITLE
propagate secret taint through needs outputs

### DIFF
--- a/docs/secretinlogrule.md
+++ b/docs/secretinlogrule.md
@@ -76,14 +76,15 @@ Derived values flow through standard shell variable assignment and GitHub Action
 
 ### Detection Logic
 
-The rule performs taint propagation within a single `run` step, and additionally propagates
-taint across steps that belong to the same job via `$GITHUB_ENV`:
+The rule performs taint propagation within a single `run` step, across steps that
+belong to the same job via `$GITHUB_ENV` / `$GITHUB_OUTPUT`, and across jobs when a
+secret-derived job output is consumed through `needs.*.outputs.*`:
 
-1. **Taint sources** — environment variables whose value either (a) contains `${{ secrets.* }}` declared at workflow-level, job-level, or step-level `env`, or (b) is assigned a tainted `${{ steps.<id>.outputs.<name> }}` expression at step-level `env`. All five sources — workflow `env` / job `env` / cross-step `$GITHUB_ENV` propagation / step-level step-output-derived `env` / step-level secrets `env` — are merged in that order, with later entries overriding earlier ones on name conflict (so step-level entries always win).
+1. **Taint sources** — environment variables whose value either (a) contains `${{ secrets.* }}` declared at workflow-level, job-level, or step-level `env`, or (b) is assigned a tainted `${{ steps.<id>.outputs.<name> }}` or `${{ needs.<job>.outputs.<name> }}` expression at step-level `env`. All five sources — workflow `env` / job `env` / cross-step `$GITHUB_ENV` propagation / step-level output-derived `env` / step-level secrets `env` — are merged in that order, with later entries overriding earlier ones on name conflict (so step-level entries always win).
 2. **Taint propagation** — shell assignments that reference a tainted variable, including command substitutions (`VAR=$(cmd $TAINTED)`). Propagation is **order-aware**: a single forward pass records the byte offset of each assignment, and sinks that appear *before* the assignment are not flagged (avoids false positives on `a=1; echo $a; a=$SECRET`). Environment-sourced variables are treated as set before the script begins (offset `-1`) and always considered valid.
 3. **Shell function argument propagation** — when a shell function is called with tainted arguments, positional parameters (`$1`, `$2`, `$@`, `$*`) inside the function body inherit that taint. Composite words such as `"$TOKEN-$KEY"` keep all upstream variables, so a partial mask does not suppress an unmasked upstream value.
 4. **Cross-step propagation via `$GITHUB_ENV`** — if a tainted shell variable is written to `$GITHUB_ENV` (via `echo "NAME=$VAR" >> $GITHUB_ENV`, `echo "NAME=$VAR" > $GITHUB_ENV`, or `cat <<EOF >> $GITHUB_ENV ... EOF`), the environment variable `NAME` becomes tainted for subsequent steps in the same job.
-5. **Cross-step propagation via `$GITHUB_OUTPUT`** — if a tainted shell variable is written to `$GITHUB_OUTPUT` by a step with an `id`, the corresponding `${{ steps.<id>.outputs.<name> }}` expression is treated as secret-derived for subsequent steps in the same job. Direct `run:` interpolation into `echo` / `printf` is flagged, and assigning that expression to `env:` taints the shell variable used by the step. Cross-*job* propagation (`needs.*.outputs.*`) and reusable-workflow propagation are separate follow-up items.
+5. **Cross-step and cross-job propagation via `$GITHUB_OUTPUT`** — if a tainted shell variable is written to `$GITHUB_OUTPUT` by a step with an `id`, the corresponding `${{ steps.<id>.outputs.<name> }}` expression is treated as secret-derived for subsequent steps in the same job. If the job exposes that step output through `jobs.<job>.outputs`, downstream `${{ needs.<job>.outputs.<name> }}` expressions are also treated as secret-derived. Direct `run:` interpolation into `echo` / `printf` is flagged, and assigning either expression form to `env:` taints the shell variable used by the step. Reusable-workflow propagation remains a separate follow-up item.
 6. **Sink detection** — the following commands are treated as sinks when they reference a tainted variable without a preceding `::add-mask::` for that variable:
    - `echo` / `printf` with a tainted argument
    - `cat` / `tee` / `dd` receiving tainted data via here-string (`<<<`) or heredoc (`<<EOF ... EOF`)
@@ -96,8 +97,8 @@ taint across steps that belong to the same job via `$GITHUB_ENV`:
 The following patterns are intentionally excluded from detection because their output does not reach *the current step's* build log directly:
 
 - **Stdout redirected to a file** — `echo "$TOKEN" > secret.txt`, `echo "$TOKEN" 1> out.txt` etc. Redirects to `/dev/stderr`, `/dev/stdout`, `/dev/tty`, or `/dev/fd/{1,2}` are *not* excluded because they are still shown in the log.
-- **Stdout redirected to `$GITHUB_OUTPUT`** — the current step's log does not receive the value, so no warning is raised for the redirect itself. If a subsequent step (a) prints the resulting `${{ steps.<id>.outputs.<name> }}` value directly, or (b) assigns that expression to a step-level `env:` and prints the resulting shell variable, both downstream uses are reported.
-- **Direct `${{ secrets.X }}` expression written to `$GITHUB_OUTPUT`** — when a producer step has no env-derived shell taint and writes `${{ secrets.X }}` directly (e.g. `echo "token=${{ secrets.X }}" >> $GITHUB_OUTPUT`), no leak is reported for downstream `${{ steps.<id>.outputs.* }}` expansion. GitHub Actions auto-masks any occurrence of a `secrets.*` value across the entire run, so the same value is masked when the downstream step expands the step output. This rule only tracks shell-derived values whose auto-mask coverage is broken (jq / sed / base64 / etc.).
+- **Stdout redirected to `$GITHUB_OUTPUT`** — the current step's log does not receive the value, so no warning is raised for the redirect itself. If a subsequent step or downstream job (a) prints the resulting `${{ steps.<id>.outputs.<name> }}` / `${{ needs.<job>.outputs.<name> }}` value directly, or (b) assigns that expression to a step-level `env:` and prints the resulting shell variable, downstream uses are reported.
+- **Direct `${{ secrets.X }}` expression written to `$GITHUB_OUTPUT`** — when a producer step has no env-derived shell taint and writes `${{ secrets.X }}` directly (e.g. `echo "token=${{ secrets.X }}" >> $GITHUB_OUTPUT`), no leak is reported for downstream `${{ steps.<id>.outputs.* }}` or `${{ needs.<job>.outputs.* }}` expansion. GitHub Actions auto-masks any occurrence of a `secrets.*` value across the entire run, so the same value is masked when the downstream step expands the output. This rule only tracks shell-derived values whose auto-mask coverage is broken (jq / sed / base64 / etc.).
 - **`printf -v VAR ...`** — captures to a shell variable instead of printing.
 - **Inside command substitutions** — `VAR=$(echo "$SECRET")` does not leak because the inner stdout is captured by `$(...)`.
 
@@ -185,6 +186,35 @@ Writing to `$GITHUB_OUTPUT` does not print the value in the producing step, but 
 does not automatically mask the derived output when a later step expands
 `${{ steps.derive.outputs.token }}`. The rule tracks this same-job path.
 
+### Cross-job `$GITHUB_OUTPUT` example
+
+```yaml
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    env:
+      SECRET_JSON: ${{ secrets.SECRET_JSON }}
+    outputs:
+      token: ${{ steps.derive.outputs.token }}
+    steps:
+      - id: derive
+        run: |
+          TOKEN=$(echo "$SECRET_JSON" | jq -r '.token')
+          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: extract
+    steps:
+      - run: |
+          echo "got: ${{ needs.extract.outputs.token }}"   # flagged
+```
+
+When a job output forwards a secret-derived step output, the same derived value can
+reach later jobs through `needs.*.outputs.*`. The rule carries that taint across
+the job output boundary and reports direct prints or step-level `env:` assignments
+that are later printed.
+
 ### Shell function argument example
 
 ```yaml
@@ -207,15 +237,14 @@ The function body prints `$1`, but the rule traces `$1` back to both `TOKEN` and
 Masking only `TOKEN` is not enough; every upstream shell variable in the composite argument
 must be masked before the leak is suppressed.
 
-### Scope Limitations (MVP)
+### Scope Limitations
 
-- **Same-job scope only** — cross-step taint is tracked within a single job via `$GITHUB_ENV` and `$GITHUB_OUTPUT`. Taint does not cross *job* boundaries (`needs.*.outputs.*`); cross-job propagation is a planned follow-up (see #432).
+- **Cross-job output propagation depends on explicit job outputs** — the rule tracks values that flow from `steps.<id>.outputs.*` into `jobs.<job>.outputs` and then into `needs.<job>.outputs.*`. It does not infer arbitrary filesystem, artifact, cache, or service-container transfer between jobs.
 - **`logger` and pipe-consuming commands not yet covered** — `logger`, `xargs`, and similar sinks are not yet detected. Pipes (`cmd1 | cmd2`) flag the upstream source if it is `echo`/`printf`, but the downstream command is not individually analyzed.
 - **Reusable workflow boundaries** — taint does not cross `workflow_call` boundaries; that is a planned follow-up (see #433).
 - **Composite / JS / Docker action internals are not parsed** — only `run:` blocks in the analyzed workflow are inspected. Leaks inside a `uses:`-referenced action are invisible.
 - **Dynamic shell function dispatch is not resolved** — direct function calls are analyzed, but variable-driven calls such as `$cmd "$TOKEN"` are treated as statically unresolved.
 - **Shell trace mode, `eval` / `bash -c` strings, `trap` handlers, process substitution, env-dumping commands, and indirect expansion are not modeled** — see "Patterns the rule does not analyze at all" above.
-- **`$GITHUB_OUTPUT` tracking is same-job only** — writes to `$GITHUB_OUTPUT` are tracked for subsequent `steps.<id>.outputs.*` uses in the same job, but job outputs consumed through `needs.*.outputs.*` are not tracked yet.
 
 ### Related Rules
 

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -582,6 +582,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 	// CodeInjection, EnvVarInjection, ArgumentInjection, and RequestForgery rules
 	// to enable cross-job taint propagation tracking via needs.*.outputs.*
 	wfTaintMap := NewWorkflowTaintMap()
+	wfSecretTaintMap := NewWorkflowSecretTaintMap()
 	var debugOut io.Writer
 	if localActions != nil {
 		debugOut = localActions.dbg
@@ -635,7 +636,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 		NewUnpinnedImagesRule(),                                       // Detects container images not pinned by SHA256 digest
 		NewSecretsInArtifactsRule(),                                   // Detects secrets exposure in artifact uploads (CWE-312)
 		NewSecretExfiltrationRule(),                                   // Detects secret exfiltration via network commands
-		NewSecretInLogRule(),                                          // Detects secret values printed to build logs via echo/printf of derived shell vars (single-step scope; cross-job follow-up tracked separately)
+		NewSecretInLogRuleWithTaintMap(wfSecretTaintMap),              // Detects secret values printed to build logs via echo/printf of derived shell vars and secret-derived outputs
 		NewReusableWorkflowTaintRule(filePath, localReusableWorkflow), // Detects untrusted inputs passed to reusable workflows
 		NewDangerousTriggersCriticalRule(),                            // Detects dangerous triggers without any mitigations
 		NewDangerousTriggersMediumRule(),                              // Detects dangerous triggers with partial mitigations

--- a/pkg/core/secretinlog.go
+++ b/pkg/core/secretinlog.go
@@ -28,24 +28,31 @@ func bareAddMaskRegex(varName string) *regexp.Regexp {
 
 type SecretInLogRule struct {
 	BaseRule
-	workflowEnvSecrets map[string]string // populated in VisitWorkflowPre from workflow-level env:
-	jobEnvSecrets      map[string]string // populated in VisitJobPre from job-level env:
+	workflowSecretTaintMap *WorkflowSecretTaintMap
+	workflowEnvSecrets     map[string]string // populated in VisitWorkflowPre from workflow-level env:
+	jobEnvSecrets          map[string]string // populated in VisitJobPre from job-level env:
 	// crossStepEnv は同一 Job 内で前 step が `$GITHUB_ENV` 経由で書き出した tainted な
 	// 環境変数を、後続 step の初期 taint source として引き継ぐためのマップ。
 	// VisitJobPre の冒頭でリセットされ、各 step 処理後に $GITHUB_ENV 書き込みから
-	// 追加される。クロスジョブ伝播は範囲外（follow-up issue）。
+	// 追加される。
 	crossStepEnv map[string]string
 	// crossStepOutputs は同一 Job 内で前 step が `$GITHUB_OUTPUT` 経由で書き出した
 	// tainted な step output を、後続 step の `${{ steps.<id>.outputs.<name> }}`
 	// 参照に引き継ぐためのマップ。
 	crossStepOutputs map[string]map[string]string
+	// pendingNeedsSteps は、consumer job が producer job より先に現れた場合に、
+	// needs.*.outputs.* の解決を VisitWorkflowPost まで遅延するための step 集合。
+	pendingNeedsSteps []*ast.Step
 }
 
 // NewSecretInLogRule は新規ルールインスタンスを返す。
-// NOTE: クロスジョブ伝播対応時（follow-up issue #432）は新しいコンストラクタシグネチャを追加し、
-// この関数はそれに nil を渡すラッパへ段階移行する。
 func NewSecretInLogRule() *SecretInLogRule {
+	return NewSecretInLogRuleWithTaintMap(nil)
+}
+
+func NewSecretInLogRuleWithTaintMap(workflowSecretTaintMap *WorkflowSecretTaintMap) *SecretInLogRule {
 	return &SecretInLogRule{
+		workflowSecretTaintMap: workflowSecretTaintMap,
 		BaseRule: BaseRule{
 			RuleName: "secret-in-log",
 			RuleDesc: "Detects secret values being printed to build logs via echo/printf of " +
@@ -321,7 +328,7 @@ func (rule *SecretInLogRule) collectLeakedVars(
 }
 
 func (rule *SecretInLogRule) findStepOutputExpressionLeaks(script string, runStr *ast.String) []stepOutputLeakOccurrence {
-	if script == "" || len(rule.crossStepOutputs) == 0 {
+	if script == "" || (len(rule.crossStepOutputs) == 0 && rule.workflowSecretTaintMap == nil) {
 		return nil
 	}
 	sanitized, exprMap := sanitizeForShellParse(script)
@@ -363,6 +370,49 @@ func (rule *SecretInLogRule) findStepOutputExpressionLeaks(script string, runStr
 		return true
 	})
 	return leaks
+}
+
+func (rule *SecretInLogRule) stepHasUnregisteredNeedsOutputReference(step *ast.Step, script string) bool {
+	if rule.workflowSecretTaintMap == nil {
+		return false
+	}
+	if containsUnregisteredNeedsOutput(script, rule.workflowSecretTaintMap) {
+		return true
+	}
+	if step == nil || step.Env == nil || step.Env.Vars == nil {
+		return false
+	}
+	for _, envVar := range step.Env.Vars {
+		if envVar == nil || envVar.Value == nil {
+			continue
+		}
+		if containsUnregisteredNeedsOutput(envVar.Value.Value, rule.workflowSecretTaintMap) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsUnregisteredNeedsOutput(value string, workflowSecretTaintMap *WorkflowSecretTaintMap) bool {
+	return containsUnregisteredSecretNeedsOutput(value, workflowSecretTaintMap)
+}
+
+func containsUnregisteredSecretNeedsOutput(value string, workflowSecretTaintMap *WorkflowSecretTaintMap) bool {
+	if value == "" || workflowSecretTaintMap == nil {
+		return false
+	}
+	for _, exprContent := range extractExpressionsFromString(value) {
+		path := normalizeStepOutputExprPath(exprContent)
+		parts := strings.Split(path, ".")
+		if len(parts) < 4 || parts[0] != "needs" || parts[2] != "outputs" {
+			continue
+		}
+		outputName := strings.Join(parts[3:], ".")
+		if _, registered := workflowSecretTaintMap.IsSecretNeedsOutput(parts[1], outputName); !registered {
+			return true
+		}
+	}
+	return false
 }
 
 func (rule *SecretInLogRule) collectLeakedStepOutputExprs(
@@ -430,12 +480,13 @@ func expressionOffsetsByPlaceholder(script string) map[string]int {
 // beforeOffset 以下なら true を返す。beforeOffset に負の値を渡すと位置制約なし。
 //
 // "current-occurrence mask" 不変条件:
-//   GitHub Actions の `::add-mask::` は発行 *後* のログ出力にのみ適用されるため、
-//   sink occurrence より前に置かれた mask 行のみが保護として機能する。
-//   同じ表現が script 内に複数回出現する場合、最初の occurrence が mask 行の前に
-//   置かれていても（例: `: "${{ X }}"; echo "::add-mask::${{ X }}"; echo "${{ X }}"`)、
-//   2 回目以降の occurrence は mask 後のものなので保護される。判定は「mask 行の
-//   位置が *この* sink occurrence （beforeOffset）以下か」で行う必要がある。
+//
+//	GitHub Actions の `::add-mask::` は発行 *後* のログ出力にのみ適用されるため、
+//	sink occurrence より前に置かれた mask 行のみが保護として機能する。
+//	同じ表現が script 内に複数回出現する場合、最初の occurrence が mask 行の前に
+//	置かれていても（例: `: "${{ X }}"; echo "::add-mask::${{ X }}"; echo "${{ X }}"`)、
+//	2 回目以降の occurrence は mask 後のものなので保護される。判定は「mask 行の
+//	位置が *この* sink occurrence （beforeOffset）以下か」で行う必要がある。
 //
 // `exprStart <= beforeOffset` は等号を許容することで `beforeOffset == exprStart`
 // （mask 行自身を sink として誤検出しないための再帰的な保護）も拾う。
@@ -523,6 +574,10 @@ func offsetToPosition(runStr *ast.String, script string, offset int) *ast.Positi
 
 // VisitWorkflowPre はワークフロールートの env: から secret taint 種を収集する。
 func (rule *SecretInLogRule) VisitWorkflowPre(node *ast.Workflow) error {
+	if rule.workflowSecretTaintMap != nil {
+		rule.workflowSecretTaintMap.Reset()
+	}
+	rule.pendingNeedsSteps = nil
 	rule.workflowEnvSecrets = rule.collectSecretEnvVars(node.Env)
 	return nil
 }
@@ -537,6 +592,30 @@ func (rule *SecretInLogRule) VisitJobPre(node *ast.Job) error {
 	for _, step := range node.Steps {
 		rule.checkStep(step)
 	}
+	if rule.workflowSecretTaintMap != nil && node.ID != nil && node.ID.Value != "" {
+		rule.workflowSecretTaintMap.RegisterJobOutputs(node.ID.Value, rule.crossStepOutputs, node.Outputs)
+	}
+	return nil
+}
+
+func (rule *SecretInLogRule) VisitWorkflowPost(node *ast.Workflow) error {
+	if rule.workflowSecretTaintMap == nil {
+		return nil
+	}
+	rule.workflowSecretTaintMap.ResolvePendingJobOutputs()
+	if len(rule.pendingNeedsSteps) == 0 {
+		return nil
+	}
+	savedCrossStepOutputs := rule.crossStepOutputs
+	rule.crossStepOutputs = nil
+	defer func() {
+		rule.crossStepOutputs = savedCrossStepOutputs
+	}()
+
+	for _, step := range rule.pendingNeedsSteps {
+		rule.checkPendingNeedsStep(step)
+	}
+	rule.pendingNeedsSteps = nil
 	return nil
 }
 
@@ -552,6 +631,9 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 	script := execRun.Run.Value
 	if script == "" {
 		return
+	}
+	if rule.stepHasUnregisteredNeedsOutputReference(step, script) {
+		rule.pendingNeedsSteps = append(rule.pendingNeedsSteps, step)
 	}
 
 	// 初期 taint 集合を構築: workflow env, job env, crossStepEnv, step env の順で merge。
@@ -614,6 +696,43 @@ func (rule *SecretInLogRule) checkStep(step *ast.Step) {
 	}
 }
 
+func (rule *SecretInLogRule) checkPendingNeedsStep(step *ast.Step) {
+	if step == nil || step.Exec == nil {
+		return
+	}
+	execRun, ok := step.Exec.(*ast.ExecRun)
+	if !ok || execRun.Run == nil {
+		return
+	}
+	script := execRun.Run.Value
+	if script == "" {
+		return
+	}
+
+	for _, leak := range rule.findStepOutputExpressionLeaks(script, execRun.Run) {
+		rule.reportStepOutputLeak(leak)
+	}
+
+	initialTainted := make(map[string]shell.Entry)
+	for k, v := range rule.collectTaintedStepOutputEnvVars(step.Env) {
+		initialTainted[k] = shell.Entry{Sources: []string{v}, Offset: -1}
+	}
+	if len(initialTainted) == 0 {
+		return
+	}
+
+	parser := syntax.NewParser(syntax.KeepComments(true), syntax.Variant(syntax.LangBash))
+	file, err := parser.Parse(strings.NewReader(script), "")
+	if err != nil || file == nil {
+		return
+	}
+	scoped := shell.PropagateTaint(file, initialTainted)
+	for _, leak := range rule.findEchoLeaks(file, scoped, script, execRun.Run) {
+		rule.reportLeak(leak)
+		rule.addAutoFixerForLeak(step, leak)
+	}
+}
+
 // reportLeak は echoLeakOccurrence をエラーとして記録する。
 // 診断メッセージの suggestion 部分は resolveMaskTarget を使って決定する (#448 review I-2):
 //   - positional ($1) かつ upstream shellvar が分かる場合は upstream var (TOKEN) をマスクするよう提案
@@ -657,7 +776,7 @@ func (rule *SecretInLogRule) reportStepOutputLeak(leak stepOutputLeakOccurrence)
 		leak.Position,
 		"secret in log: step output %s (origin: %s) is printed via '%s' without masking. "+
 			"Values written to $GITHUB_OUTPUT are not automatically masked when later expanded "+
-			"through steps.*.outputs.* and can appear in plaintext in build logs. "+
+			"through steps.*.outputs.* or needs.*.outputs.* and can appear in plaintext in build logs. "+
 			"Pass the output through an environment variable and mask it before printing, or avoid printing the value. "+
 			"See https://sisaku-security.github.io/lint/docs/rules/secretinlogrule/",
 		leak.Expr, leak.Origin, leak.Command,
@@ -1166,7 +1285,7 @@ func (rule *SecretInLogRule) collectSecretEnvVars(env *ast.Env) map[string]strin
 
 func (rule *SecretInLogRule) collectTaintedStepOutputEnvVars(env *ast.Env) map[string]string {
 	result := make(map[string]string)
-	if env == nil || env.Vars == nil || len(rule.crossStepOutputs) == 0 {
+	if env == nil || env.Vars == nil || (len(rule.crossStepOutputs) == 0 && rule.workflowSecretTaintMap == nil) {
 		return result
 	}
 	for key, envVar := range env.Vars {
@@ -1199,14 +1318,24 @@ func (rule *SecretInLogRule) resolveTaintedStepOutputExpr(exprStr string) (strin
 		return "", "", false
 	}
 	parts := strings.Split(path, ".")
-	if len(parts) < 4 || parts[0] != "steps" || parts[2] != "outputs" {
+	if len(parts) < 4 || parts[2] != "outputs" {
 		return "", "", false
 	}
-	stepID := parts[1]
 	outputName := strings.Join(parts[3:], ".")
-	if outputs := rule.crossStepOutputs[stepID]; outputs != nil {
-		if origin, ok := outputs[outputName]; ok {
-			return path, origin, true
+	switch parts[0] {
+	case "steps":
+		stepID := parts[1]
+		if outputs := rule.crossStepOutputs[stepID]; outputs != nil {
+			if origin, ok := outputs[outputName]; ok {
+				return path, origin, true
+			}
+		}
+	case "needs":
+		if rule.workflowSecretTaintMap == nil {
+			return "", "", false
+		}
+		if needsPath, origin, ok := rule.workflowSecretTaintMap.ResolveFromExprStr(path); ok {
+			return needsPath, origin, true
 		}
 	}
 	return "", "", false

--- a/pkg/core/secretinlog_test.go
+++ b/pkg/core/secretinlog_test.go
@@ -1389,11 +1389,10 @@ func TestSecretInLog_CrossStep_NoIDStepOutputDoesNotPropagate(t *testing.T) {
 	}
 }
 
-// TestSecretInLog_CrossStep_NeedsOutputsNotFlagged は cross-job propagation
-// （needs.<job>.outputs.<name>）が現在は範囲外であることをピン留めする。
-// resolveTaintedStepOutputExpr が `parts[0] != "steps"` を弾くロジック
-// （line 1184）が誤って needs を受け入れるよう拡張された場合、このテストが落ちる。
-func TestSecretInLog_CrossStep_NeedsOutputsNotFlagged(t *testing.T) {
+// TestSecretInLog_CrossJob_NeedsOutputsDirectExpressionLeak は、producer job が
+// secret-derived な値を $GITHUB_OUTPUT と job outputs で公開し、consumer job が
+// needs.<job>.outputs.<name> を直接 echo した場合に検出されることを保証する。
+func TestSecretInLog_CrossJob_NeedsOutputsDirectExpressionLeak(t *testing.T) {
 	t.Parallel()
 
 	step1 := mkRunStepForTest(t,
@@ -1401,16 +1400,238 @@ func TestSecretInLog_CrossStep_NeedsOutputsNotFlagged(t *testing.T) {
 		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
 	)
 	step1.ID = &ast.String{Value: "derive"}
-	// downstream は needs.<job>.outputs.* を expand している想定。
-	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ needs.upstream.outputs.token }}"`)
-	job := &ast.Job{Steps: []*ast.Step{step1, step2}}
-
-	rule := NewSecretInLogRule()
-	if err := rule.VisitJobPre(job); err != nil {
-		t.Fatalf("VisitJobPre: %v", err)
+	producer := &ast.Job{
+		ID:    &ast.String{Value: "upstream"},
+		Steps: []*ast.Step{step1},
+		Outputs: map[string]*ast.Output{
+			"token": {
+				Name:  &ast.String{Value: "token"},
+				Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+			},
+		},
 	}
-	if got := len(rule.Errors()); got != 0 {
-		t.Errorf("needs.*.outputs.* is out of scope; got %d unexpected errors: %v", got, rule.Errors())
+	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ needs.upstream.outputs.token }}"`)
+	consumer := &ast.Job{
+		ID:    &ast.String{Value: "downstream"},
+		Needs: []*ast.String{{Value: "upstream"}},
+		Steps: []*ast.Step{step2},
+	}
+
+	rule := NewSecretInLogRuleWithTaintMap(NewWorkflowSecretTaintMap())
+	if err := rule.VisitWorkflowPre(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPre: %v", err)
+	}
+	if err := rule.VisitJobPre(producer); err != nil {
+		t.Fatalf("VisitJobPre(producer): %v", err)
+	}
+	if err := rule.VisitJobPre(consumer); err != nil {
+		t.Fatalf("VisitJobPre(consumer): %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 cross-job needs output leak, got %d: %v", got, rule.Errors())
+	}
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "needs.upstream.outputs.token") {
+		t.Errorf("message should mention the tainted needs output, got: %s", msg)
+	}
+}
+
+func TestSecretInLog_CrossJob_NeedsOutputsEnvExpressionLeak(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	producer := &ast.Job{
+		ID:    &ast.String{Value: "upstream"},
+		Steps: []*ast.Step{step1},
+		Outputs: map[string]*ast.Output{
+			"token": {
+				Name:  &ast.String{Value: "token"},
+				Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+			},
+		},
+	}
+	step2 := mkRunStepForTest(t,
+		map[string]string{"TOKEN": "${{ needs.upstream.outputs.token }}"},
+		`echo "$TOKEN"`,
+	)
+	consumer := &ast.Job{
+		ID:    &ast.String{Value: "downstream"},
+		Needs: []*ast.String{{Value: "upstream"}},
+		Steps: []*ast.Step{step2},
+	}
+
+	rule := NewSecretInLogRuleWithTaintMap(NewWorkflowSecretTaintMap())
+	if err := rule.VisitWorkflowPre(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPre: %v", err)
+	}
+	if err := rule.VisitJobPre(producer); err != nil {
+		t.Fatalf("VisitJobPre(producer): %v", err)
+	}
+	if err := rule.VisitJobPre(consumer); err != nil {
+		t.Fatalf("VisitJobPre(consumer): %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 cross-job needs output env leak, got %d: %v", got, rule.Errors())
+	}
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "needs.upstream.outputs.token") {
+		t.Errorf("message should mention the tainted needs output, got: %s", msg)
+	}
+}
+
+func TestSecretInLog_CrossJob_NeedsOutputsDirectExpressionLeak_ReverseJobOrder(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	producer := &ast.Job{
+		ID:    &ast.String{Value: "upstream"},
+		Steps: []*ast.Step{step1},
+		Outputs: map[string]*ast.Output{
+			"token": {
+				Name:  &ast.String{Value: "token"},
+				Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+			},
+		},
+	}
+	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ needs.upstream.outputs.token }}"`)
+	consumer := &ast.Job{
+		ID:    &ast.String{Value: "downstream"},
+		Needs: []*ast.String{{Value: "upstream"}},
+		Steps: []*ast.Step{step2},
+	}
+
+	rule := NewSecretInLogRuleWithTaintMap(NewWorkflowSecretTaintMap())
+	if err := rule.VisitWorkflowPre(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPre: %v", err)
+	}
+	if err := rule.VisitJobPre(consumer); err != nil {
+		t.Fatalf("VisitJobPre(consumer): %v", err)
+	}
+	if err := rule.VisitJobPre(producer); err != nil {
+		t.Fatalf("VisitJobPre(producer): %v", err)
+	}
+	if err := rule.VisitWorkflowPost(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPost: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 reverse-order cross-job needs output leak, got %d: %v", got, rule.Errors())
+	}
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "needs.upstream.outputs.token") {
+		t.Errorf("message should mention the tainted needs output, got: %s", msg)
+	}
+}
+
+func TestSecretInLog_CrossJob_NeedsOutputsEnvExpressionLeak_ReverseJobOrder(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	producer := &ast.Job{
+		ID:    &ast.String{Value: "upstream"},
+		Steps: []*ast.Step{step1},
+		Outputs: map[string]*ast.Output{
+			"token": {
+				Name:  &ast.String{Value: "token"},
+				Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+			},
+		},
+	}
+	step2 := mkRunStepForTest(t,
+		map[string]string{"TOKEN": "${{ needs.upstream.outputs.token }}"},
+		`echo "$TOKEN"`,
+	)
+	consumer := &ast.Job{
+		ID:    &ast.String{Value: "downstream"},
+		Needs: []*ast.String{{Value: "upstream"}},
+		Steps: []*ast.Step{step2},
+	}
+
+	rule := NewSecretInLogRuleWithTaintMap(NewWorkflowSecretTaintMap())
+	if err := rule.VisitWorkflowPre(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPre: %v", err)
+	}
+	if err := rule.VisitJobPre(consumer); err != nil {
+		t.Fatalf("VisitJobPre(consumer): %v", err)
+	}
+	if err := rule.VisitJobPre(producer); err != nil {
+		t.Fatalf("VisitJobPre(producer): %v", err)
+	}
+	if err := rule.VisitWorkflowPost(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPost: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 reverse-order cross-job needs output env leak, got %d: %v", got, rule.Errors())
+	}
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "needs.upstream.outputs.token") {
+		t.Errorf("message should mention the tainted needs output, got: %s", msg)
+	}
+}
+
+func TestSecretInLog_CrossJob_NeedsOutputsMultiHop_ReverseJobOrder(t *testing.T) {
+	t.Parallel()
+
+	step1 := mkRunStepForTest(t,
+		map[string]string{"SECRET_JSON": "${{ secrets.S }}"},
+		"D=$(echo \"$SECRET_JSON\" | jq -r .k)\necho \"token=$D\" >> $GITHUB_OUTPUT",
+	)
+	step1.ID = &ast.String{Value: "derive"}
+	producer := &ast.Job{
+		ID:    &ast.String{Value: "upstream"},
+		Steps: []*ast.Step{step1},
+		Outputs: map[string]*ast.Output{
+			"token": {
+				Name:  &ast.String{Value: "token"},
+				Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+			},
+		},
+	}
+	forwarder := &ast.Job{
+		ID:    &ast.String{Value: "forwarder"},
+		Needs: []*ast.String{{Value: "upstream"}},
+		Outputs: map[string]*ast.Output{
+			"forwarded": {
+				Name:  &ast.String{Value: "forwarded"},
+				Value: &ast.String{Value: "${{ needs.upstream.outputs.token }}"},
+			},
+		},
+	}
+	step2 := mkRunStepForTest(t, nil, `echo "got: ${{ needs.forwarder.outputs.forwarded }}"`)
+	consumer := &ast.Job{
+		ID:    &ast.String{Value: "downstream"},
+		Needs: []*ast.String{{Value: "forwarder"}},
+		Steps: []*ast.Step{step2},
+	}
+
+	rule := NewSecretInLogRuleWithTaintMap(NewWorkflowSecretTaintMap())
+	if err := rule.VisitWorkflowPre(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPre: %v", err)
+	}
+	if err := rule.VisitJobPre(consumer); err != nil {
+		t.Fatalf("VisitJobPre(consumer): %v", err)
+	}
+	if err := rule.VisitJobPre(forwarder); err != nil {
+		t.Fatalf("VisitJobPre(forwarder): %v", err)
+	}
+	if err := rule.VisitJobPre(producer); err != nil {
+		t.Fatalf("VisitJobPre(producer): %v", err)
+	}
+	if err := rule.VisitWorkflowPost(&ast.Workflow{}); err != nil {
+		t.Fatalf("VisitWorkflowPost: %v", err)
+	}
+	if got := len(rule.Errors()); got != 1 {
+		t.Fatalf("expected 1 reverse-order multi-hop needs output leak, got %d: %v", got, rule.Errors())
+	}
+	if msg := rule.Errors()[0].Description; !strings.Contains(msg, "needs.forwarder.outputs.forwarded") {
+		t.Errorf("message should mention the tainted needs output, got: %s", msg)
 	}
 }
 

--- a/pkg/core/workflow_secret_taint.go
+++ b/pkg/core/workflow_secret_taint.go
@@ -1,0 +1,196 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// WorkflowSecretTaintMap tracks secret-derived values that cross job boundaries
+// via jobs.<job>.outputs and needs.<job>.outputs.<name>.
+type WorkflowSecretTaintMap struct {
+	// jobOutputSecrets: jobID (lowercase) -> outputName (lowercase) -> origin
+	// A registered job with no secret-derived outputs is represented by an empty inner map.
+	jobOutputSecrets map[string]map[string]string
+	pendingOutputs   []pendingSecretJobOutput
+}
+
+type pendingSecretJobOutput struct {
+	jobID       string
+	outputName  string
+	outputValue string
+}
+
+func NewWorkflowSecretTaintMap() *WorkflowSecretTaintMap {
+	return &WorkflowSecretTaintMap{
+		jobOutputSecrets: make(map[string]map[string]string),
+	}
+}
+
+func (m *WorkflowSecretTaintMap) Reset() {
+	m.jobOutputSecrets = make(map[string]map[string]string)
+	m.pendingOutputs = nil
+}
+
+func (m *WorkflowSecretTaintMap) markJobAsRegistered(jobID string) {
+	jobID = strings.ToLower(jobID)
+	if _, exists := m.jobOutputSecrets[jobID]; !exists {
+		m.jobOutputSecrets[jobID] = make(map[string]string)
+	}
+}
+
+func (m *WorkflowSecretTaintMap) setJobOutputSecret(jobID, outputName, origin string) {
+	jobID = strings.ToLower(jobID)
+	outputName = strings.ToLower(outputName)
+	if m.jobOutputSecrets[jobID] == nil {
+		m.jobOutputSecrets[jobID] = make(map[string]string)
+	}
+	m.jobOutputSecrets[jobID][outputName] = mergeSecretOrigins(m.jobOutputSecrets[jobID][outputName], origin)
+}
+
+func (m *WorkflowSecretTaintMap) IsSecretNeedsOutput(jobID, outputName string) (origin string, registered bool) {
+	jobID = strings.ToLower(jobID)
+	outputName = strings.ToLower(outputName)
+
+	outputs, exists := m.jobOutputSecrets[jobID]
+	if !exists {
+		return "", false
+	}
+	return outputs[outputName], true
+}
+
+// RegisterJobOutputs analyzes job outputs and records outputs that are backed by
+// secret-derived step outputs from the same job or secret-derived needs outputs
+// from previously registered jobs.
+func (m *WorkflowSecretTaintMap) RegisterJobOutputs(jobID string, stepOutputSecrets map[string]map[string]string, outputs map[string]*ast.Output) {
+	m.markJobAsRegistered(jobID)
+
+	for outputName, output := range outputs {
+		if output == nil || output.Value == nil || output.Value.Value == "" {
+			continue
+		}
+		if origin := m.extractSecretOriginFromValue(output.Value.Value, stepOutputSecrets); origin != "" {
+			m.setJobOutputSecret(jobID, outputName, origin)
+			continue
+		}
+		if containsUnregisteredSecretNeedsOutput(output.Value.Value, m) {
+			m.pendingOutputs = append(m.pendingOutputs, pendingSecretJobOutput{
+				jobID:       jobID,
+				outputName:  outputName,
+				outputValue: output.Value.Value,
+			})
+		}
+	}
+}
+
+func (m *WorkflowSecretTaintMap) ResolvePendingJobOutputs() {
+	for {
+		if len(m.pendingOutputs) == 0 {
+			return
+		}
+		progressed := false
+		remaining := m.pendingOutputs[:0]
+		for _, pending := range m.pendingOutputs {
+			if origin := m.extractSecretOriginFromValue(pending.outputValue, nil); origin != "" {
+				m.setJobOutputSecret(pending.jobID, pending.outputName, origin)
+				progressed = true
+				continue
+			}
+			remaining = append(remaining, pending)
+		}
+		m.pendingOutputs = remaining
+		if !progressed {
+			return
+		}
+	}
+}
+
+func (m *WorkflowSecretTaintMap) extractSecretOriginFromValue(value string, stepOutputSecrets map[string]map[string]string) string {
+	var origins []string
+	for _, exprContent := range extractExpressionsFromString(value) {
+		path := normalizeStepOutputExprPath(exprContent)
+		if path == "" {
+			continue
+		}
+		parts := strings.Split(path, ".")
+		if len(parts) < 4 || parts[2] != "outputs" {
+			continue
+		}
+
+		outputName := strings.Join(parts[3:], ".")
+		switch parts[0] {
+		case "steps":
+			if outputs := stepOutputSecrets[parts[1]]; outputs != nil {
+				if origin, ok := outputs[outputName]; ok && origin != "" {
+					origins = append(origins, splitSecretOrigins(origin)...)
+				}
+			}
+		case "needs":
+			if origin, registered := m.IsSecretNeedsOutput(parts[1], outputName); registered && origin != "" {
+				origins = append(origins, splitSecretOrigins(origin)...)
+			}
+		}
+	}
+	return joinUniqueSecretOrigins(origins)
+}
+
+func (m *WorkflowSecretTaintMap) ResolveFromExprStr(exprStr string) (path, origin string, ok bool) {
+	path = normalizeStepOutputExprPath(exprStr)
+	if path == "" {
+		return "", "", false
+	}
+	parts := strings.Split(path, ".")
+	if len(parts) < 4 || parts[0] != "needs" || parts[2] != "outputs" {
+		return "", "", false
+	}
+
+	outputName := strings.Join(parts[3:], ".")
+	origin, registered := m.IsSecretNeedsOutput(parts[1], outputName)
+	if !registered || origin == "" {
+		return "", "", false
+	}
+	return path, origin, true
+}
+
+func mergeSecretOrigins(existing, incoming string) string {
+	if incoming == "" {
+		return existing
+	}
+	if existing == "" {
+		return joinUniqueSecretOrigins(splitSecretOrigins(incoming))
+	}
+	origins := append(splitSecretOrigins(existing), splitSecretOrigins(incoming)...)
+	return joinUniqueSecretOrigins(origins)
+}
+
+func splitSecretOrigins(origin string) []string {
+	if origin == "" {
+		return nil
+	}
+	parts := strings.Split(origin, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
+func joinUniqueSecretOrigins(origins []string) string {
+	seen := make(map[string]struct{}, len(origins))
+	result := make([]string, 0, len(origins))
+	for _, origin := range origins {
+		origin = strings.TrimSpace(origin)
+		if origin == "" {
+			continue
+		}
+		if _, ok := seen[origin]; ok {
+			continue
+		}
+		seen[origin] = struct{}{}
+		result = append(result, origin)
+	}
+	return strings.Join(result, ",")
+}

--- a/pkg/core/workflow_secret_taint_test.go
+++ b/pkg/core/workflow_secret_taint_test.go
@@ -1,0 +1,160 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+func TestWorkflowSecretTaintMap_RegisterJobOutputs_StepsRef(t *testing.T) {
+	t.Parallel()
+
+	m := NewWorkflowSecretTaintMap()
+	stepOutputs := map[string]map[string]string{
+		"derive": {
+			"token": "secrets.S",
+		},
+	}
+	outputs := map[string]*ast.Output{
+		"token": {
+			Name:  &ast.String{Value: "token"},
+			Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+		},
+	}
+	m.RegisterJobOutputs("extract", stepOutputs, outputs)
+
+	origin, registered := m.IsSecretNeedsOutput("extract", "token")
+	if !registered {
+		t.Fatal("job should be registered after RegisterJobOutputs")
+	}
+	if origin != "secrets.S" {
+		t.Fatalf("origin = %q, want %q", origin, "secrets.S")
+	}
+}
+
+func TestWorkflowSecretTaintMap_RegisterJobOutputs_CleanOutput(t *testing.T) {
+	t.Parallel()
+
+	m := NewWorkflowSecretTaintMap()
+	outputs := map[string]*ast.Output{
+		"sha": {
+			Name:  &ast.String{Value: "sha"},
+			Value: &ast.String{Value: "${{ steps.build.outputs.sha }}"},
+		},
+	}
+	m.RegisterJobOutputs("safe-job", nil, outputs)
+
+	origin, registered := m.IsSecretNeedsOutput("safe-job", "sha")
+	if !registered {
+		t.Fatal("job should be registered even for clean outputs")
+	}
+	if origin != "" {
+		t.Fatalf("clean output should have no secret origin, got: %q", origin)
+	}
+}
+
+func TestWorkflowSecretTaintMap_MultiHopChain(t *testing.T) {
+	t.Parallel()
+
+	m := NewWorkflowSecretTaintMap()
+	outputsA := map[string]*ast.Output{
+		"token": {
+			Name:  &ast.String{Value: "token"},
+			Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+		},
+	}
+	m.RegisterJobOutputs("job-a", map[string]map[string]string{
+		"derive": {
+			"token": "secrets.S",
+		},
+	}, outputsA)
+
+	outputsB := map[string]*ast.Output{
+		"processed": {
+			Name:  &ast.String{Value: "processed"},
+			Value: &ast.String{Value: "${{ needs.job-a.outputs.token }}"},
+		},
+	}
+	m.RegisterJobOutputs("job-b", nil, outputsB)
+
+	path, origin, ok := m.ResolveFromExprStr("needs.job-b.outputs.processed")
+	if !ok {
+		t.Fatal("needs.job-b.outputs.processed should resolve")
+	}
+	if path != "needs.job-b.outputs.processed" {
+		t.Fatalf("path = %q, want needs.job-b.outputs.processed", path)
+	}
+	if origin != "secrets.S" {
+		t.Fatalf("origin = %q, want secrets.S", origin)
+	}
+}
+
+func TestWorkflowSecretTaintMap_MultiHopChain_ReverseRegistrationOrder(t *testing.T) {
+	t.Parallel()
+
+	m := NewWorkflowSecretTaintMap()
+	outputsB := map[string]*ast.Output{
+		"processed": {
+			Name:  &ast.String{Value: "processed"},
+			Value: &ast.String{Value: "${{ needs.job-a.outputs.token }}"},
+		},
+	}
+	m.RegisterJobOutputs("job-b", nil, outputsB)
+
+	outputsA := map[string]*ast.Output{
+		"token": {
+			Name:  &ast.String{Value: "token"},
+			Value: &ast.String{Value: "${{ steps.derive.outputs.token }}"},
+		},
+	}
+	m.RegisterJobOutputs("job-a", map[string]map[string]string{
+		"derive": {
+			"token": "secrets.S",
+		},
+	}, outputsA)
+
+	m.ResolvePendingJobOutputs()
+
+	path, origin, ok := m.ResolveFromExprStr("needs.job-b.outputs.processed")
+	if !ok {
+		t.Fatal("needs.job-b.outputs.processed should resolve after pending output resolution")
+	}
+	if path != "needs.job-b.outputs.processed" {
+		t.Fatalf("path = %q, want needs.job-b.outputs.processed", path)
+	}
+	if origin != "secrets.S" {
+		t.Fatalf("origin = %q, want secrets.S", origin)
+	}
+}
+
+func TestWorkflowSecretTaintMap_RegisterJobOutputs_MultipleOrigins(t *testing.T) {
+	t.Parallel()
+
+	m := NewWorkflowSecretTaintMap()
+	outputs := map[string]*ast.Output{
+		"combined": {
+			Name:  &ast.String{Value: "combined"},
+			Value: &ast.String{Value: "${{ steps.a.outputs.one }}-${{ steps.b.outputs.two }}-${{ steps.a.outputs.one }}"},
+		},
+	}
+	m.RegisterJobOutputs("extract", map[string]map[string]string{
+		"a": {
+			"one": "secrets.ONE",
+		},
+		"b": {
+			"two": "secrets.TWO",
+		},
+	}, outputs)
+
+	origin, registered := m.IsSecretNeedsOutput("extract", "combined")
+	if !registered {
+		t.Fatal("job should be registered")
+	}
+	if !strings.Contains(origin, "secrets.ONE") || !strings.Contains(origin, "secrets.TWO") {
+		t.Fatalf("origin should contain both secrets, got: %q", origin)
+	}
+	if strings.Count(origin, "secrets.ONE") != 1 {
+		t.Fatalf("origin should deduplicate repeated secrets, got: %q", origin)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `WorkflowSecretTaintMap` for secret-derived job outputs exposed through `needs.*.outputs.*`.
- Wire `secret-in-log` to detect cross-job output leaks through direct `echo` / `printf` interpolation and step-level `env:` assignments.
- Defer unresolved `needs.*.outputs.*` checks until workflow post-processing so producer/consumer job order does not matter, including multi-hop job outputs.
- Update `secret-in-log` docs with the new cross-job behavior and scope limitations.

## Validation

- `go test -count=1 ./...`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ジョブ出力（`needs.<job>.outputs.*`）を経由したシークレット露出の検知機能を追加しました。複数ジョブ間でのシークレット伝播パターン（直接式・環境変数式・複数ホップ）に対応しています。

* **ドキュメント**
  * secret-in-log ルールのドキュメントを更新し、クロスジョブの伝播範囲と検出ロジック、非検出パターン、スコープの制限事項を明確化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->