### PR TITLE
fix argument injection autofix composition

### DIFF
--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/sisaku-security/sisakulint/pkg/ast"
@@ -242,6 +243,10 @@ func (rule *ArgumentInjectionRule) prepareScriptForParsing(script string, exprs 
 	exprToPlaceholder := make(map[string]string)
 
 	for i, expr := range exprs {
+		if _, exists := exprToPlaceholder[expr.raw]; exists {
+			continue
+		}
+
 		exprPattern1 := fmt.Sprintf("${{ %s }}", expr.raw)
 		exprPattern2 := fmt.Sprintf("${{%s}}", expr.raw)
 		placeholderName := fmt.Sprintf("__SISAKULINT_ARGEXPR_%d__", i)
@@ -265,9 +270,14 @@ func (rule *ArgumentInjectionRule) analyzeExpressions(
 	s *ast.Step,
 ) *stepWithArgumentInjection {
 	var stepUntrusted *stepWithArgumentInjection
+	processedExprs := make(map[string]bool)
 
 	for i := range exprs {
 		expr := &exprs[i]
+		if processedExprs[expr.raw] {
+			continue
+		}
+		processedExprs[expr.raw] = true
 
 		placeholderName := exprToPlaceholder[expr.raw]
 		varUsages := parser.FindVarUsageAsCommandArg(placeholderName, dangerousCmdNames)
@@ -451,6 +461,7 @@ func (rule *ArgumentInjectionRule) FixStep(step *ast.Step) error {
 	}
 
 	script := rule.replaceExpressionsWithEnvVars(run.Run.Value, stepInfo, envVarMap)
+	script = rule.rewriteExistingEnvVarArguments(script, stepInfo, envVarMap)
 	run.Run.Value = script
 
 	return rule.updateStepRunScript(step, script)
@@ -533,19 +544,111 @@ func (rule *ArgumentInjectionRule) replaceExpressionsWithEnvVars(
 		exprPattern1 := exprPrefix + untrustedInfo.expr.raw + exprSuffix
 		exprPattern2 := fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw)
 
-		newValue := rule.buildReplacementValue(envVarName, untrustedInfo.commandName)
+		newValue := fmt.Sprintf("$%s", envVarName)
 		script = strings.ReplaceAll(script, exprPattern1, newValue)
 		script = strings.ReplaceAll(script, exprPattern2, newValue)
 	}
 	return script
 }
 
-// buildReplacementValue builds the replacement value for an expression.
-func (rule *ArgumentInjectionRule) buildReplacementValue(envVarName, commandName string) string {
-	if commandsNotSupportingDoubleDash[commandName] {
-		return fmt.Sprintf("\"$%s\"", envVarName)
+type argumentScriptReplacement struct {
+	start       int
+	end         int
+	replacement string
+}
+
+// rewriteExistingEnvVarArguments fixes env-var references left behind by earlier
+// autofixers that already replaced the original ${{ }} expression.
+func (rule *ArgumentInjectionRule) rewriteExistingEnvVarArguments(
+	script string,
+	stepInfo *stepWithArgumentInjection,
+	envVarMap map[string]string,
+) string {
+	parser := shell.NewShellParser(script)
+	var replacements []argumentScriptReplacement
+
+	for _, untrustedInfo := range stepInfo.untrustedExprs {
+		envVarName := envVarMap[untrustedInfo.expr.raw]
+		if envVarName == "" {
+			continue
+		}
+
+		usages := parser.FindVarUsageAsCommandArg(envVarName, []string{untrustedInfo.commandName})
+		for _, usage := range usages {
+			replacement, ok := rule.replacementForEnvVarUsage(usage, envVarName)
+			if ok {
+				replacements = append(replacements, replacement)
+			}
+		}
 	}
-	return fmt.Sprintf("-- \"$%s\"", envVarName)
+
+	return applyArgumentScriptReplacements(script, replacements)
+}
+
+func (rule *ArgumentInjectionRule) replacementForEnvVarUsage(
+	usage shell.VarArgUsage,
+	envVarName string,
+) (argumentScriptReplacement, bool) {
+	if usage.IsAfterDoubleDash {
+		return argumentScriptReplacement{}, false
+	}
+
+	isStandaloneArg := rule.isStandaloneArgUsage(usage, envVarName)
+	if isStandaloneArg {
+		if !commandsNotSupportingDoubleDash[usage.CommandName] {
+			return argumentScriptReplacement{
+				start:       usage.ArgStartPos,
+				end:         usage.ArgEndPos,
+				replacement: fmt.Sprintf("-- \"$%s\"", envVarName),
+			}, true
+		}
+		if usage.IsQuoted {
+			return argumentScriptReplacement{}, false
+		}
+		return argumentScriptReplacement{
+			start:       usage.ArgStartPos,
+			end:         usage.ArgEndPos,
+			replacement: fmt.Sprintf("\"$%s\"", envVarName),
+		}, true
+	}
+
+	if usage.IsQuoted {
+		return argumentScriptReplacement{}, false
+	}
+	return argumentScriptReplacement{
+		start:       usage.StartPos,
+		end:         usage.EndPos,
+		replacement: fmt.Sprintf("\"$%s\"", envVarName),
+	}, true
+}
+
+func (rule *ArgumentInjectionRule) isStandaloneArgUsage(usage shell.VarArgUsage, varName string) bool {
+	argValue := strings.TrimSpace(usage.ArgValue)
+	return argValue == "$"+varName ||
+		argValue == "${"+varName+"}" ||
+		argValue == "\"$"+varName+"\"" ||
+		argValue == "\"${"+varName+"}\""
+}
+
+func applyArgumentScriptReplacements(script string, replacements []argumentScriptReplacement) string {
+	sort.SliceStable(replacements, func(i, j int) bool {
+		return replacements[i].start > replacements[j].start
+	})
+
+	nextStart := len(script)
+	for _, replacement := range replacements {
+		if replacement.start < 0 ||
+			replacement.end < replacement.start ||
+			replacement.end > len(script) ||
+			replacement.end > nextStart {
+			continue
+		}
+
+		script = script[:replacement.start] + replacement.replacement + script[replacement.end:]
+		nextStart = replacement.start
+	}
+
+	return script
 }
 
 // updateStepRunScript updates the step's run script in the YAML node.

--- a/pkg/core/argumentinjection_test.go
+++ b/pkg/core/argumentinjection_test.go
@@ -587,3 +587,150 @@ func TestArgumentInjection_GenerateEnvVarName(t *testing.T) {
 		})
 	}
 }
+
+func TestArgumentInjection_FixStep_ComposesWithCodeInjection(t *testing.T) {
+	tests := []struct {
+		name string
+		run  string
+		want string
+	}{
+		{
+			name: "standalone argument gets double dash after code injection fix",
+			run:  `git diff ${{ github.event.pull_request.head.ref }}`,
+			want: `git diff -- "$PR_REF"`,
+		},
+		{
+			name: "embedded argument gets quoted without double dash after code injection fix",
+			run:  `curl https://api.example.com/${{ github.event.pull_request.title }}`,
+			want: `curl https://api.example.com/"$PR_TITLE"`,
+		},
+		{
+			name: "repeated standalone expression gets double dash after code injection fix",
+			run: `git diff ${{ github.event.pull_request.head.ref }}
+git log ${{ github.event.pull_request.head.ref }}`,
+			want: `git diff -- "$PR_REF"
+git log -- "$PR_REF"`,
+		},
+		{
+			name: "repeated mixed expression uses per-argument rewrite after code injection fix",
+			run: `git diff ${{ github.event.pull_request.head.ref }}
+curl https://api.example.com/${{ github.event.pull_request.head.ref }}`,
+			want: `git diff -- "$PR_REF"
+curl https://api.example.com/"$PR_REF"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workflow, job, step := argumentInjectionWorkflowWithRun(tt.run)
+			codeRule := CodeInjectionCriticalRule(nil)
+			argRule := ArgumentInjectionCriticalRule(nil)
+
+			if err := codeRule.VisitWorkflowPre(workflow); err != nil {
+				t.Fatalf("code VisitWorkflowPre() error = %v", err)
+			}
+			if err := codeRule.VisitJobPre(job); err != nil {
+				t.Fatalf("code VisitJobPre() error = %v", err)
+			}
+			if err := argRule.VisitWorkflowPre(workflow); err != nil {
+				t.Fatalf("arg VisitWorkflowPre() error = %v", err)
+			}
+			if err := argRule.VisitJobPre(job); err != nil {
+				t.Fatalf("arg VisitJobPre() error = %v", err)
+			}
+
+			if len(codeRule.AutoFixers()) == 0 {
+				t.Fatal("expected code-injection autofixer")
+			}
+			if len(argRule.AutoFixers()) == 0 {
+				t.Fatal("expected argument-injection autofixer")
+			}
+
+			if err := codeRule.FixStep(step); err != nil {
+				t.Fatalf("code FixStep() error = %v", err)
+			}
+			if err := argRule.FixStep(step); err != nil {
+				t.Fatalf("arg FixStep() error = %v", err)
+			}
+
+			got := step.Exec.(*ast.ExecRun).Run.Value
+			if got != tt.want {
+				t.Errorf("fixed run script = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestArgumentInjection_FixStep_EmbeddedExpressionUsesQuoteOnly(t *testing.T) {
+	workflow, job, step := argumentInjectionWorkflowWithRun(
+		`curl https://api.example.com/${{ github.event.pull_request.title }}`,
+	)
+	rule := ArgumentInjectionCriticalRule(nil)
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatalf("VisitWorkflowPre() error = %v", err)
+	}
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre() error = %v", err)
+	}
+	if len(rule.AutoFixers()) == 0 {
+		t.Fatal("expected argument-injection autofixer")
+	}
+
+	if err := rule.FixStep(step); err != nil {
+		t.Fatalf("FixStep() error = %v", err)
+	}
+
+	want := `curl https://api.example.com/"$PR_TITLE"`
+	got := step.Exec.(*ast.ExecRun).Run.Value
+	if got != want {
+		t.Errorf("fixed run script = %q, want %q", got, want)
+	}
+}
+
+func TestArgumentInjection_FixStep_RepeatedMixedExpressionUsesPerArgumentRewrite(t *testing.T) {
+	workflow, job, step := argumentInjectionWorkflowWithRun(`git diff ${{ github.event.pull_request.head.ref }}
+curl https://api.example.com/${{ github.event.pull_request.head.ref }}`)
+	rule := ArgumentInjectionCriticalRule(nil)
+
+	if err := rule.VisitWorkflowPre(workflow); err != nil {
+		t.Fatalf("VisitWorkflowPre() error = %v", err)
+	}
+	if err := rule.VisitJobPre(job); err != nil {
+		t.Fatalf("VisitJobPre() error = %v", err)
+	}
+	if len(rule.AutoFixers()) == 0 {
+		t.Fatal("expected argument-injection autofixer")
+	}
+
+	if err := rule.FixStep(step); err != nil {
+		t.Fatalf("FixStep() error = %v", err)
+	}
+
+	want := `git diff -- "$PR_REF"
+curl https://api.example.com/"$PR_REF"`
+	got := step.Exec.(*ast.ExecRun).Run.Value
+	if got != want {
+		t.Errorf("fixed run script = %q, want %q", got, want)
+	}
+}
+
+func argumentInjectionWorkflowWithRun(run string) (*ast.Workflow, *ast.Job, *ast.Step) {
+	workflow := &ast.Workflow{
+		On: []ast.Event{
+			&ast.WebhookEvent{
+				Hook: &ast.String{Value: "pull_request_target"},
+			},
+		},
+	}
+	step := &ast.Step{
+		Exec: &ast.ExecRun{
+			Run: &ast.String{
+				Value: run,
+				Pos:   &ast.Position{Line: 1, Col: 1},
+			},
+		},
+	}
+	job := &ast.Job{Steps: []*ast.Step{step}}
+	return workflow, job, step
+}

