### PR TITLE
Detect lockfile cache save poisoning

### DIFF
--- a/docs/cachepoisoningrule.md
+++ b/docs/cachepoisoningrule.md
@@ -215,11 +215,11 @@ Detected lockfile writes include explicit file writes such as:
 | Command shape | Example |
 |---------------|---------|
 | Stdout redirection | `printf '%s\n' payload >> package-lock.json` |
-| File utilities | `touch Cargo.lock`, `sed -i 's/a/b/' poetry.lock`, `tee requirements.txt` |
+| File utilities | `touch Cargo.lock`, `mv package-lock.json /tmp/package-lock.bak`, `sed -i 's/a/b/' poetry.lock`, `tee requirements.txt` |
 | Download/output commands | `curl -o package-lock.json ...`, `wget -O go.sum ...`, `dd of=pom.xml ...` |
 | Package manager lockfile commands | `npm install --package-lock-only`, `pnpm install --lockfile-only`, `yarn install`, `poetry lock`, `pipenv lock`, `go mod tidy`, `cargo update`, `bundle lock`, `composer update`, `mvn versions:lock-snapshots`, `gradle --write-locks` |
 
-`hashFiles()` pattern matching handles recursive globs, root-anchored patterns, and exclusions. For example, `hashFiles('/package-lock.json')` matches a write to `package-lock.json`, while `hashFiles('**/package-lock.json', '!package-lock.json')` does not report because the lockfile is explicitly excluded.
+`hashFiles()` pattern matching handles recursive globs, root-anchored patterns, and exclusions within each `hashFiles()` call. For example, `hashFiles('/package-lock.json')` matches a write to `package-lock.json`, while `hashFiles('**/package-lock.json', '!package-lock.json')` does not report because the lockfile is explicitly excluded in that call.
 
 **Scope:** this check is intentionally limited to a single job. Cross-job propagation and reusable workflow propagation are not analyzed by this rule.
 

--- a/docs/cachepoisoningrule.md
+++ b/docs/cachepoisoningrule.md
@@ -26,17 +26,14 @@ Cache poisoning vulnerabilities pose significant risks to CI/CD pipeline integri
 
 This vulnerability aligns with **OWASP CI/CD Security Risk CICD-SEC-9: Improper Artifact Integrity Validation**.
 
-1. **Indirect Cache Poisoning**: Dangerous combinations of untrusted triggers with unsafe checkout and cache operations
-2. **Composite Action Cache Poisoning**: Unsafe checkout followed by a composite action that invokes `actions/cache` or a setup action with caching enabled
-3. **Direct Cache Poisoning**: Untrusted input in cache configuration (key, restore-keys, path) that can be exploited regardless of trigger type
-4. **Package Cache Directory Writes**: Direct writes to package manager cache directories that can be persisted by later cache save steps
+The rule detects six types of cache poisoning attacks:
 
-The rule detects five types of cache poisoning attacks:
 1. **Indirect Cache Poisoning**: Untrusted triggers + unsafe checkout + cache actions
 2. **Composite Action Cache Poisoning**: Untrusted triggers + unsafe checkout + local or remote composite actions that use cache
 3. **Direct Cache Poisoning**: Untrusted actors directly writing to cache entries through unsafe cache configuration or exposed cache paths
 4. **Package Cache Directory Writes**: Direct writes to package manager cache directories from `run:` scripts
-5. **Cache Lifecycle Abuse**: Cache hierarchy exploitation or excessive cache actions that could enable cache flooding attacks
+5. **Lockfile-Controlled Cache Save Keys**: Same-job lockfile writes followed by `actions/cache/save` keys derived from the modified lockfile
+6. **Cache Lifecycle Abuse**: Cache hierarchy exploitation or excessive cache actions that could enable cache flooding attacks
 
 #### Key Features
 
@@ -47,6 +44,7 @@ The rule detects five types of cache poisoning attacks:
 - **Job-Level Trigger Scoping**: Honors job-level `if:` filters such as `github.event_name == 'push'` to avoid applying workflow-level unsafe triggers to jobs that cannot run on them
 - **Direct Cache Input Validation**: Checks for untrusted expressions in `key`, `restore-keys`, and `path` inputs
 - **Package Cache Directory Write Detection**: Detects `run:` scripts that write directly into npm, pip, Cargo, Gradle, Maven, or Go cache directories
+- **Lockfile-Controlled Cache Save Detection**: Detects `run:` scripts that modify dependency lockfiles before a later same-job `actions/cache/save` hashes the same lockfile in `with.key`
 - **Job Isolation**: Correctly scopes detection to individual jobs
 - **Smart Checkout Tracking**: Resets unsafe state when a safe checkout follows an unsafe one
 - **Conservative Pattern Matching**: Detects direct, indirect, and unknown expression patterns
