### PR TITLE
Add dependency review settings rule

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -41,7 +41,7 @@ sisakulint categorizes security rules by severity based on CVSS scores, attack i
 |----------|-------|------------|-------------|
 | **Critical** | 14 | 9.0-10.0 | Immediate risk, can lead to RCE or full compromise |
 | **High** | 17 | 7.0-8.9 | Significant risk, enables serious attacks |
-| **Medium** | 13 | 4.0-6.9 | Moderate risk, requires specific conditions |
+| **Medium** | 14 | 4.0-6.9 | Moderate risk, requires specific conditions |
 | **Low** | 5 | 0.1-3.9 | Best practices, minimal direct security impact |
 
 ### Critical Severity Rules (9.0-10.0)
@@ -102,6 +102,7 @@ sisakulint categorizes security rules by severity based on CVSS scores, attack i
 | [unsound-contains]({{< ref "unsoundcontains.md" >}}) | 6/10 | Detects bypassable contains() function usage | Yes |
 | [archived-uses]({{< ref "archiveduses.md" >}}) | 5/10 | Detects usage of archived actions | No |
 | [unpinned-images]({{< ref "unpinnedimages.md" >}}) | 6/10 | Container images not pinned by SHA256 digest | No |
+| [dependency-review-settings]({{< ref "dependencyreviewsettings.md" >}}) | Medium | Detects dependency-review-action comment summaries without pull-requests write permission | No |
 
 ### Low Severity Rules (0.1-3.9)
 

--- a/docs/dependencyreviewsettings.md
+++ b/docs/dependencyreviewsettings.md
@@ -1,0 +1,110 @@
+---
+title: "Dependency Review Settings Rule"
+weight: 1
+---
+
+### Dependency Review Settings Rule Overview
+
+This rule detects `actions/dependency-review-action` configurations that request pull request comment summaries without granting the permission needed to write those comments.
+
+#### Key Features
+
+- **Permission Consistency Check**: Reports `comment-summary-in-pr: always` and `comment-summary-in-pr: on-failure` when the effective permissions do not include `pull-requests: write`
+- **Job Override Awareness**: Follows GitHub Actions semantics where job-level `permissions:` override workflow-level `permissions:`
+- **Focused Scope**: Ignores `comment-summary-in-pr: never`, missing settings, and unrelated actions
+
+### Security and Reliability Impact
+
+**Severity: Medium**
+
+`actions/dependency-review-action` can post a summary comment on pull requests. When comment summaries are enabled without `pull-requests: write`, the workflow configuration is internally inconsistent: the action is configured to write a PR comment, but the `GITHUB_TOKEN` permissions do not allow it.
+
+This can cause dependency review feedback to be missing from the pull request even though the workflow appears to be configured for reviewer-facing summaries.
+
+### Example Vulnerable Workflow
+
+```yaml
+name: Dependency Review
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+```
+
+### Safe Configuration
+
+Grant `pull-requests: write` at the job level when PR comments are needed:
+
+```yaml
+name: Dependency Review
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+```
+
+Or disable PR comments:
+
+```yaml
+with:
+  comment-summary-in-pr: never
+```
+
+### What the Rule Detects
+
+#### `comment-summary-in-pr: always`
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+```
+
+#### `comment-summary-in-pr: on-failure`
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: on-failure
+```
+
+### Limitations
+
+- Dynamic expressions in `permissions:` are not evaluated.
+- The rule checks scalar `with.comment-summary-in-pr` values only.
+- Repository default token permissions are not inferred; add explicit `pull-requests: write` when PR comments are required.

