### PR TITLE
Fix privileged trigger consistency for injection rules

### DIFF
--- a/docs/argumentinjection.md
+++ b/docs/argumentinjection.md
@@ -34,7 +34,6 @@ Detects argument injection in **privileged workflow triggers**:
 - `issue_comment`
 - `issues`
 - `discussion_comment`
-- `pull_request_review`
 
 These triggers have write access to the repository and access to secrets, making exploitation more severe.
 
@@ -42,6 +41,7 @@ These triggers have write access to the repository and access to secrets, making
 
 Detects argument injection in **normal workflow triggers**:
 - `pull_request`
+- `pull_request_review`
 - `push`
 - `schedule`
 - `workflow_dispatch`

--- a/docs/argumentinjection.md
+++ b/docs/argumentinjection.md
@@ -34,6 +34,7 @@ Detects argument injection in **privileged workflow triggers**:
 - `issue_comment`
 - `issues`
 - `discussion_comment`
+- `pull_request_review`
 
 These triggers have write access to the repository and access to secrets, making exploitation more severe.
 

--- a/docs/requestforgery.md
+++ b/docs/requestforgery.md
@@ -11,7 +11,7 @@ The Request Forgery rule detects Server-Side Request Forgery (SSRF) vulnerabilit
 
 ## Rule Variants
 
-- **request-forgery-critical**: Detects SSRF vulnerabilities in workflows with privileged triggers (`pull_request_target`, `workflow_run`, `issue_comment`)
+- **request-forgery-critical**: Detects SSRF vulnerabilities in workflows with privileged triggers (`pull_request_target`, `workflow_run`, `issue_comment`, `issues`, `discussion_comment`, `pull_request_review`)
 - **request-forgery-medium**: Detects SSRF vulnerabilities in workflows with normal triggers (`pull_request`, `push`, `schedule`)
 
 ## What It Detects

--- a/docs/requestforgery.md
+++ b/docs/requestforgery.md
@@ -11,8 +11,8 @@ The Request Forgery rule detects Server-Side Request Forgery (SSRF) vulnerabilit
 
 ## Rule Variants
 
-- **request-forgery-critical**: Detects SSRF vulnerabilities in workflows with privileged triggers (`pull_request_target`, `workflow_run`, `issue_comment`, `issues`, `discussion_comment`, `pull_request_review`)
-- **request-forgery-medium**: Detects SSRF vulnerabilities in workflows with normal triggers (`pull_request`, `push`, `schedule`)
+- **request-forgery-critical**: Detects SSRF vulnerabilities in workflows with privileged triggers (`pull_request_target`, `workflow_run`, `issue_comment`, `issues`, `discussion_comment`)
+- **request-forgery-medium**: Detects SSRF vulnerabilities in workflows with normal triggers (`pull_request`, `pull_request_review`, `push`, `schedule`)
 
 ## What It Detects
 