@@ -182,6 +180,48 @@ Package manager front-ends (`npm`, `npx`, `pnpm`, `yarn`, `pip`, `pip3`, `python
 **Suppression:** add `-ignore "cache-poisoning"` (or `# sisakulint:disable=cache-poisoning` if available in your config) to silence this rule for known-good workflows. Suppressing the rule disables every cache-poisoning sub-check, not just the directory-write tier.
 
 **Known limitation:** detection works on shell AST tokens, so paths computed at runtime through external shell variables (e.g. `mkdir -p "$CACHE_ROOT/.npm"`) are not resolved and will be missed. Literal-path writes like `mkdir -p ~/.npm`, `${HOME}/.npm`, `"/home/runner/.npm"`, and writes nested under `bash -c '...'` wrappers are detected.
+
+#### Lockfile-Controlled Cache Save Keys
+
+The rule also detects same-job flows where a `run:` step modifies a dependency lockfile and a later `actions/cache/save` step derives its cache key from that same lockfile with `hashFiles()`. This matters because an attacker who can change the lockfile can also influence the cache key that receives the saved dependency cache.
+
+The rule reports when all conditions are met:
+
+1. A `run:` step modifies a known dependency lockfile.
+2. A later step in the same job uses `actions/cache/save`.
+3. `with.key` contains `hashFiles()` with a pattern set that includes the modified lockfile.
+
+Severity is split by trigger:
+
+| Tier | Trigger |
+|------|---------|
+| **High** | PR-related triggers: `pull_request`, `pull_request_target`, `pull_request_review`, `pull_request_review_comment` |
+| **Medium** | Other triggers |
+
+Recognized lockfiles include:
+
+| Ecosystem | Lockfiles |
+|-----------|-----------|
+| JavaScript / Node | `package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml`, `yarn.lock` |
+| Python | `requirements.txt`, `poetry.lock`, `Pipfile.lock` |
+| Rust | `Cargo.lock` |
+| Ruby | `Gemfile.lock` |
+| PHP | `composer.lock` |
+| Go | `go.sum` |
+| JVM | `pom.xml`, `build.gradle`, `build.gradle.kts`, `gradle.lockfile` |
+
+Detected lockfile writes include explicit file writes such as:
+
+| Command shape | Example |
+|---------------|---------|
+| Stdout redirection | `printf '%s\n' payload >> package-lock.json` |
+| File utilities | `touch Cargo.lock`, `sed -i 's/a/b/' poetry.lock`, `tee requirements.txt` |
+| Download/output commands | `curl -o package-lock.json ...`, `wget -O go.sum ...`, `dd of=pom.xml ...` |
+| Package manager lockfile commands | `npm install --package-lock-only`, `pnpm install --lockfile-only`, `yarn install`, `poetry lock`, `pipenv lock`, `go mod tidy`, `cargo update`, `bundle lock`, `composer update`, `mvn versions:lock-snapshots`, `gradle --write-locks` |
+
+`hashFiles()` pattern matching handles recursive globs, root-anchored patterns, and exclusions. For example, `hashFiles('/package-lock.json')` matches a write to `package-lock.json`, while `hashFiles('**/package-lock.json', '!package-lock.json')` does not report because the lockfile is explicitly excluded.
+
+**Scope:** this check is intentionally limited to a single job. Cross-job propagation and reusable workflow propagation are not analyzed by this rule.
 
 ### Example Vulnerable Workflows
 

--- a/pkg/core/cachepoisoningrule.go
+++ b/pkg/core/cachepoisoningrule.go
@@ -1067,9 +1067,18 @@ func (rule *CachePoisoningRule) checkCallExprWritesLockfile(call *syntax.CallExp
 	}
 
 	switch cmdName {
-	case "cp", "mv", "install":
+	case "cp", "install":
 		if dest, lockfilePath, ok := lastNonFlagWithLockfile(call.Args[argStart+1:]); ok {
 			rule.recordLockfileWrite(lockfilePath, dest.Pos(), script, runStr)
+		}
+	case "mv":
+		for _, arg := range call.Args[argStart+1:] {
+			if isLikelyFlagWord(arg) {
+				continue
+			}
+			if lockfilePath, ok := matchLockfileArg(arg); ok {
+				rule.recordLockfileWrite(lockfilePath, arg.Pos(), script, runStr)
+			}
 		}
 	case "rm", "touch", "tee":
 		for _, arg := range call.Args[argStart+1:] {
@@ -1317,46 +1326,48 @@ func (rule *CachePoisoningRule) checkLockfileHashFilesCacheSave(action *ast.Exec
 		return
 	}
 
-	globs := rule.hashFilesGlobs(keyInput.Value)
-	if len(globs) == 0 {
+	globSets := rule.hashFilesGlobSets(keyInput.Value)
+	if len(globSets) == 0 {
 		return
 	}
 
 	reported := make(map[string]bool)
 	for _, write := range rule.jobLockfileWrites {
-		matchedGlob, ok := lockfileMatchesHashFilesGlobs(globs, write.path)
-		if !ok {
-			continue
+		for _, globs := range globSets {
+			matchedGlob, ok := lockfileMatchesHashFilesGlobs(globs, write.path)
+			if !ok {
+				continue
+			}
+			key := write.path + "\x00" + matchedGlob
+			if reported[key] {
+				continue
+			}
+			reported[key] = true
+			severity := "medium"
+			if rule.isPullRequestEvent {
+				severity = "high"
+			}
+			pos := write.pos
+			if pos == nil {
+				pos = keyInput.Value.Pos
+			}
+			rule.Errorf(
+				pos,
+				"cache poisoning via lockfile-controlled cache key (%s): run step modifies lockfile %q before actions/cache/save uses hashFiles(%q) in its key. "+
+					"An attacker can alter the saved cache key and persist poisoned dependency cache content; avoid modifying hashed lockfiles before saving caches or include an immutable trusted key component",
+				severity,
+				write.path,
+				matchedGlob,
+			)
 		}
-		key := write.path + "\x00" + matchedGlob
-		if reported[key] {
-			continue
-		}
-		reported[key] = true
-		severity := "medium"
-		if rule.isPullRequestEvent {
-			severity = "high"
-		}
-		pos := write.pos
-		if pos == nil {
-			pos = keyInput.Value.Pos
-		}
-		rule.Errorf(
-			pos,
-			"cache poisoning via lockfile-controlled cache key (%s): run step modifies lockfile %q before actions/cache/save uses hashFiles(%q) in its key. "+
-				"An attacker can alter the saved cache key and persist poisoned dependency cache content; avoid modifying hashed lockfiles before saving caches or include an immutable trusted key component",
-			severity,
-			write.path,
-			matchedGlob,
-		)
 	}
 }
 
-func (rule *CachePoisoningRule) hashFilesGlobs(value *ast.String) []string {
+func (rule *CachePoisoningRule) hashFilesGlobSets(value *ast.String) [][]string {
 	if value == nil {
 		return nil
 	}
-	var globs []string
+	var globSets [][]string
 	for _, expr := range rule.extractAndParseExpressions(value) {
 		expressions.VisitExprNode(expr.node, func(node, _ expressions.ExprNode, entering bool) {
 			if !entering {
@@ -1366,6 +1377,7 @@ func (rule *CachePoisoningRule) hashFilesGlobs(value *ast.String) []string {
 			if !ok || strings.ToLower(call.Callee) != "hashfiles" {
 				return
 			}
+			var globs []string
 			for _, arg := range call.Args {
 				str, ok := arg.(*expressions.StringNode)
 				if !ok {
@@ -1375,9 +1387,12 @@ func (rule *CachePoisoningRule) hashFilesGlobs(value *ast.String) []string {
 					globs = append(globs, glob)
 				}
 			}
+			if len(globs) > 0 {
+				globSets = append(globSets, uniqueStrings(globs))
+			}
 		})
 	}
-	return uniqueStrings(globs)
+	return globSets
 }
 
 func matchLockfileArg(word *syntax.Word) (string, bool) {

--- a/pkg/core/cachepoisoningrule.go
+++ b/pkg/core/cachepoisoningrule.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
@@ -35,6 +36,7 @@ type CachePoisoningRule struct {
 	cacheActionCount       int
 	workflowTriggers       []string
 	directCacheDirWrites   []directCacheDirectoryWriteInfo
+	jobLockfileWrites      []lockfileWriteInfo
 	// jobPostJobCacheSaveDirs tracks cache roots persisted by a post-job save
 	// step (actions/cache@v* or actions/setup-* with cache: enabled). Those
 	// persist matching roots at job end, so every recorded write under a
@@ -69,6 +71,11 @@ type directCacheFixInfo struct {
 type directCacheDirectoryWriteInfo struct {
 	cacheDir string
 	pos      *ast.Position
+}
+
+type lockfileWriteInfo struct {
+	path string
+	pos  *ast.Position
 }
 
 // NewCachePoisoningRule creates a new cache poisoning detection rule.
@@ -323,6 +330,7 @@ func (rule *CachePoisoningRule) VisitWorkflowPre(node *ast.Workflow) error {
 	rule.cacheActionCount = 0
 	rule.workflowTriggers = nil
 	rule.directCacheDirWrites = nil
+	rule.jobLockfileWrites = nil
 
 	for _, event := range node.On {
 		switch e := event.(type) {
@@ -342,7 +350,7 @@ func (rule *CachePoisoningRule) VisitWorkflowPre(node *ast.Workflow) error {
 				}
 
 				// Check for PR workflows (cache scope concern)
-				if triggerName == EventPullRequest || triggerName == EventPullRequestTarget {
+				if isPRRelatedTrigger(triggerName) {
 					rule.isPullRequestEvent = true
 				}
 
@@ -428,6 +436,7 @@ func (rule *CachePoisoningRule) VisitJobPre(node *ast.Job) error {
 	rule.directCacheDirWrites = nil
 	rule.jobPostJobCacheSaveDirs = nil
 	rule.jobCacheSaveCutoffs = nil
+	rule.jobLockfileWrites = nil
 
 	if len(rule.unsafeTriggers) == 0 {
 		return nil
@@ -529,6 +538,7 @@ func uniqueCacheDirs(writes []directCacheDirectoryWriteInfo) []string {
 func (rule *CachePoisoningRule) VisitStep(node *ast.Step) error {
 	if run, ok := node.Exec.(*ast.ExecRun); ok {
 		rule.checkDirectCacheDirectoryWrite(run)
+		rule.checkLockfileWrite(run)
 		return nil
 	}
 
@@ -568,6 +578,10 @@ func (rule *CachePoisoningRule) VisitStep(node *ast.Step) error {
 	// This applies to any trigger (including pull_request, push, etc.)
 	if actionName == "actions/cache" {
 		rule.checkDirectCachePoisoning(node, action)
+	}
+
+	if actionName == "actions/cache/save" {
+		rule.checkLockfileHashFilesCacheSave(action)
 	}
 
 	// Check for cache actions
@@ -973,6 +987,581 @@ func shellPosToASTPos(pos syntax.Pos, script string, runStr *ast.String) *ast.Po
 		return &out
 	}
 	return &ast.Position{Line: 1, Col: 1}
+}
+
+var dependencyLockfileNames = map[string]bool{
+	"package-lock.json":   true,
+	"npm-shrinkwrap.json": true,
+	"pnpm-lock.yaml":      true,
+	"yarn.lock":           true,
+	"requirements.txt":    true,
+	"poetry.lock":         true,
+	"pipfile.lock":        true,
+	"cargo.lock":          true,
+	"gemfile.lock":        true,
+	"composer.lock":       true,
+	"go.sum":              true,
+	"pom.xml":             true,
+	"build.gradle":        true,
+	"build.gradle.kts":    true,
+	"gradle.lockfile":     true,
+}
+
+func isPRRelatedTrigger(eventName string) bool {
+	switch eventName {
+	case EventPullRequest, EventPullRequestTarget, "pull_request_review", "pull_request_review_comment":
+		return true
+	}
+	return false
+}
+
+func (rule *CachePoisoningRule) checkLockfileWrite(run *ast.ExecRun) {
+	if run == nil || run.Run == nil {
+		return
+	}
+
+	script := run.Run.Value
+	sanitized, _ := sanitizeForShellParse(script)
+	parser := syntax.NewParser(syntax.KeepComments(true), syntax.Variant(syntax.LangBash))
+	file, err := parser.Parse(strings.NewReader(sanitized), "")
+	if err != nil || file == nil {
+		return
+	}
+
+	rule.walkLockfileShellAST(file, sanitized, run.Run)
+}
+
+func (rule *CachePoisoningRule) walkLockfileShellAST(file *syntax.File, script string, runStr *ast.String) {
+	syntax.Walk(file, func(node syntax.Node) bool {
+		switch x := node.(type) {
+		case *syntax.CallExpr:
+			rule.checkCallExprWritesLockfile(x, script, runStr)
+		case *syntax.Stmt:
+			rule.recordLockfileWritesFromRedirects(x.Redirs, script, runStr)
+		}
+		return true
+	})
+}
+
+func (rule *CachePoisoningRule) checkCallExprWritesLockfile(call *syntax.CallExpr, script string, runStr *ast.String) {
+	if len(call.Args) == 0 {
+		return
+	}
+
+	cmdName, argStart, ok := unwrapCommandPrefixes(call)
+	if !ok {
+		return
+	}
+
+	if isInlineShellWrapper(cmdName) {
+		rule.walkInlineShellScriptForLockfiles(call, argStart, syntax.Pos{}, script, runStr)
+		return
+	}
+
+	if lockfiles := lockfilesWrittenByPackageManager(cmdName, call.Args[argStart+1:]); len(lockfiles) > 0 {
+		pos := call.Args[argStart].Pos()
+		for _, lockfilePath := range lockfiles {
+			rule.recordLockfileWrite(lockfilePath, pos, script, runStr)
+		}
+		return
+	}
+
+	switch cmdName {
+	case "cp", "mv", "install":
+		if dest, lockfilePath, ok := lastNonFlagWithLockfile(call.Args[argStart+1:]); ok {
+			rule.recordLockfileWrite(lockfilePath, dest.Pos(), script, runStr)
+		}
+	case "rm", "touch", "tee":
+		for _, arg := range call.Args[argStart+1:] {
+			if isLikelyFlagWord(arg) {
+				continue
+			}
+			if lockfilePath, ok := matchLockfileArg(arg); ok {
+				rule.recordLockfileWrite(lockfilePath, arg.Pos(), script, runStr)
+			}
+		}
+	case "sed":
+		if !hasFlagWord(call.Args[argStart+1:], "-i") {
+			return
+		}
+		for _, arg := range call.Args[argStart+1:] {
+			if isLikelyFlagWord(arg) {
+				continue
+			}
+			if lockfilePath, ok := matchLockfileArg(arg); ok {
+				rule.recordLockfileWrite(lockfilePath, arg.Pos(), script, runStr)
+			}
+		}
+	case "curl":
+		if dest, pos, ok := curlOutputLockfileDest(call.Args[argStart+1:]); ok {
+			rule.recordLockfileWrite(dest, pos, script, runStr)
+		}
+	case "wget":
+		if dest, pos, ok := wgetOutputLockfileDest(call.Args[argStart+1:]); ok {
+			rule.recordLockfileWrite(dest, pos, script, runStr)
+		}
+	case "dd":
+		if dest, pos, ok := ddOutputLockfileDest(call.Args[argStart+1:]); ok {
+			rule.recordLockfileWrite(dest, pos, script, runStr)
+		}
+	}
+}
+
+func (rule *CachePoisoningRule) walkInlineShellScriptForLockfiles(call *syntax.CallExpr, argStart int, outerFallbackPos syntax.Pos, script string, runStr *ast.String) {
+	args := call.Args[argStart+1:]
+	for i, arg := range args {
+		token := bashWordLiteral(arg)
+		if token != "-c" || i+1 >= len(args) {
+			continue
+		}
+		inner := bashWordLiteral(args[i+1])
+		if inner == "" {
+			return
+		}
+		parser := syntax.NewParser(syntax.KeepComments(true), syntax.Variant(syntax.LangBash))
+		innerFile, err := parser.Parse(strings.NewReader(inner), "")
+		if err != nil || innerFile == nil {
+			return
+		}
+		fallbackPos := args[i+1].Pos()
+		if outerFallbackPos.IsValid() {
+			fallbackPos = outerFallbackPos
+		}
+		syntax.Walk(innerFile, func(node syntax.Node) bool {
+			switch x := node.(type) {
+			case *syntax.CallExpr:
+				rule.checkCallExprWritesLockfileWithFallback(x, fallbackPos, script, runStr)
+			case *syntax.Stmt:
+				for _, r := range x.Redirs {
+					if r == nil || r.Word == nil || !isOutputRedirect(r.Op) {
+						continue
+					}
+					if lockfilePath, ok := matchLockfileArg(r.Word); ok {
+						rule.recordLockfileWrite(lockfilePath, fallbackPos, script, runStr)
+					}
+				}
+			}
+			return true
+		})
+		return
+	}
+}
+
+func (rule *CachePoisoningRule) checkCallExprWritesLockfileWithFallback(call *syntax.CallExpr, fallbackPos syntax.Pos, script string, runStr *ast.String) {
+	before := len(rule.jobLockfileWrites)
+	rule.checkCallExprWritesLockfile(call, script, runStr)
+	for i := before; i < len(rule.jobLockfileWrites); i++ {
+		rule.jobLockfileWrites[i].pos = shellPosToASTPos(fallbackPos, script, runStr)
+	}
+}
+
+func (rule *CachePoisoningRule) recordLockfileWritesFromRedirects(redirs []*syntax.Redirect, script string, runStr *ast.String) {
+	for _, r := range redirs {
+		if r == nil || r.Word == nil || !isOutputRedirect(r.Op) {
+			continue
+		}
+		if lockfilePath, ok := matchLockfileArg(r.Word); ok {
+			rule.recordLockfileWrite(lockfilePath, r.Word.Pos(), script, runStr)
+		}
+	}
+}
+
+func (rule *CachePoisoningRule) recordLockfileWrite(lockfilePath string, pos syntax.Pos, script string, runStr *ast.String) {
+	rule.jobLockfileWrites = append(rule.jobLockfileWrites, lockfileWriteInfo{
+		path: lockfilePath,
+		pos:  shellPosToASTPos(pos, script, runStr),
+	})
+}
+
+func lockfilesWrittenByPackageManager(cmdName string, args []*syntax.Word) []string {
+	tokens := shellWordTokens(args)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	switch cmdName {
+	case "npm":
+		if commandHasSubcommand(tokens, "update") ||
+			(commandHasSubcommand(tokens, "install") && hasToken(tokens, "--package-lock-only")) {
+			return []string{"package-lock.json"}
+		}
+	case "pnpm":
+		if commandHasSubcommand(tokens, "update") ||
+			(commandHasSubcommand(tokens, "install") && hasToken(tokens, "--lockfile-only")) {
+			return []string{"pnpm-lock.yaml"}
+		}
+	case "yarn":
+		if hasAnyToken(tokens, "--immutable", "--frozen-lockfile") {
+			return nil
+		}
+		if commandHasAnySubcommand(tokens, "install", "add", "up", "upgrade") {
+			return []string{"yarn.lock"}
+		}
+	case "poetry":
+		if commandHasAnySubcommand(tokens, "lock", "update") {
+			return []string{"poetry.lock"}
+		}
+	case "pipenv":
+		if commandHasSubcommand(tokens, "lock") {
+			return []string{"Pipfile.lock"}
+		}
+	case "go":
+		if len(tokens) >= 2 && tokens[0] == "mod" && (tokens[1] == "tidy" || tokens[1] == "download") {
+			return []string{"go.sum"}
+		}
+	case "cargo":
+		if commandHasAnySubcommand(tokens, "update", "generate-lockfile") {
+			return []string{"Cargo.lock"}
+		}
+	case "bundle", "bundler":
+		if commandHasAnySubcommand(tokens, "lock", "update") {
+			return []string{"Gemfile.lock"}
+		}
+	case "composer":
+		if commandHasSubcommand(tokens, "update") {
+			return []string{"composer.lock"}
+		}
+	case "mvn", "mvnw", "./mvnw":
+		if hasTokenPrefix(tokens, "versions:") {
+			return []string{"pom.xml"}
+		}
+	case "gradle", "gradlew", "./gradlew":
+		if hasAnyToken(tokens, "--write-locks", "--write-verification-metadata") {
+			return []string{"gradle.lockfile"}
+		}
+	}
+
+	return nil
+}
+
+func shellWordTokens(args []*syntax.Word) []string {
+	tokens := make([]string, 0, len(args))
+	for _, arg := range args {
+		token := strings.ToLower(bashWordLiteral(arg))
+		if token != "" {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
+}
+
+func commandHasSubcommand(tokens []string, subcommand string) bool {
+	return commandHasAnySubcommand(tokens, subcommand)
+}
+
+func commandHasAnySubcommand(tokens []string, subcommands ...string) bool {
+	for i := 0; i < len(tokens); i++ {
+		token := tokens[i]
+		if commandOptionConsumesValue(token) {
+			i++
+			continue
+		}
+		if isLikelyFlagToken(token) {
+			continue
+		}
+		for _, subcommand := range subcommands {
+			if token == subcommand {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func commandOptionConsumesValue(token string) bool {
+	switch token {
+	case "-C", "-c", "-p", "-w",
+		"--prefix", "--workspace", "--filter", "--dir", "--cwd", "--project", "--config",
+		"--cache", "--registry", "--global-folder", "--modules-dir", "--lockfile-dir",
+		"--manifest", "--file", "--settings", "--build-file", "--project-dir":
+		return true
+	}
+	return false
+}
+
+func hasToken(tokens []string, want string) bool {
+	for _, token := range tokens {
+		if token == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyToken(tokens []string, wants ...string) bool {
+	for _, want := range wants {
+		if hasToken(tokens, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTokenPrefix(tokens []string, prefix string) bool {
+	for _, token := range tokens {
+		if strings.HasPrefix(token, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (rule *CachePoisoningRule) checkLockfileHashFilesCacheSave(action *ast.ExecAction) {
+	if len(rule.jobLockfileWrites) == 0 || action == nil || action.Inputs == nil {
+		return
+	}
+
+	keyInput := action.Inputs["key"]
+	if keyInput == nil || keyInput.Value == nil {
+		return
+	}
+
+	globs := rule.hashFilesGlobs(keyInput.Value)
+	if len(globs) == 0 {
+		return
+	}
+
+	reported := make(map[string]bool)
+	for _, write := range rule.jobLockfileWrites {
+		matchedGlob, ok := lockfileMatchesHashFilesGlobs(globs, write.path)
+		if !ok {
+			continue
+		}
+		key := write.path + "\x00" + matchedGlob
+		if reported[key] {
+			continue
+		}
+		reported[key] = true
+		severity := "medium"
+		if rule.isPullRequestEvent {
+			severity = "high"
+		}
+		pos := write.pos
+		if pos == nil {
+			pos = keyInput.Value.Pos
+		}
+		rule.Errorf(
+			pos,
+			"cache poisoning via lockfile-controlled cache key (%s): run step modifies lockfile %q before actions/cache/save uses hashFiles(%q) in its key. "+
+				"An attacker can alter the saved cache key and persist poisoned dependency cache content; avoid modifying hashed lockfiles before saving caches or include an immutable trusted key component",
+			severity,
+			write.path,
+			matchedGlob,
+		)
+	}
+}
+
+func (rule *CachePoisoningRule) hashFilesGlobs(value *ast.String) []string {
+	if value == nil {
+		return nil
+	}
+	var globs []string
+	for _, expr := range rule.extractAndParseExpressions(value) {
+		expressions.VisitExprNode(expr.node, func(node, _ expressions.ExprNode, entering bool) {
+			if !entering {
+				return
+			}
+			call, ok := node.(*expressions.FuncCallNode)
+			if !ok || strings.ToLower(call.Callee) != "hashfiles" {
+				return
+			}
+			for _, arg := range call.Args {
+				str, ok := arg.(*expressions.StringNode)
+				if !ok {
+					continue
+				}
+				if glob := normalizeHashFilesPattern(str.Value); glob != "" {
+					globs = append(globs, glob)
+				}
+			}
+		})
+	}
+	return uniqueStrings(globs)
+}
+
+func matchLockfileArg(word *syntax.Word) (string, bool) {
+	if word == nil {
+		return "", false
+	}
+	return matchLockfilePath(bashWordLiteral(word))
+}
+
+func matchLockfilePath(p string) (string, bool) {
+	normalized := normalizeLockfilePath(p)
+	if normalized == "" {
+		return "", false
+	}
+	if dependencyLockfileNames[strings.ToLower(path.Base(normalized))] {
+		return normalized, true
+	}
+	return "", false
+}
+
+func normalizeLockfilePath(p string) string {
+	p = strings.TrimSpace(p)
+	p = strings.Trim(p, `"'`)
+	if p == "" || strings.Contains(p, "$") {
+		return ""
+	}
+	p = strings.ReplaceAll(p, "\\", "/")
+	for strings.HasPrefix(p, "./") {
+		p = strings.TrimPrefix(p, "./")
+	}
+	cleaned := path.Clean(p)
+	if cleaned == "." {
+		return ""
+	}
+	return strings.TrimPrefix(cleaned, "./")
+}
+
+func normalizeHashFilesPattern(p string) string {
+	p = strings.TrimSpace(p)
+	p = strings.Trim(p, `"'`)
+	if p == "" || strings.Contains(p, "$") {
+		return ""
+	}
+	negated := false
+	if strings.HasPrefix(p, "!") {
+		negated = true
+		p = strings.TrimSpace(strings.TrimPrefix(p, "!"))
+	}
+	p = strings.ReplaceAll(p, "\\", "/")
+	for strings.HasPrefix(p, "./") {
+		p = strings.TrimPrefix(p, "./")
+	}
+	p = strings.TrimPrefix(p, "/")
+	cleaned := path.Clean(p)
+	if cleaned == "." {
+		return ""
+	}
+	cleaned = strings.TrimPrefix(cleaned, "./")
+	if negated {
+		return "!" + cleaned
+	}
+	return cleaned
+}
+
+func lockfileMatchesHashFilesGlobs(globs []string, lockfilePath string) (string, bool) {
+	var matched string
+	for _, glob := range globs {
+		excluded := strings.HasPrefix(glob, "!")
+		pattern := strings.TrimPrefix(glob, "!")
+		if !lockfileGlobMatchesPath(pattern, lockfilePath) {
+			continue
+		}
+		if excluded {
+			matched = ""
+			continue
+		}
+		matched = pattern
+	}
+	return matched, matched != ""
+}
+
+func lockfileGlobMatchesPath(glob, lockfilePath string) bool {
+	glob = normalizeHashFilesPattern(glob)
+	lockfilePath = normalizeLockfilePath(lockfilePath)
+	if glob == "" || lockfilePath == "" {
+		return false
+	}
+	if glob == lockfilePath {
+		return true
+	}
+	if !strings.ContainsAny(glob, "*?[") {
+		return false
+	}
+	if strings.HasPrefix(glob, "**/") {
+		suffix := strings.TrimPrefix(glob, "**/")
+		return lockfilePath == suffix || strings.HasSuffix(lockfilePath, "/"+suffix)
+	}
+	if idx := strings.Index(glob, "/**/"); idx != -1 {
+		prefix := glob[:idx]
+		suffix := glob[idx+4:]
+		return strings.HasPrefix(lockfilePath, prefix+"/") &&
+			(lockfilePath == prefix+"/"+suffix || strings.HasSuffix(lockfilePath, "/"+suffix))
+	}
+	matched, err := path.Match(glob, lockfilePath)
+	return err == nil && matched
+}
+
+func lastNonFlagWithLockfile(args []*syntax.Word) (*syntax.Word, string, bool) {
+	for i := len(args) - 1; i >= 0; i-- {
+		w := args[i]
+		if w == nil || isLikelyFlagWord(w) {
+			continue
+		}
+		if lockfilePath, ok := matchLockfileArg(w); ok {
+			return w, lockfilePath, true
+		}
+		return nil, "", false
+	}
+	return nil, "", false
+}
+
+func ddOutputLockfileDest(args []*syntax.Word) (string, syntax.Pos, bool) {
+	if dest, pos, ok := ddOutputPath(args); ok {
+		if lockfilePath, matched := matchLockfilePath(dest); matched {
+			return lockfilePath, pos, true
+		}
+	}
+	return "", syntax.Pos{}, false
+}
+
+func curlOutputLockfileDest(args []*syntax.Word) (string, syntax.Pos, bool) {
+	if dest, pos, ok := curlOutputPath(args); ok {
+		if lockfilePath, matched := matchLockfilePath(dest); matched {
+			return lockfilePath, pos, true
+		}
+	}
+	return "", syntax.Pos{}, false
+}
+
+func wgetOutputLockfileDest(args []*syntax.Word) (string, syntax.Pos, bool) {
+	if dest, pos, ok := wgetOutputPath(args); ok {
+		if lockfilePath, matched := matchLockfilePath(dest); matched {
+			return lockfilePath, pos, true
+		}
+	}
+	return "", syntax.Pos{}, false
+}
+
+func curlOutputPath(args []*syntax.Word) (string, syntax.Pos, bool) {
+	for i, w := range args {
+		t := bashWordLiteral(w)
+		if (t == "-o" || t == "--output") && i+1 < len(args) {
+			dest := args[i+1]
+			return bashWordLiteral(dest), dest.Pos(), true
+		}
+		if strings.HasPrefix(t, "--output=") {
+			return strings.TrimPrefix(t, "--output="), w.Pos(), true
+		}
+	}
+	return "", syntax.Pos{}, false
+}
+
+func wgetOutputPath(args []*syntax.Word) (string, syntax.Pos, bool) {
+	for i, w := range args {
+		t := bashWordLiteral(w)
+		if t == "-O" && i+1 < len(args) {
+			dest := args[i+1]
+			return bashWordLiteral(dest), dest.Pos(), true
+		}
+		if strings.HasPrefix(t, "--output-document=") {
+			return strings.TrimPrefix(t, "--output-document="), w.Pos(), true
+		}
+	}
+	return "", syntax.Pos{}, false
+}
+
+func ddOutputPath(args []*syntax.Word) (string, syntax.Pos, bool) {
+	for _, w := range args {
+		t := bashWordLiteral(w)
+		if strings.HasPrefix(t, "of=") {
+			return strings.TrimPrefix(t, "of="), w.Pos(), true
+		}
+	}
+	return "", syntax.Pos{}, false
 }
 
 // unwrapCommandPrefixes resolves the effective command name past sudo/env/

--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -2335,6 +2335,26 @@ jobs:
 	}
 }
 
+func TestCachePoisoningRule_LockfileWriteEvaluatesHashFilesCallsIndependently(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' malicious >> package-lock.json
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('!**/package-lock.json', 'README.md') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+	assertOneLockfileFinding(t, rule, "package-lock.json", "(high)")
+}
+
 func TestCachePoisoningRule_LockfileWriteMatchesRootAnchoredHashFiles(t *testing.T) {
 	t.Parallel()
 
@@ -2350,6 +2370,26 @@ jobs:
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('/package-lock.json') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+	assertOneLockfileFinding(t, rule, "package-lock.json", "(high)")
+}
+
+func TestCachePoisoningRule_LockfileWriteDetectsMvFromLockfile(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: mv package-lock.json /tmp/package-lock.bak
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json') }}
 `
 	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
 	assertOneLockfileFinding(t, rule, "package-lock.json", "(high)")

--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -2034,6 +2035,426 @@ jobs:
 	}
 	if !foundCriticalDirectWrite {
 		t.Fatalf("Expected composite cache save to promote direct write to critical, got %#v", rule.Errors())
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteBeforeCacheSaveHashFiles(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' malicious >> package-lock.json
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+
+	errors := rule.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("Expected exactly 1 lockfile cache-save finding, got %d: %#v", len(errors), errors)
+	}
+	for _, want := range []string{
+		"lockfile",
+		"package-lock.json",
+		"actions/cache/save",
+		"hashFiles",
+		"(high)",
+	} {
+		if !strings.Contains(errors[0].Description, want) {
+			t.Fatalf("Expected finding to contain %q, got %q", want, errors[0].Description)
+		}
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteBeforeCacheSaveHashFilesNonPR(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'h1 example.com' >> go.sum
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ hashFiles('**/go.sum') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+
+	errors := rule.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("Expected exactly 1 lockfile cache-save finding, got %d: %#v", len(errors), errors)
+	}
+	if !strings.Contains(errors[0].Description, "(medium)") {
+		t.Fatalf("Expected non-PR workflow finding to stay medium, got %q", errors[0].Description)
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteDetectsExplicitOutputCommands(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		run      string
+		lockfile string
+		cacheKey string
+	}{
+		{
+			name:     "curl output",
+			run:      "curl -fsSL https://example.invalid/package-lock.json -o package-lock.json",
+			lockfile: "package-lock.json",
+			cacheKey: "npm-${{ hashFiles('**/package-lock.json') }}",
+		},
+		{
+			name:     "wget output",
+			run:      "wget https://example.invalid/go.sum -O go.sum",
+			lockfile: "go.sum",
+			cacheKey: "go-${{ hashFiles('**/go.sum') }}",
+		},
+		{
+			name:     "dd output",
+			run:      "dd if=/tmp/pom.xml of=pom.xml",
+			lockfile: "pom.xml",
+			cacheKey: "maven-${{ hashFiles('**/pom.xml') }}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflowYAML := fmt.Sprintf(`
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: %q
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.cache
+          key: %s
+`, tt.run, tt.cacheKey)
+			rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+			assertOneLockfileFinding(t, rule, tt.lockfile, "(high)")
+		})
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteDetectsPackageManagerCommands(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		run      string
+		lockfile string
+		cacheKey string
+	}{
+		{
+			name:     "npm package lock only",
+			run:      "npm install --package-lock-only",
+			lockfile: "package-lock.json",
+			cacheKey: "npm-${{ hashFiles('**/package-lock.json') }}",
+		},
+		{
+			name:     "pnpm lockfile only",
+			run:      "pnpm install --lockfile-only",
+			lockfile: "pnpm-lock.yaml",
+			cacheKey: "pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}",
+		},
+		{
+			name:     "yarn install updates lock",
+			run:      "yarn install",
+			lockfile: "yarn.lock",
+			cacheKey: "yarn-${{ hashFiles('**/yarn.lock') }}",
+		},
+		{
+			name:     "poetry lock",
+			run:      "poetry lock",
+			lockfile: "poetry.lock",
+			cacheKey: "poetry-${{ hashFiles('**/poetry.lock') }}",
+		},
+		{
+			name:     "go mod tidy",
+			run:      "go mod tidy",
+			lockfile: "go.sum",
+			cacheKey: "go-${{ hashFiles('**/go.sum') }}",
+		},
+		{
+			name:     "cargo update",
+			run:      "cargo update",
+			lockfile: "Cargo.lock",
+			cacheKey: "cargo-${{ hashFiles('**/Cargo.lock') }}",
+		},
+		{
+			name:     "bundle lock",
+			run:      "bundle lock",
+			lockfile: "Gemfile.lock",
+			cacheKey: "ruby-${{ hashFiles('**/Gemfile.lock') }}",
+		},
+		{
+			name:     "composer update",
+			run:      "composer update",
+			lockfile: "composer.lock",
+			cacheKey: "composer-${{ hashFiles('**/composer.lock') }}",
+		},
+		{
+			name:     "maven versions lock snapshots",
+			run:      "mvn versions:lock-snapshots",
+			lockfile: "pom.xml",
+			cacheKey: "maven-${{ hashFiles('**/pom.xml') }}",
+		},
+		{
+			name:     "gradle dependency lock",
+			run:      "gradle dependencies --write-locks",
+			lockfile: "gradle.lockfile",
+			cacheKey: "gradle-${{ hashFiles('**/gradle.lockfile') }}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflowYAML := fmt.Sprintf(`
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: %q
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.cache
+          key: %s
+`, tt.run, tt.cacheKey)
+			rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+			assertOneLockfileFinding(t, rule, tt.lockfile, "(high)")
+		})
+	}
+}
+
+func TestCachePoisoningRule_LockfileWritePullRequestReviewIsHigh(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request_review
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' malicious >> package-lock.json
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+	assertOneLockfileFinding(t, rule, "package-lock.json", "(high)")
+}
+
+func TestCachePoisoningRule_LockfileWriteRequiresPriorModification(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "building"
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("Expected no finding without a lockfile modification, got %d: %#v", got, rule.Errors())
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteIgnoresUnrelatedHashFiles(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' malicious >> package-lock.json
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: go-${{ hashFiles('**/go.sum') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("Expected unrelated hashFiles glob to stay quiet, got %d: %#v", got, rule.Errors())
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteRespectsHashFilesExclusions(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' malicious >> package-lock.json
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json', '!package-lock.json') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("Expected excluded hashFiles lockfile to stay quiet, got %d: %#v", got, rule.Errors())
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteMatchesRootAnchoredHashFiles(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' malicious >> package-lock.json
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('/package-lock.json') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+	assertOneLockfileFinding(t, rule, "package-lock.json", "(high)")
+}
+
+func TestCachePoisoningRule_LockfileWritePackageManagerCommandsSkipOptionValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		run      string
+		lockfile string
+		cacheKey string
+	}{
+		{
+			name:     "npm prefix before install",
+			run:      "npm --prefix ./app install --package-lock-only",
+			lockfile: "package-lock.json",
+			cacheKey: "npm-${{ hashFiles('**/package-lock.json') }}",
+		},
+		{
+			name:     "pnpm dir before update",
+			run:      "pnpm --dir ./app update",
+			lockfile: "pnpm-lock.yaml",
+			cacheKey: "pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflowYAML := fmt.Sprintf(`
+name: w
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: %q
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.cache
+          key: %s
+`, tt.run, tt.cacheKey)
+			rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+			assertOneLockfileFinding(t, rule, tt.lockfile, "(high)")
+		})
+	}
+}
+
+func TestCachePoisoningRule_LockfileWriteCrossJobOutOfScope(t *testing.T) {
+	t.Parallel()
+
+	workflowYAML := `
+name: w
+on: pull_request
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' malicious >> package-lock.json
+  save:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+`
+	rule := runCachePoisoningRuleForWorkflow(t, workflowYAML)
+
+	if got := len(rule.Errors()); got != 0 {
+		t.Fatalf("Expected cross-job lockfile/cache-save flow to stay out of scope, got %d: %#v", got, rule.Errors())
+	}
+}
+
+func runCachePoisoningRuleForWorkflow(t *testing.T, workflowYAML string) *CachePoisoningRule {
+	t.Helper()
+
+	workflow, parseErrs := Parse([]byte(workflowYAML))
+	if len(parseErrs) > 0 {
+		t.Fatalf("Parse returned errors: %v", parseErrs)
+	}
+
+	rule := NewCachePoisoningRule()
+	visitor := NewSyntaxTreeVisitor()
+	visitor.AddVisitor(rule)
+	if err := visitor.VisitTree(workflow); err != nil {
+		t.Fatalf("VisitTree returned error: %v", err)
+	}
+	return rule
+}
+
+func assertOneLockfileFinding(t *testing.T, rule *CachePoisoningRule, lockfile string, severity string) {
+	t.Helper()
+
+	errors := rule.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("Expected exactly 1 lockfile cache-save finding, got %d: %#v", len(errors), errors)
+	}
+	for _, want := range []string{"lockfile", lockfile, severity} {
+		if !strings.Contains(errors[0].Description, want) {
+			t.Fatalf("Expected finding to contain %q, got %q", want, errors[0].Description)
+		}
 	}
 }
 

--- a/pkg/core/codeinjection.go
+++ b/pkg/core/codeinjection.go
@@ -407,39 +407,36 @@ func (rule *CodeInjectionRule) FixStep(step *ast.Step) error {
 
 		if untrustedInfo.isInRunScript {
 			// For run: scripts, use $ENV_VAR
-			runReplacements[fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw)] = fmt.Sprintf("$%s", envVarName)
-			runReplacements[fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw)] = fmt.Sprintf("$%s", envVarName)
-
-			// Also update AST
-			run := step.Exec.(*ast.ExecRun)
-			if run.Run != nil {
-				run.Run.Value = strings.ReplaceAll(
-					run.Run.Value,
-					fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw),
-					fmt.Sprintf("$%s", envVarName),
-				)
-				run.Run.Value = strings.ReplaceAll(
-					run.Run.Value,
-					fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw),
-					fmt.Sprintf("$%s", envVarName),
-				)
-			}
+			shellRef := fmt.Sprintf("$%s", envVarName)
+			quotedShellRef := fmt.Sprintf("\"%s\"", shellRef)
+			spacedExpr := fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw)
+			compactExpr := fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw)
+			runReplacements[fmt.Sprintf("'%s'", spacedExpr)] = quotedShellRef
+			runReplacements[fmt.Sprintf("'%s'", compactExpr)] = quotedShellRef
+			runReplacements[spacedExpr] = shellRef
+			runReplacements[compactExpr] = shellRef
 		} else {
 			// For github-script, use process.env.ENV_VAR
 			scriptReplacements[fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw)] = fmt.Sprintf("process.env.%s", envVarName)
 			scriptReplacements[fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw)] = fmt.Sprintf("process.env.%s", envVarName)
+		}
+	}
 
-			// Also update AST
+	// Also update the parsed AST values in memory.
+	if len(runReplacements) > 0 {
+		if run, ok := step.Exec.(*ast.ExecRun); ok && run.Run != nil {
+			run.Run.Value = applyStringReplacements(run.Run.Value, runReplacements)
+		}
+	}
+	if len(scriptReplacements) > 0 {
+		for _, untrustedInfo := range stepInfo.untrustedExprs {
+			if untrustedInfo.isInRunScript {
+				continue
+			}
 			if untrustedInfo.scriptInput != nil && untrustedInfo.scriptInput.Value != nil {
-				untrustedInfo.scriptInput.Value.Value = strings.ReplaceAll(
+				untrustedInfo.scriptInput.Value.Value = applyStringReplacements(
 					untrustedInfo.scriptInput.Value.Value,
-					fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw),
-					fmt.Sprintf("process.env.%s", envVarName),
-				)
-				untrustedInfo.scriptInput.Value.Value = strings.ReplaceAll(
-					untrustedInfo.scriptInput.Value.Value,
-					fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw),
-					fmt.Sprintf("process.env.%s", envVarName),
+					scriptReplacements,
 				)
 			}
 		}

--- a/pkg/core/codeinjectionutil.go
+++ b/pkg/core/codeinjectionutil.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -85,9 +86,7 @@ func ReplaceInRunScript(stepNode *yaml.Node, replacements map[string]string) err
 			runNode := stepNode.Content[i+1]
 			if runNode.Kind == yaml.ScalarNode {
 				// Apply all replacements
-				for oldExpr, newExpr := range replacements {
-					runNode.Value = strings.ReplaceAll(runNode.Value, oldExpr, newExpr)
-				}
+				runNode.Value = applyStringReplacements(runNode.Value, replacements)
 			}
 			return nil
 		}
@@ -116,9 +115,7 @@ func ReplaceInGitHubScript(stepNode *yaml.Node, replacements map[string]string) 
 					scriptNode := withNode.Content[j+1]
 					if scriptNode.Kind == yaml.ScalarNode {
 						// Apply all replacements
-						for oldExpr, newExpr := range replacements {
-							scriptNode.Value = strings.ReplaceAll(scriptNode.Value, oldExpr, newExpr)
-						}
+						scriptNode.Value = applyStringReplacements(scriptNode.Value, replacements)
 					}
 					return nil
 				}
@@ -128,4 +125,18 @@ func ReplaceInGitHubScript(stepNode *yaml.Node, replacements map[string]string) 
 	}
 
 	return fmt.Errorf("with section not found in step node")
+}
+
+func applyStringReplacements(value string, replacements map[string]string) string {
+	keys := make([]string, 0, len(replacements))
+	for oldExpr := range replacements {
+		keys = append(keys, oldExpr)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
+	for _, oldExpr := range keys {
+		value = strings.ReplaceAll(value, oldExpr, replacements[oldExpr])
+	}
+	return value
 }


### PR DESCRIPTION
## Summary

- Detect `run:` steps that modify dependency lockfiles before a later `actions/cache/save` hashes the same lockfile in `with.key`.
- Mark PR-triggered workflows as `(high)` and non-PR workflows as `(medium)` in the diagnostic text.
- Keep normal cache saves quiet when no lockfile was modified, or when `hashFiles()` references unrelated files.
- Fix the existing code-injection autofix regression where a single-quoted expression became a non-expanding shell variable.

Fixes #487.

## Validation

- `go test ./pkg/core -run 'TestCachePoisoningRule_LockfileWrite' -count=1`\n- `go test ./pkg/core -run 'TestCachePoisoningRule' -count=1`\n- `go test ./pkg/core -run 'TestCodeInjection.*AutoFix|TestCachePoisoningRule' -count=1`\n- `git diff --check`\n- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ロックファイル更新に伴うキャッシュ中毒攻撃の検出機能を追加。`actions/cache/save` とロックファイルの変更を組み合わせた攻撃パターンを新たに検出できるようになりました。

* **ドキュメント**
  * キャッシュ中毒ルールのドキュメントを更新。新しい攻撃タイプの詳細条件と対象ロックファイルを明記しました。

* **テスト**
  * 新しい検出機能の包括的なテストケースを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sisaku-security/sisakulint/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->