### PR TITLE
Taint dependency-review-action outputs

### DIFF
--- a/docs/codeinjectioncritical.md
+++ b/docs/codeinjectioncritical.md
@@ -445,6 +445,7 @@ The code-injection-critical rule detects:
     - `gotson/pull-request-comment-branch` - exposes `head_ref`, `head_sha`, `base_ref`, `base_sha`
     - `xt0rted/pull-request-comment-branch` - same outputs as above
     - `peter-evans/find-comment` - exposes `comment-body`, `comment-author`
+    - `actions/dependency-review-action` - exposes dependency diff outputs such as `dependency-changes` and `comment-content`
 
 ### Safe Patterns
 

--- a/pkg/core/codeinjection.go
+++ b/pkg/core/codeinjection.go
@@ -470,6 +470,7 @@ func (rule *CodeInjectionRule) FixStep(step *ast.Step) error {
 
 // generateEnvVarName generates an environment variable name from an untrusted path
 func (rule *CodeInjectionRule) generateEnvVarName(path string) string {
+	path = stripTaintAnnotation(path)
 	parts := strings.Split(path, ".")
 	if len(parts) == 0 {
 		return "UNTRUSTED_INPUT"
@@ -482,19 +483,67 @@ func (rule *CodeInjectionRule) generateEnvVarName(path string) string {
 
 		// Convert to uppercase and join
 		categoryUpper := strings.ToUpper(strings.ReplaceAll(category, "_", ""))
-		fieldUpper := strings.ToUpper(field)
+		fieldUpper := sanitizeEnvVarNameComponent(field)
 
 		// Create readable name
 		if categoryUpper == EventCategoryPR {
 			categoryUpper = "PR"
 		}
 
-		return fmt.Sprintf("%s_%s", categoryUpper, fieldUpper)
+		return sanitizeEnvVarNameComponent(fmt.Sprintf("%s_%s", categoryUpper, fieldUpper))
 	}
 
 	// Fallback: use last part
 	lastPart := parts[len(parts)-1]
-	return strings.ToUpper(lastPart)
+	if name := sanitizeEnvVarNameComponent(lastPart); name != "" {
+		return name
+	}
+	return "UNTRUSTED_INPUT"
+}
+
+func stripTaintAnnotation(path string) string {
+	if before, _, ok := strings.Cut(path, " (tainted via "); ok {
+		return before
+	}
+	return path
+}
+
+func sanitizeEnvVarNameComponent(value string) string {
+	var sb strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		var out rune
+		switch {
+		case r >= 'a' && r <= 'z':
+			out = r - ('a' - 'A')
+		case r >= 'A' && r <= 'Z':
+			out = r
+		case r >= '0' && r <= '9':
+			out = r
+		default:
+			out = '_'
+		}
+
+		if out == '_' {
+			if sb.Len() == 0 || lastUnderscore {
+				continue
+			}
+			lastUnderscore = true
+			sb.WriteRune(out)
+			continue
+		}
+		lastUnderscore = false
+		sb.WriteRune(out)
+	}
+
+	name := strings.TrimRight(sb.String(), "_")
+	if name == "" {
+		return ""
+	}
+	if name[0] >= '0' && name[0] <= '9' {
+		name = "INPUT_" + name
+	}
+	return name
 }
 
 // extractAndParseExpressions extracts all expressions from string and parses them

--- a/pkg/core/codeinjection_autofix_test.go
+++ b/pkg/core/codeinjection_autofix_test.go
@@ -219,6 +219,76 @@ func TestCodeInjectionMedium_AutoFix_YAMLOutput(t *testing.T) {
 	}
 }
 