--- a/pkg/shell/parser.go
+++ b/pkg/shell/parser.go
@@ -24,6 +24,9 @@ type VarArgUsage struct {
 	ShellVarUsage
 	CommandName       string
 	ArgPosition       int
+	ArgValue          string
+	ArgStartPos       int
+	ArgEndPos         int
 	HasDoubleDash     bool
 	IsAfterDoubleDash bool
 }
@@ -1412,7 +1415,17 @@ func (p *ShellParser) FindVarUsageAsCommandArg(varName string, cmdNames []string
 			doubleDashPos := p.findDoubleDashPosition(call)
 			for argIdx, arg := range call.Args[1:] {
 				actualIdx := argIdx + 1
-				p.findVarInArg(arg, varName, cmdName, actualIdx, doubleDashPos, &usages)
+				p.findVarInArg(
+					arg,
+					varName,
+					cmdName,
+					actualIdx,
+					doubleDashPos,
+					p.wordToString(arg),
+					int(arg.Pos().Offset()), //nolint:gosec // byte offset of workflow shell scripts cannot realistically overflow int
+					int(arg.End().Offset()), //nolint:gosec // byte offset of workflow shell scripts cannot realistically overflow int
+					&usages,
+				)
 			}
 		}
 		return true
@@ -1435,7 +1448,17 @@ func (p *ShellParser) findDoubleDashPosition(call *syntax.CallExpr) int {
 	return -1
 }
 