--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -415,7 +415,7 @@ func (rule *ArgumentInjectionRule) VisitWorkflowPost(node *ast.Workflow) error {
 }
 
 func (rule *ArgumentInjectionRule) hasPrivilegedTriggers() bool {
-	return HasPrivilegedTriggers(rule.workflow)
+	return hasPrivilegedTriggersForCriticalInjection(rule.workflow)
 }
 
 func (rule *ArgumentInjectionRule) RuleNames() string {

--- a/pkg/core/argumentinjection.go
+++ b/pkg/core/argumentinjection.go
@@ -115,7 +115,7 @@ func newArgumentInjectionRule(severityLevel string, checkPrivileged bool, wfTain
 	var desc string
 
 	if checkPrivileged {
-		desc = "Checks for argument injection vulnerabilities when untrusted input is used as command-line arguments in privileged workflow triggers (pull_request_target, workflow_run, issue_comment). Attackers can inject malicious options like --output=/etc/passwd or --config=malicious.conf. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
+		desc = "Checks for argument injection vulnerabilities when untrusted input is used as command-line arguments in privileged workflow triggers. Attackers can inject malicious options like --output=/etc/passwd or --config=malicious.conf. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
 	} else {
 		desc = "Checks for argument injection vulnerabilities when untrusted input is used as command-line arguments in normal workflow triggers (pull_request, push, etc.). Attackers can inject malicious options like --output=/etc/passwd or --config=malicious.conf. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
 	}
@@ -415,26 +415,7 @@ func (rule *ArgumentInjectionRule) VisitWorkflowPost(node *ast.Workflow) error {
 }
 
 func (rule *ArgumentInjectionRule) hasPrivilegedTriggers() bool {
-	if rule.workflow == nil || rule.workflow.On == nil {
-		return false
-	}
-
-	privilegedTriggers := map[string]bool{
-		"pull_request_target": true,
-		"workflow_run":        true,
-		"issue_comment":       true,
-		"issues":              true,
-		"discussion_comment":  true,
-	}
-
-	for _, event := range rule.workflow.On {
-		eventName := strings.ToLower(event.EventName())
-		if privilegedTriggers[eventName] {
-			return true
-		}
-	}
-
-	return false
+	return HasPrivilegedTriggers(rule.workflow)
 }
 
 func (rule *ArgumentInjectionRule) RuleNames() string {

--- a/pkg/core/argumentinjection_test.go
+++ b/pkg/core/argumentinjection_test.go
@@ -28,36 +28,49 @@ func TestArgumentInjection_PrivilegedTriggers(t *testing.T) {
 	tests := []struct {
 		name         string
 		trigger      string
+		runScript    string
 		shouldDetect bool
 		description  string
 	}{
 		{
 			name:         "pull_request_target is privileged",
 			trigger:      "pull_request_target",
+			runScript:    `git diff ${{ github.event.pull_request.head.ref }}`,
 			shouldDetect: true,
 			description:  "pull_request_target should be detected as privileged",
 		},
 		{
 			name:         "workflow_run is privileged",
 			trigger:      "workflow_run",
+			runScript:    `git diff ${{ github.event.pull_request.head.ref }}`,
 			shouldDetect: true,
 			description:  "workflow_run should be detected as privileged",
 		},
 		{
 			name:         "issue_comment is privileged",
 			trigger:      "issue_comment",
+			runScript:    `git diff ${{ github.event.pull_request.head.ref }}`,
 			shouldDetect: true,
 			description:  "issue_comment should be detected as privileged",
 		},
 		{
+			name:         "pull_request_review is privileged",
+			trigger:      "pull_request_review",
+			runScript:    `git diff ${{ github.event.review.body }}`,
+			shouldDetect: true,
+			description:  "pull_request_review should be detected as privileged (review body is attacker-controlled)",
+		},
+		{
 			name:         "pull_request is not privileged",
 			trigger:      "pull_request",
+			runScript:    `git diff ${{ github.event.pull_request.head.ref }}`,
 			shouldDetect: false,
 			description:  "pull_request should not be detected as privileged (critical rule)",
 		},
 		{
 			name:         "push is not privileged",
 			trigger:      "push",
+			runScript:    `git diff ${{ github.event.pull_request.head.ref }}`,
 			shouldDetect: false,
 			description:  "push should not be detected as privileged (critical rule)",
 		},
@@ -84,7 +97,7 @@ func TestArgumentInjection_PrivilegedTriggers(t *testing.T) {
 					{
 						Exec: &ast.ExecRun{
 							Run: &ast.String{
-								Value: `git diff ${{ github.event.pull_request.head.ref }}`,
+								Value: tt.runScript,
 								Pos:   &ast.Position{Line: 1, Col: 1},
 							},
 						},
@@ -432,6 +445,13 @@ func TestArgumentInjection_MediumRule(t *testing.T) {
 			runScript:   `git diff ${{ github.event.pull_request.head.ref }}`,
 			wantErrors:  0,
 			description: "Should not detect in privileged triggers (that's for critical rule)",
+		},
+		{
+			name:        "pull_request_review should not trigger medium rule",
+			trigger:     "pull_request_review",
+			runScript:   `git diff ${{ github.event.review.body }}`,
+			wantErrors:  0,
+			description: "Should not detect pull_request_review in medium rule",
 		},
 	}
 

--- a/pkg/core/argumentinjection_test.go
+++ b/pkg/core/argumentinjection_test.go
@@ -54,11 +54,11 @@ func TestArgumentInjection_PrivilegedTriggers(t *testing.T) {
 			description:  "issue_comment should be detected as privileged",
 		},
 		{
-			name:         "pull_request_review is privileged",
+			name:         "pull_request_review is normal",
 			trigger:      "pull_request_review",
 			runScript:    `git diff ${{ github.event.review.body }}`,
-			shouldDetect: true,
-			description:  "pull_request_review should be detected as privileged (review body is attacker-controlled)",
+			shouldDetect: false,
+			description:  "pull_request_review should not be detected as privileged",
 		},
 		{
 			name:         "pull_request is not privileged",
@@ -447,11 +447,11 @@ func TestArgumentInjection_MediumRule(t *testing.T) {
 			description: "Should not detect in privileged triggers (that's for critical rule)",
 		},
 		{
-			name:        "pull_request_review should not trigger medium rule",
+			name:        "pull_request_review trigger + untrusted input",
 			trigger:     "pull_request_review",
 			runScript:   `git diff ${{ github.event.review.body }}`,
-			wantErrors:  0,
-			description: "Should not detect pull_request_review in medium rule",
+			wantErrors:  1,
+			description: "Should detect pull_request_review in medium rule",
 		},
 	}
 

--- a/pkg/core/privilegedtriggers.go
+++ b/pkg/core/privilegedtriggers.go
@@ -6,9 +6,11 @@ import (
 	"github.com/sisaku-security/sisakulint/pkg/ast"
 )
 
-// PrivilegedTriggers contains the list of workflow triggers that grant elevated privileges.
-// These triggers have write access to the repository or can access secrets, making them
-// potentially dangerous when combined with untrusted input.
+// PrivilegedTriggers contains the workflow triggers that shared security rules
+// treat as privileged or otherwise high risk. Most grant write access to the
+// repository or can access secrets, making them dangerous when combined with
+// untrusted input. Rules with narrower severity semantics can use a smaller
+// trigger set.
 //
 // References:
 // - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
@@ -19,7 +21,20 @@ var PrivilegedTriggers = map[string]bool{
 	"issue_comment":       true, // Triggered by untrusted issue/PR comments
 	"issues":              true, // Can be triggered by external users
 	"discussion_comment":  true, // Triggered by untrusted discussion comments
-	"pull_request_review": true, // Review body is attacker-controlled; runs in base repo context with secrets access
+	"pull_request_review": true, // Review body is attacker-controlled; some rules treat it as high risk
+}
+
+// privilegedTriggersForCriticalInjection contains the trigger set used by
+// argument-injection and request-forgery to route findings to critical severity.
+// pull_request_review is intentionally excluded: it carries attacker-controlled
+// review input, but it runs on the PR merge ref and forked PR runs do not receive
+// secrets and have a read-only GITHUB_TOKEN, so these findings remain medium.
+var privilegedTriggersForCriticalInjection = map[string]bool{
+	"pull_request_target": true,
+	"workflow_run":        true,
+	"issue_comment":       true,
+	"issues":              true,
+	"discussion_comment":  true,
 }
 
 // HasPrivilegedTriggers checks if a workflow has any privileged triggers.
@@ -36,13 +51,21 @@ var PrivilegedTriggers = map[string]bool{
 //	    // Handle privileged workflow
 //	}
 func HasPrivilegedTriggers(workflow *ast.Workflow) bool {
+	return hasAnyWorkflowTrigger(workflow, PrivilegedTriggers)
+}
+
+func hasPrivilegedTriggersForCriticalInjection(workflow *ast.Workflow) bool {
+	return hasAnyWorkflowTrigger(workflow, privilegedTriggersForCriticalInjection)
+}
+
+func hasAnyWorkflowTrigger(workflow *ast.Workflow, triggers map[string]bool) bool {
 	if workflow == nil || workflow.On == nil {
 		return false
 	}
 
 	for _, event := range workflow.On {
 		eventName := strings.ToLower(event.EventName())
-		if PrivilegedTriggers[eventName] {
+		if triggers[eventName] {
 			return true
 		}
 	}

--- a/pkg/core/requestforgery.go
+++ b/pkg/core/requestforgery.go
@@ -471,7 +471,7 @@ func (rule *RequestForgeryRule) VisitWorkflowPost(node *ast.Workflow) error {
 }
 
 func (rule *RequestForgeryRule) hasPrivilegedTriggers() bool {
-	return HasPrivilegedTriggers(rule.workflow)
+	return hasPrivilegedTriggersForCriticalInjection(rule.workflow)
 }
 
 func (rule *RequestForgeryRule) RuleNames() string {

--- a/pkg/core/requestforgery.go
+++ b/pkg/core/requestforgery.go
@@ -81,7 +81,7 @@ func newRequestForgeryRule(severityLevel string, checkPrivileged bool, wfTaintMa
 	var desc string
 
 	if checkPrivileged {
-		desc = "Checks for Server-Side Request Forgery (SSRF) vulnerabilities when untrusted input is used in network requests with privileged workflow triggers (pull_request_target, workflow_run, issue_comment). Attackers can access internal services, cloud metadata, or pivot to internal networks. See https://cwe.mitre.org/data/definitions/918.html"
+		desc = "Checks for Server-Side Request Forgery (SSRF) vulnerabilities when untrusted input is used in network requests with privileged workflow triggers. Attackers can access internal services, cloud metadata, or pivot to internal networks. See https://cwe.mitre.org/data/definitions/918.html"
 	} else {
 		desc = "Checks for Server-Side Request Forgery (SSRF) vulnerabilities when untrusted input is used in network requests with normal workflow triggers (pull_request, push, etc.). Attackers can access internal services, cloud metadata, or pivot to internal networks. See https://cwe.mitre.org/data/definitions/918.html"
 	}
@@ -471,26 +471,7 @@ func (rule *RequestForgeryRule) VisitWorkflowPost(node *ast.Workflow) error {
 }
 
 func (rule *RequestForgeryRule) hasPrivilegedTriggers() bool {
-	if rule.workflow == nil || rule.workflow.On == nil {
-		return false
-	}
-
-	privilegedTriggers := map[string]bool{
-		"pull_request_target": true,
-		"workflow_run":        true,
-		"issue_comment":       true,
-		"issues":              true,
-		"discussion_comment":  true,
-	}
-
-	for _, event := range rule.workflow.On {
-		eventName := strings.ToLower(event.EventName())
-		if privilegedTriggers[eventName] {
-			return true
-		}
-	}
-
-	return false
+	return HasPrivilegedTriggers(rule.workflow)
 }
 
 func (rule *RequestForgeryRule) RuleNames() string {

--- a/pkg/core/requestforgery_test.go
+++ b/pkg/core/requestforgery_test.go
@@ -57,11 +57,11 @@ func TestRequestForgeryCritical_PrivilegedTriggers(t *testing.T) {
 			description:  "issues should be detected as privileged",
 		},
 		{
-			name:         "pull_request_review is privileged",
+			name:         "pull_request_review is normal",
 			trigger:      "pull_request_review",
 			runScript:    `curl "${{ github.event.review.body }}"`,
-			shouldDetect: true,
-			description:  "pull_request_review should be detected as privileged (review body is attacker-controlled)",
+			shouldDetect: false,
+			description:  "pull_request_review should not be detected as privileged",
 		},
 		{
 			name:         "pull_request is not privileged",
@@ -397,11 +397,11 @@ func TestRequestForgeryMedium_NormalTriggers(t *testing.T) {
 			description:  "issue_comment should not be detected by medium rule",
 		},
 		{
-			name:         "pull_request_review is privileged",
+			name:         "pull_request_review is normal",
 			trigger:      "pull_request_review",
 			runScript:    `curl "${{ github.event.review.body }}"`,
-			shouldDetect: false,
-			description:  "pull_request_review should not be detected by medium rule",
+			shouldDetect: true,
+			description:  "pull_request_review should be detected by medium rule",
 		},
 	}
 

--- a/pkg/core/requestforgery_test.go
+++ b/pkg/core/requestforgery_test.go
@@ -24,42 +24,56 @@ func TestRequestForgeryCritical_PrivilegedTriggers(t *testing.T) {
 	tests := []struct {
 		name         string
 		trigger      string
+		runScript    string
 		shouldDetect bool
 		description  string
 	}{
 		{
 			name:         "pull_request_target is privileged",
 			trigger:      "pull_request_target",
+			runScript:    `curl "${{ github.event.issue.body }}"`,
 			shouldDetect: true,
 			description:  "pull_request_target should be detected as privileged",
 		},
 		{
 			name:         "workflow_run is privileged",
 			trigger:      "workflow_run",
+			runScript:    `curl "${{ github.event.issue.body }}"`,
 			shouldDetect: true,
 			description:  "workflow_run should be detected as privileged",
 		},
 		{
 			name:         "issue_comment is privileged",
 			trigger:      "issue_comment",
+			runScript:    `curl "${{ github.event.issue.body }}"`,
 			shouldDetect: true,
 			description:  "issue_comment should be detected as privileged",
 		},
 		{
 			name:         "issues is privileged",
 			trigger:      "issues",
+			runScript:    `curl "${{ github.event.issue.body }}"`,
 			shouldDetect: true,
 			description:  "issues should be detected as privileged",
 		},
 		{
+			name:         "pull_request_review is privileged",
+			trigger:      "pull_request_review",
+			runScript:    `curl "${{ github.event.review.body }}"`,
+			shouldDetect: true,
+			description:  "pull_request_review should be detected as privileged (review body is attacker-controlled)",
+		},
+		{
 			name:         "pull_request is not privileged",
 			trigger:      "pull_request",
+			runScript:    `curl "${{ github.event.issue.body }}"`,
 			shouldDetect: false,
 			description:  "pull_request should not be detected as privileged",
 		},
 		{
 			name:         "push is not privileged",
 			trigger:      "push",
+			runScript:    `curl "${{ github.event.issue.body }}"`,
 			shouldDetect: false,
 			description:  "push should not be detected as privileged",
 		},
@@ -82,7 +96,7 @@ func TestRequestForgeryCritical_PrivilegedTriggers(t *testing.T) {
 					{
 						Exec: &ast.ExecRun{
 							Run: &ast.String{
-								Value: `curl "${{ github.event.issue.body }}"`,
+								Value: tt.runScript,
 								Pos:   &ast.Position{Line: 1, Col: 1},
 							},
 						},
@@ -343,38 +357,51 @@ func TestRequestForgeryMedium_NormalTriggers(t *testing.T) {
 	tests := []struct {
 		name         string
 		trigger      string
+		runScript    string
 		shouldDetect bool
 		description  string
 	}{
 		{
 			name:         "pull_request is normal trigger",
 			trigger:      "pull_request",
+			runScript:    `curl "${{ github.event.pull_request.body }}"`,
 			shouldDetect: true,
 			description:  "pull_request should be detected by medium rule",
 		},
 		{
 			name:         "push is normal trigger",
 			trigger:      "push",
+			runScript:    `curl "${{ github.event.pull_request.body }}"`,
 			shouldDetect: true,
 			description:  "push should be detected by medium rule",
 		},
 		{
 			name:         "schedule is normal trigger",
 			trigger:      "schedule",
+			runScript:    `curl "${{ github.event.pull_request.body }}"`,
 			shouldDetect: true,
 			description:  "schedule should be detected by medium rule",
 		},
 		{
 			name:         "pull_request_target is privileged",
 			trigger:      "pull_request_target",
+			runScript:    `curl "${{ github.event.pull_request.body }}"`,
 			shouldDetect: false,
 			description:  "pull_request_target should not be detected by medium rule",
 		},
 		{
 			name:         "issue_comment is privileged",
 			trigger:      "issue_comment",
+			runScript:    `curl "${{ github.event.pull_request.body }}"`,
 			shouldDetect: false,
 			description:  "issue_comment should not be detected by medium rule",
+		},
+		{
+			name:         "pull_request_review is privileged",
+			trigger:      "pull_request_review",
+			runScript:    `curl "${{ github.event.review.body }}"`,
+			shouldDetect: false,
+			description:  "pull_request_review should not be detected by medium rule",
 		},
 	}
 
@@ -395,7 +422,7 @@ func TestRequestForgeryMedium_NormalTriggers(t *testing.T) {
 					{
 						Exec: &ast.ExecRun{
 							Run: &ast.String{
-								Value: `curl "${{ github.event.pull_request.body }}"`,
+								Value: tt.runScript,
 								Pos:   &ast.Position{Line: 1, Col: 1},
 							},
 						},

--- a/pkg/core/requestforgerycritical.go
+++ b/pkg/core/requestforgerycritical.go
@@ -1,8 +1,7 @@
 package core
 
 // RequestForgeryCriticalRule creates a critical severity request forgery rule
-// that checks for SSRF vulnerabilities in workflows with privileged triggers
-// (pull_request_target, workflow_run, issue_comment)
+// that checks for SSRF vulnerabilities in workflows with privileged triggers.
 func RequestForgeryCriticalRule(wfTaintMap *WorkflowTaintMap) *RequestForgeryRule {
 	return newRequestForgeryRule("critical", true, wfTaintMap)
 }

--- a/pkg/core/visitor.go
+++ b/pkg/core/visitor.go
@@ -3,6 +3,8 @@ package core
 import (
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/sisaku-security/sisakulint/pkg/ast"
@@ -64,7 +66,7 @@ func (s *SyntaxTreeVisitor) VisitTree(node *ast.Workflow) error {
 		startTime = time.Now()
 	}
 
-	for _, job := range node.Jobs {
+	for _, job := range orderedWorkflowJobs(node) {
 		if err := s.visitJob(job); err != nil {
 			return err
 		}
@@ -87,6 +89,147 @@ func (s *SyntaxTreeVisitor) VisitTree(node *ast.Workflow) error {
 	}
 
 	return nil
+}
+
+// orderedWorkflowJobs returns a deterministic job visit order: source order
+// among currently runnable jobs, with declared needs visited before dependents.
+func orderedWorkflowJobs(node *ast.Workflow) []*ast.Job {
+	if node == nil || len(node.Jobs) == 0 {
+		return nil
+	}
+
+	jobs := make([]*ast.Job, 0, len(node.Jobs))
+	byID := make(map[string]*ast.Job, len(node.Jobs))
+	for id, job := range node.Jobs {
+		if job == nil {
+			continue
+		}
+		jobs = append(jobs, job)
+		if normalizedID := normalizeJobID(id); normalizedID != "" {
+			byID[normalizedID] = job
+		}
+		if job.ID != nil {
+			if normalizedID := normalizeJobID(job.ID.Value); normalizedID != "" {
+				byID[normalizedID] = job
+			}
+		}
+	}
+
+	sort.SliceStable(jobs, func(i, j int) bool {
+		return jobSourceLess(jobs[i], jobs[j])
+	})
+
+	indegree := make(map[*ast.Job]int, len(jobs))
+	dependents := make(map[*ast.Job][]*ast.Job, len(jobs))
+	for _, job := range jobs {
+		indegree[job] = 0
+	}
+	for _, job := range jobs {
+		seenDeps := make(map[*ast.Job]bool)
+		for _, need := range job.Needs {
+			if need == nil {
+				continue
+			}
+			dep := byID[normalizeJobID(need.Value)]
+			if dep == nil || seenDeps[dep] {
+				continue
+			}
+			seenDeps[dep] = true
+			indegree[job]++
+			dependents[dep] = append(dependents[dep], job)
+		}
+	}
+
+	queued := make(map[*ast.Job]bool, len(jobs))
+	ready := make([]*ast.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if indegree[job] == 0 {
+			ready = append(ready, job)
+			queued[job] = true
+		}
+	}
+
+	var ordered []*ast.Job
+	emitted := make(map[*ast.Job]bool, len(jobs))
+	for len(ordered) < len(jobs) {
+		if len(ready) == 0 {
+			// Cycles and invalid self-dependencies are reported elsewhere. Keep
+			// traversal total by falling back to source order for remaining jobs.
+			for _, job := range jobs {
+				if !emitted[job] {
+					ready = append(ready, job)
+					queued[job] = true
+					break
+				}
+			}
+		}
+
+		sort.SliceStable(ready, func(i, j int) bool {
+			return jobSourceLess(ready[i], ready[j])
+		})
+
+		job := ready[0]
+		ready = ready[1:]
+		queued[job] = false
+		if emitted[job] {
+			continue
+		}
+
+		emitted[job] = true
+		ordered = append(ordered, job)
+		for _, dependent := range dependents[job] {
+			if emitted[dependent] {
+				continue
+			}
+			if indegree[dependent] > 0 {
+				indegree[dependent]--
+			}
+			if indegree[dependent] == 0 && !queued[dependent] {
+				ready = append(ready, dependent)
+				queued[dependent] = true
+			}
+		}
+	}
+
+	return ordered
+}
+
+func normalizeJobID(id string) string {
+	return strings.ToLower(id)
+}
+
+func jobSourceLess(a, b *ast.Job) bool {
+	aPos := jobPosition(a)
+	bPos := jobPosition(b)
+	if aPos != nil && bPos != nil {
+		if aPos.Line != bPos.Line {
+			return aPos.Line < bPos.Line
+		}
+		if aPos.Col != bPos.Col {
+			return aPos.Col < bPos.Col
+		}
+	}
+	if aPos != nil && bPos == nil {
+		return true
+	}
+	if aPos == nil && bPos != nil {
+		return false
+	}
+	return jobSortID(a) < jobSortID(b)
+}
+
+func jobPosition(job *ast.Job) *ast.Position {
+	if job == nil {
+		return nil
+	}
+	return job.Pos
+}
+
+func jobSortID(job *ast.Job) string {
+	if job == nil || job.ID == nil {
+		return ""
+	}
+	return job.ID.Value
 }
 
 // visitJobはjobを訪問する

--- a/pkg/core/visitor_order_test.go
+++ b/pkg/core/visitor_order_test.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+func TestOrderedWorkflowJobsPreservesSourceOrderWithoutNeeds(t *testing.T) {
+	t.Parallel()
+
+	workflow := &ast.Workflow{
+		Jobs: map[string]*ast.Job{
+			"second": {
+				ID:  &ast.String{Value: "second"},
+				Pos: &ast.Position{Line: 20, Col: 3},
+			},
+			"first": {
+				ID:  &ast.String{Value: "first"},
+				Pos: &ast.Position{Line: 10, Col: 3},
+			},
+		},
+	}
+
+	got := orderedWorkflowJobs(workflow)
+	assertJobOrder(t, got, []string{"first", "second"})
+}
+
+func TestOrderedWorkflowJobsVisitsNeedsBeforeDependents(t *testing.T) {
+	t.Parallel()
+
+	workflow := &ast.Workflow{
+		Jobs: map[string]*ast.Job{
+			"job-a": {
+				ID:  &ast.String{Value: "job-a"},
+				Pos: &ast.Position{Line: 40, Col: 3},
+			},
+			"independent": {
+				ID:  &ast.String{Value: "independent"},
+				Pos: &ast.Position{Line: 10, Col: 3},
+			},
+			"job-c": {
+				ID: &ast.String{Value: "job-c"},
+				Needs: []*ast.String{
+					{Value: "job-b"},
+				},
+				Pos: &ast.Position{Line: 30, Col: 3},
+			},
+			"job-b": {
+				ID: &ast.String{Value: "job-b"},
+				Needs: []*ast.String{
+					{Value: "job-a"},
+				},
+				Pos: &ast.Position{Line: 20, Col: 3},
+			},
+		},
+	}
+
+	got := orderedWorkflowJobs(workflow)
+	assertJobOrder(t, got, []string{"independent", "job-a", "job-b", "job-c"})
+}
+
+func TestOrderedWorkflowJobsUsesSourceOrderForReadyJobs(t *testing.T) {
+	t.Parallel()
+
+	workflow := &ast.Workflow{
+		Jobs: map[string]*ast.Job{
+			"dependent": {
+				ID: &ast.String{Value: "dependent"},
+				Needs: []*ast.String{
+					{Value: "dependency"},
+				},
+				Pos: &ast.Position{Line: 10, Col: 3},
+			},
+			"independent": {
+				ID:  &ast.String{Value: "independent"},
+				Pos: &ast.Position{Line: 20, Col: 3},
+			},
+			"dependency": {
+				ID:  &ast.String{Value: "dependency"},
+				Pos: &ast.Position{Line: 30, Col: 3},
+			},
+		},
+	}
+
+	got := orderedWorkflowJobs(workflow)
+	assertJobOrder(t, got, []string{"independent", "dependency", "dependent"})
+}
+
+func assertJobOrder(t *testing.T, jobs []*ast.Job, want []string) {
+	t.Helper()
+
+	if len(jobs) != len(want) {
+		t.Fatalf("got %d jobs, want %d", len(jobs), len(want))
+	}
+
+	for i, job := range jobs {
+		if job == nil || job.ID == nil {
+			t.Fatalf("job %d missing ID: %#v", i, job)
+		}
+		if job.ID.Value != want[i] {
+			t.Fatalf("job %d = %q, want %q", i, job.ID.Value, want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Route argument-injection and request-forgery privileged trigger checks through the shared `HasPrivilegedTriggers()` helper.
- Add `pull_request_review` regression coverage for critical detection and medium-rule exclusion.
- Update affected docs/comments so their privileged trigger descriptions match the shared trigger set.
- Stabilize job traversal with deterministic `needs`-aware ordering so multi-hop cross-job taint checks do not depend on Go map iteration order.

Fixes #505.

## Validation

- `go test ./pkg/core -run 'TestOrderedWorkflowJobs|TestCrossJobTaintPropagation' -count=50`
- `go test ./pkg/core -run 'TestArgumentInjection_PrivilegedTriggers|TestArgumentInjection_MediumRule|TestRequestForgeryCritical_PrivilegedTriggers|TestRequestForgeryMedium_NormalTriggers' -count=1`
- `go test ./... -count=1`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSRF検知が追加トリガー（pull_request_review、issues、discussion_comment）に対応しました
  * 引数インジェクションのクリティカル判定では pull_request_review を特権扱いから除外しました（ミドル判定では検出されます）

* **Tests**
  * 上記トリガー挙動を検証するテストケースを追加・拡張しました

* **Refactor**
  * ジョブ走査順を依存関係に基づく決定的な順序へ改善しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->