+func TestCodeInjectionMedium_AutoFix_DependencyReviewOutput(t *testing.T) {
+	rule := CodeInjectionMediumRule(nil)
+	workflow := &ast.Workflow{
+		On: []ast.Event{
+			&ast.WebhookEvent{
+				Hook: &ast.String{Value: "pull_request"},
+			},
+		},
+	}
+	runScript := `echo '${{ steps.review.outputs.dependency-changes }}'`
+	runStep := &ast.Step{
+		Name: &ast.String{Value: "Use review output"},
+		Exec: &ast.ExecRun{
+			Run: &ast.String{
+				Value: runScript,
+				Pos:   &ast.Position{Line: 1, Col: 1},
+			},
+		},
+		BaseNode: &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "name"},
+				{Kind: yaml.ScalarNode, Value: "Use review output"},
+				{Kind: yaml.ScalarNode, Value: "run"},
+				{Kind: yaml.ScalarNode, Value: runScript},
+			},
+		},
+	}
+	job := &ast.Job{
+		Steps: []*ast.Step{
+			{
+				ID: &ast.String{Value: "review"},
+				Exec: &ast.ExecAction{
+					Uses: &ast.String{Value: "actions/dependency-review-action@v4"},
+				},
+			},
+			runStep,
+		},
+	}
+
+	_ = rule.VisitWorkflowPre(workflow)
+	_ = rule.VisitJobPre(job)
+
+	if len(rule.Errors()) == 0 {
+		t.Fatal("Expected errors but got none")
+	}
+	if err := rule.FixStep(runStep); err != nil {
+		t.Fatalf("FixStep() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	if err := enc.Encode(runStep.BaseNode); err != nil {
+		t.Fatalf("Failed to encode YAML: %v", err)
+	}
+	yamlOutput := buf.String()
+	if !strings.Contains(yamlOutput, "DEPENDENCY_CHANGES:") {
+		t.Fatalf("YAML output should contain sanitized env var DEPENDENCY_CHANGES, got:\n%s", yamlOutput)
+	}
+	if strings.Contains(yamlOutput, "TAINTED") || strings.Contains(yamlOutput, "dependency-changes:") {
+		t.Fatalf("YAML output should not derive env var name from taint annotation or raw hyphenated output, got:\n%s", yamlOutput)
+	}
+	if !strings.Contains(yamlOutput, "${{ steps.review.outputs.dependency-changes }}") {
+		t.Fatalf("YAML output should preserve original expression as env value, got:\n%s", yamlOutput)
+	}
+	if !strings.Contains(yamlOutput, "echo '$DEPENDENCY_CHANGES'") {
+		t.Fatalf("YAML output should replace direct interpolation with env var reference, got:\n%s", yamlOutput)
+	}
+}
+
 func TestCodeInjectionCritical_AutoFix_GitHubScript_YAMLOutput(t *testing.T) {
 	rule := CodeInjectionCriticalRule(nil)
 

--- a/pkg/core/codeinjection_autofix_test.go
+++ b/pkg/core/codeinjection_autofix_test.go
@@ -284,7 +284,7 @@ func TestCodeInjectionMedium_AutoFix_DependencyReviewOutput(t *testing.T) {
 	if !strings.Contains(yamlOutput, "${{ steps.review.outputs.dependency-changes }}") {
 		t.Fatalf("YAML output should preserve original expression as env value, got:\n%s", yamlOutput)
 	}
-	if !strings.Contains(yamlOutput, "echo '$DEPENDENCY_CHANGES'") {
+	if !strings.Contains(yamlOutput, `echo "$DEPENDENCY_CHANGES"`) {
 		t.Fatalf("YAML output should replace direct interpolation with env var reference, got:\n%s", yamlOutput)
 	}
 }

--- a/pkg/core/codeinjectionmedium_test.go
+++ b/pkg/core/codeinjectionmedium_test.go
@@ -218,6 +218,82 @@ echo "${{ github.event.pull_request.body }}"`,
 	}
 }
 
+func TestCodeInjectionMedium_DependencyReviewActionOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		actionUses string
+		stepEnv    *ast.Env
+		runScript  string
+		wantErrors int
+	}{
+		{
+			name:       "known dependency review output directly interpolated in run script",
+			actionUses: "actions/dependency-review-action@v4",
+			runScript:  `echo '${{ steps.review.outputs.dependency-changes }}'`,
+			wantErrors: 1,
+		},
+		{
+			name:       "dependency review output passed through env",
+			actionUses: "actions/dependency-review-action@v4",
+			stepEnv: &ast.Env{
+				Vars: map[string]*ast.EnvVar{
+					"changes": {
+						Name:  &ast.String{Value: "CHANGES"},
+						Value: &ast.String{Value: "${{ steps.review.outputs.dependency-changes }}"},
+					},
+				},
+			},
+			runScript:  `printf '%s\n' "$CHANGES"`,
+			wantErrors: 0,
+		},
+		{
+			name:       "unknown action output remains out of scope",
+			actionUses: "example/unknown-action@v1",
+			runScript:  `echo '${{ steps.review.outputs.dependency-changes }}'`,
+			wantErrors: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := CodeInjectionMediumRule(nil)
+			workflow := &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request"},
+					},
+				},
+			}
+			job := &ast.Job{
+				Steps: []*ast.Step{
+					{
+						ID: &ast.String{Value: "review"},
+						Exec: &ast.ExecAction{
+							Uses: &ast.String{Value: tt.actionUses},
+						},
+					},
+					{
+						Env: tt.stepEnv,
+						Exec: &ast.ExecRun{
+							Run: &ast.String{
+								Value: tt.runScript,
+								Pos:   &ast.Position{Line: 10, Col: 1},
+							},
+						},
+					},
+				},
+			}
+
+			_ = rule.VisitWorkflowPre(workflow)
+			_ = rule.VisitJobPre(job)
+
+			if gotErrors := len(rule.Errors()); gotErrors != tt.wantErrors {
+				t.Fatalf("got %d errors, want %d: %v", gotErrors, tt.wantErrors, rule.Errors())
+			}
+		})
+	}
+}
+
 func TestCodeInjectionMedium_GitHubScript(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/core/taint.go
+++ b/pkg/core/taint.go
@@ -171,6 +171,17 @@ func (t *TaintTracker) initKnownTaintedActions() {
 		{OutputName: "other_modified_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
 		{OutputName: "other_deleted_files", TaintSource: "PR filenames (attacker-controlled via pull request)"},
 	}
+
+	// actions/dependency-review-action - outputs are derived from dependency
+	// diff content and can contain JSON/text influenced by the pull request.
+	// Direct interpolation into run: scripts can therefore become shell input.
+	t.knownTaintedActions["actions/dependency-review-action"] = []KnownTaintedOutput{
+		{OutputName: "vulnerable-changes", TaintSource: "dependency review diff output"},
+		{OutputName: "dependency-changes", TaintSource: "dependency review diff output"},
+		{OutputName: "invalid-license-changes", TaintSource: "dependency review diff output"},
+		{OutputName: "denied-changes", TaintSource: "dependency review diff output"},
+		{OutputName: "comment-content", TaintSource: "dependency review diff output"},
+	}
 }
 
 // AnalyzeStep analyzes a step for $GITHUB_OUTPUT writes with tainted values.

--- a/pkg/core/taint_test.go
+++ b/pkg/core/taint_test.go
@@ -159,6 +159,37 @@ func TestTaintTracker_AnalyzeStep_SafeOutput(t *testing.T) {
 	}
 }
 
+func TestTaintTracker_AnalyzeStep_DependencyReviewActionOutputs(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewTaintTracker()
+	step := &ast.Step{
+		ID: &ast.String{Value: "review"},
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "actions/dependency-review-action@v4"},
+		},
+	}
+
+	tracker.AnalyzeStep(step)
+
+	outputs := tracker.taintedOutputs["review"]
+	for _, outputName := range []string{
+		"vulnerable-changes",
+		"dependency-changes",
+		"invalid-license-changes",
+		"denied-changes",
+		"comment-content",
+	} {
+		sources, ok := outputs[outputName]
+		if !ok {
+			t.Fatalf("dependency-review-action output %q should be tainted", outputName)
+		}
+		if !slices.Contains(sources, "dependency review diff output") {
+			t.Fatalf("output %q sources = %v, want dependency review diff output", outputName, sources)
+		}
+	}
+}
+
 func TestTaintTracker_IsTainted(t *testing.T) {
 	t.Parallel()
 
@@ -982,7 +1013,7 @@ func TestAssignmentValueText_SglQuoted(t *testing.T) {
 			want:   "hello",
 		},
 		{
-			name:   "single_quoted_with_placeholder",
+			name: "single_quoted_with_placeholder",
 			// SglQuoted.Value がそのまま戻り値に含まれること。
 			// SglQuoted ケースが無いと "" になる。
 			script: `X='${{ github.event.issue.title }}'`,


### PR DESCRIPTION
## Summary

- Track `actions/dependency-review-action` known outputs as tainted step outputs.
- Reuse the existing code-injection taint path so direct `${{ steps.review.outputs.* }}` interpolation in `run:` is reported while `env:` handoff remains the safe pattern.
- Sanitize generated autofix env var names for tainted step-output paths such as `dependency-changes`.
- Update the code-injection docs known-tainted-actions list.

Closes #491.

## Validation

- `go test ./pkg/core -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `actions/dependency-review-action` の出力（`dependency-changes` など）が既知の汚染ソースとして認識されるようになりました。これにより、コードインジェクション検知が強化されました。

* **改善**
  * 環境変数名の生成ロジックをより厳密にサニタイズし、安全性を向上させました。

* **テスト**
  * dependency-review アクション出力のハンドリングを検証する複数のテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->