--- a/pkg/core/dependency_review_settings.go
+++ b/pkg/core/dependency_review_settings.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+const dependencyReviewSettingsRuleName = "dependency-review-settings"
+
+// DependencyReviewSettingsRule checks settings for actions/dependency-review-action.
+type DependencyReviewSettingsRule struct {
+	BaseRule
+	workflowPermissions *ast.Permissions
+	currentPermissions  *ast.Permissions
+}
+
+func NewDependencyReviewSettingsRule() *DependencyReviewSettingsRule {
+	return &DependencyReviewSettingsRule{
+		BaseRule: BaseRule{
+			RuleName: dependencyReviewSettingsRuleName,
+			RuleDesc: "Checks actions/dependency-review-action settings for required permissions",
+		},
+	}
+}
+
+func (rule *DependencyReviewSettingsRule) VisitWorkflowPre(workflow *ast.Workflow) error {
+	rule.workflowPermissions = workflow.Permissions
+	rule.currentPermissions = workflow.Permissions
+	return nil
+}
+
+func (rule *DependencyReviewSettingsRule) VisitJobPre(job *ast.Job) error {
+	if job.Permissions != nil {
+		rule.currentPermissions = job.Permissions
+		return nil
+	}
+	rule.currentPermissions = rule.workflowPermissions
+	return nil
+}
+
+func (rule *DependencyReviewSettingsRule) VisitStep(step *ast.Step) error {
+	action, ok := step.Exec.(*ast.ExecAction)
+	if !ok || action.Uses == nil || !isDependencyReviewAction(action.Uses.Value) {
+		return nil
+	}
+
+	input := action.Inputs["comment-summary-in-pr"]
+	if input == nil || input.Value == nil {
+		return nil
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(input.Value.Value))
+	if mode != "always" && mode != "on-failure" {
+		return nil
+	}
+
+	if hasPullRequestsWrite(rule.currentPermissions) {
+		return nil
+	}
+
+	pos := input.Value.Pos
+	if pos == nil {
+		pos = step.Pos
+	}
+	rule.Errorf(
+		pos,
+		"actions/dependency-review-action sets comment-summary-in-pr: %s, but effective permissions do not include pull-requests: write. Add pull-requests: write at the job permissions level or disable PR comments. See https://sisaku-security.github.io/lint/docs/rules/dependencyreviewsettings/",
+		mode,
+	)
+	return nil
+}
+
+func isDependencyReviewAction(uses string) bool {
+	uses = strings.ToLower(strings.TrimSpace(uses))
+	action, _, ok := strings.Cut(uses, "@")
+	return ok && action == "actions/dependency-review-action"
+}
+
+func hasPullRequestsWrite(permissions *ast.Permissions) bool {
+	if permissions == nil {
+		return false
+	}
+	if permissions.All != nil {
+		return permissions.All.Value == "write-all"
+	}
+	scope := permissions.Scopes["pull-requests"]
+	return scope != nil && scope.Value != nil && scope.Value.Value == "write"
+}