-func (p *ShellParser) findVarInArg(node syntax.Node, varName string, cmdName string, argPos int, doubleDashPos int, usages *[]VarArgUsage) {
+func (p *ShellParser) findVarInArg(
+	node syntax.Node,
+	varName string,
+	cmdName string,
+	argPos int,
+	doubleDashPos int,
+	argValue string,
+	argStartPos int,
+	argEndPos int,
+	usages *[]VarArgUsage,
+) {
 	if node == nil {
 		return
 	}
@@ -1443,11 +1466,11 @@ func (p *ShellParser) findVarInArg(node syntax.Node, varName string, cmdName str
 	switch x := node.(type) {
 	case *syntax.Word:
 		for _, part := range x.Parts {
-			p.findVarInArg(part, varName, cmdName, argPos, doubleDashPos, usages)
+			p.findVarInArg(part, varName, cmdName, argPos, doubleDashPos, argValue, argStartPos, argEndPos, usages)
 		}
 	case *syntax.DblQuoted:
 		for _, part := range x.Parts {
-			p.findVarInArg(part, varName, cmdName, argPos, doubleDashPos, usages)
+			p.findVarInArg(part, varName, cmdName, argPos, doubleDashPos, argValue, argStartPos, argEndPos, usages)
 		}
 	case *syntax.ParamExp:
 		if x.Param != nil && x.Param.Value == varName {
@@ -1464,13 +1487,16 @@ func (p *ShellParser) findVarInArg(node syntax.Node, varName string, cmdName str
 				},
 				CommandName:       cmdName,
 				ArgPosition:       argPos,
+				ArgValue:          argValue,
+				ArgStartPos:       argStartPos,
+				ArgEndPos:         argEndPos,
 				HasDoubleDash:     doubleDashPos != -1,
 				IsAfterDoubleDash: doubleDashPos != -1 && argPos > doubleDashPos,
 			}
 			*usages = append(*usages, usage)
 		}
 		if x.Exp != nil && x.Exp.Word != nil {
-			p.findVarInArg(x.Exp.Word, varName, cmdName, argPos, doubleDashPos, usages)
+			p.findVarInArg(x.Exp.Word, varName, cmdName, argPos, doubleDashPos, argValue, argStartPos, argEndPos, usages)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #503.

- Preserve argument-injection autofix hardening when `code-injection-critical` has already lifted the same `${{ }}` expression into an env var.
- Distinguish standalone shell arguments from embedded/mid-token arguments so embedded URLs get quote-only rewrites instead of malformed `/-- "$VAR"` output.
- Handle repeated identical `${{ }}` expressions in a single step without losing argument-injection detection or reusing the wrong replacement shape.
- Add regression coverage for co-fire, repeated-expression co-fire, argument-only repeated mixed usage, and embedded-expression autofix behavior.

## Root Cause

`argument-injection-critical` recorded the vulnerable expression during linting, but its autofix later keyed only on the original `${{ }}` literal. When `code-injection-critical` ran first, that literal was already replaced with `$VAR`, so argument-injection silently skipped the `-- "$VAR"` hardening. The embedded case also used the standalone-argument replacement form directly inside a larger token.

A related duplicate-expression bug also overwrote placeholder tracking for repeated identical `${{ }}` expressions in the same step, which prevented the argument-injection fixer from being registered for those repeated usages. The fixer now first lowers expressions to plain env-var references, then applies the same shell-AST positional pass to choose `-- "$VAR"` versus quote-only per actual argument usage.

## Validation

- `go test ./pkg/core -run 'TestArgumentInjection' -count=1`
- `go test ./pkg/shell -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./pkg/core -run 'TestArgumentInjection' -count=1`
- `go test -race ./pkg/shell -count=1`
- `go build -o ./sisakulint ./cmd/sisakulint`
- `./sisakulint -fix dry-run script/actions/argument-injection.yaml` representative output checked for `git diff -- "$PR_REF"` and quote-only embedded URL rewrites