--- a/pkg/core/dependency_review_settings_test.go
+++ b/pkg/core/dependency_review_settings_test.go
@@ -1,0 +1,261 @@
+package core
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestDependencyReviewSettingsRule_CommentSummaryRequiresPullRequestsWrite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		workflow     string
+		wantFindings int
+	}{
+		{
+			name: "comment summary always without pull-requests write",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+`,
+			wantFindings: 1,
+		},
+		{
+			name: "comment summary on-failure without pull-requests write",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: on-failure
+`,
+			wantFindings: 1,
+		},
+		{
+			name: "comment summary without explicit permissions",
+			workflow: `
+name: dependency review
+on: pull_request
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+`,
+			wantFindings: 1,
+		},
+		{
+			name: "workflow-level pull-requests write allows comment summary",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  pull-requests: write
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+`,
+			wantFindings: 0,
+		},
+		{
+			name: "job-level pull-requests write allows comment summary",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  review:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+`,
+			wantFindings: 0,
+		},
+		{
+			name: "job-level permissions override workflow pull-requests write",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  pull-requests: write
+jobs:
+  review:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+`,
+			wantFindings: 1,
+		},
+		{
+			name: "comment summary never is ignored",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: never
+`,
+			wantFindings: 0,
+		},
+		{
+			name: "missing comment summary setting is ignored",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+`,
+			wantFindings: 0,
+		},
+		{
+			name: "write-all allows comment summary",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions: write-all
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+`,
+			wantFindings: 0,
+		},
+		{
+			name: "other action is ignored",
+			workflow: `
+name: dependency review
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          comment-summary-in-pr: always
+`,
+			wantFindings: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rule := NewDependencyReviewSettingsRule()
+			workflow, parseErrs := Parse([]byte(tt.workflow))
+			if len(parseErrs) > 0 {
+				t.Fatalf("Parse() errors = %v", parseErrs)
+			}
+
+			visitor := NewSyntaxTreeVisitor()
+			visitor.AddVisitor(rule)
+			if err := visitor.VisitTree(workflow); err != nil {
+				t.Fatalf("VisitTree() error = %v", err)
+			}
+
+			gotFindings := countDependencyReviewCommentSummaryFindings(rule)
+			if gotFindings != tt.wantFindings {
+				t.Fatalf("findings = %d, want %d; errors = %v", gotFindings, tt.wantFindings, rule.Errors())
+			}
+		})
+	}
+}
+
+func TestDependencyReviewSettingsRule_LinterIntegration(t *testing.T) {
+	t.Parallel()
+
+	workflow := `
+name: dependency review
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+`
+	linter, err := NewLinter(io.Discard, &LinterOptions{})
+	if err != nil {
+		t.Fatalf("NewLinter() error = %v", err)
+	}
+	result, err := linter.Lint("<test>", []byte(workflow), nil)
+	if err != nil {
+		t.Fatalf("Lint() error = %v", err)
+	}
+
+	found := false
+	for _, err := range result.Errors {
+		if err.Type == "dependency-review-settings" &&
+			strings.Contains(err.Description, "comment-summary-in-pr") &&
+			strings.Contains(err.Description, "pull-requests: write") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected dependency-review-settings finding, got errors = %v", result.Errors)
+	}
+}
+
+func countDependencyReviewCommentSummaryFindings(rule *DependencyReviewSettingsRule) int {
+	count := 0
+	for _, err := range rule.Errors() {
+		if err.Type == "dependency-review-settings" &&
+			strings.Contains(err.Description, "comment-summary-in-pr") &&
+			strings.Contains(err.Description, "pull-requests: write") {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -613,6 +613,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 		OutputClobberingMediumRule(),            // Detects output clobbering in normal workflow triggers
 		CommitShaRule(gitHubToken),
 		NewDependabotGitHubActionsRule(filePath, isRemote), // Checks dependabot.yaml has github-actions ecosystem when unpinned actions found
+		NewDependencyReviewSettingsRule(),                  // Checks dependency-review-action settings against required permissions
 		ArtifactPoisoningRule(),
 		NewArtifactPoisoningMediumRule(),
 		NewActionListRule(),


### PR DESCRIPTION
## Summary

- Add `dependency-review-settings` to detect `actions/dependency-review-action` PR comment summaries without effective `pull-requests: write` permission
- Respect workflow-level permissions and job-level override semantics
- Add parser/visitor unit coverage, linter integration coverage, and rule documentation

## Why

Fixes #490. `comment-summary-in-pr: always` and `comment-summary-in-pr: on-failure` require the workflow token to be able to write pull request comments. Without `pull-requests: write`, the action configuration is inconsistent and expected PR feedback may not appear.

## Validation

- `go test ./pkg/core -run 'TestDependencyReviewSettingsRule' -count=1`
- `go test ./pkg/core -run 'TestCrossJobTaintPropagation/3ジョブチェーン:_multi-hop_で検出される' -count=1`
- `go test ./... -count=1`

Note: an initial full `go test ./...` run hit an existing intermittent `TestCrossJobTaintPropagation` failure. The affected subtest passed in isolation, and the full suite passed on rerun with `-count=1`.