### PR TITLE
fix github-script autofix quotes

### DIFF
--- a/pkg/core/codeinjection.go
+++ b/pkg/core/codeinjection.go
@@ -434,7 +434,7 @@ func (rule *CodeInjectionRule) FixStep(step *ast.Step) error {
 				continue
 			}
 			if untrustedInfo.scriptInput != nil && untrustedInfo.scriptInput.Value != nil {
-				untrustedInfo.scriptInput.Value.Value = applyStringReplacements(
+				untrustedInfo.scriptInput.Value.Value = applyGitHubScriptReplacements(
 					untrustedInfo.scriptInput.Value.Value,
 					scriptReplacements,
 				)

--- a/pkg/core/codeinjection_autofix_test.go
+++ b/pkg/core/codeinjection_autofix_test.go
@@ -369,4 +369,16 @@ func TestCodeInjectionCritical_AutoFix_GitHubScript_YAMLOutput(t *testing.T) {
 	if !strings.Contains(yamlOutput, "process.env.COMMENT_BODY") {
 		t.Errorf("YAML output should contain process.env.COMMENT_BODY, got:\n%s", yamlOutput)
 	}
+	if strings.Contains(yamlOutput, "'process.env.COMMENT_BODY'") || strings.Contains(yamlOutput, `"process.env.COMMENT_BODY"`) {
+		t.Errorf("YAML output should use process.env.COMMENT_BODY as a JS expression, got:\n%s", yamlOutput)
+	}
+	if !strings.Contains(yamlOutput, "console.log(process.env.COMMENT_BODY)") {
+		t.Errorf("YAML output should strip string-literal quotes around process.env.COMMENT_BODY, got:\n%s", yamlOutput)
+	}
+
+	action := step.Exec.(*ast.ExecAction)
+	gotScript := action.Inputs["script"].Value.Value
+	if gotScript != "console.log(process.env.COMMENT_BODY)" {
+		t.Errorf("AST script = %q, want %q", gotScript, "console.log(process.env.COMMENT_BODY)")
+	}
 }

--- a/pkg/core/codeinjection_autofix_test.go
+++ b/pkg/core/codeinjection_autofix_test.go
@@ -382,3 +382,76 @@ func TestCodeInjectionCritical_AutoFix_GitHubScript_YAMLOutput(t *testing.T) {
 		t.Errorf("AST script = %q, want %q", gotScript, "console.log(process.env.COMMENT_BODY)")
 	}
 }
+
+func TestCodeInjectionCritical_AutoFix_GitHubScript_ObjectKey(t *testing.T) {
+	rule := CodeInjectionCriticalRule(nil)
+
+	workflow := &ast.Workflow{
+		On: []ast.Event{
+			&ast.WebhookEvent{
+				Hook: &ast.String{Value: "issue_comment"},
+			},
+		},
+	}
+
+	scriptValue := `const headers = { '${{ github.event.issue.body }}': 'x' }`
+	step := &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{Value: "actions/github-script@v6"},
+			Inputs: map[string]*ast.Input{
+				"script": {
+					Name: &ast.String{Value: "script"},
+					Value: &ast.String{
+						Value: scriptValue,
+						Pos:   &ast.Position{Line: 1, Col: 1},
+					},
+				},
+			},
+		},
+		BaseNode: &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "uses"},
+				{Kind: yaml.ScalarNode, Value: "actions/github-script@v6"},
+				{Kind: yaml.ScalarNode, Value: "with"},
+				{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "script"},
+						{Kind: yaml.ScalarNode, Value: scriptValue},
+					},
+				},
+			},
+		},
+	}
+	job := &ast.Job{Steps: []*ast.Step{step}}
+
+	_ = rule.VisitWorkflowPre(workflow)
+	_ = rule.VisitJobPre(job)
+
+	if len(rule.Errors()) == 0 {
+		t.Fatal("Expected errors but got none")
+	}
+	if err := rule.FixStep(step); err != nil {
+		t.Fatalf("FixStep() error = %v", err)
+	}
+
+	wantScript := `const headers = { [process.env.ISSUE_BODY]: 'x' }`
+	action := step.Exec.(*ast.ExecAction)
+	if gotScript := action.Inputs["script"].Value.Value; gotScript != wantScript {
+		t.Errorf("AST script = %q, want %q", gotScript, wantScript)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	if err := enc.Encode(step.BaseNode); err != nil {
+		t.Fatalf("Failed to encode YAML: %v", err)
+	}
+	yamlOutput := buf.String()
+	if !strings.Contains(yamlOutput, "[process.env.ISSUE_BODY]") {
+		t.Errorf("YAML output should contain computed key [process.env.ISSUE_BODY], got:\n%s", yamlOutput)
+	}
+	if strings.Contains(yamlOutput, "{ process.env.ISSUE_BODY:") {
+		t.Errorf("YAML output should not emit process.env.ISSUE_BODY as a bare object key, got:\n%s", yamlOutput)
+	}
+}

--- a/pkg/core/codeinjectionutil.go
+++ b/pkg/core/codeinjectionutil.go
@@ -195,7 +195,7 @@ func applyGitHubScriptReplacements(value string, replacements map[string]string)
 
 		content := value[i+1 : end]
 		if rewritten, changed := rewriteGitHubScriptStringLiteral(content, quote, replacements, keys); changed {
-			if isJSObjectPropertyKeyLiteral(value, i, end) {
+			if isJSComputedPropertyNameLiteral(value, i, end) {
 				rewritten = "[" + rewritten + "]"
 			}
 			builder.WriteString(rewritten)
@@ -231,9 +231,9 @@ func findJSBlockCommentEnd(value string, start int) int {
 	return len(value)
 }
 
-func isJSObjectPropertyKeyLiteral(value string, start, end int) bool {
+func isJSComputedPropertyNameLiteral(value string, start, end int) bool {
 	next := nextNonSpaceIndex(value, end+1)
-	if next == -1 || value[next] != ':' {
+	if next == -1 || (value[next] != ':' && value[next] != '(') {
 		return false
 	}
 

--- a/pkg/core/codeinjectionutil.go
+++ b/pkg/core/codeinjectionutil.go
@@ -195,6 +195,9 @@ func applyGitHubScriptReplacements(value string, replacements map[string]string)
 
 		content := value[i+1 : end]
 		if rewritten, changed := rewriteGitHubScriptStringLiteral(content, quote, replacements, keys); changed {
+			if isJSObjectPropertyKeyLiteral(value, i, end) {
+				rewritten = "[" + rewritten + "]"
+			}
 			builder.WriteString(rewritten)
 		} else {
 			builder.WriteString(value[i : end+1])
@@ -226,6 +229,40 @@ func findJSBlockCommentEnd(value string, start int) int {
 		return start + end + len("*/")
 	}
 	return len(value)
+}
+
+func isJSObjectPropertyKeyLiteral(value string, start, end int) bool {
+	next := nextNonSpaceIndex(value, end+1)
+	if next == -1 || value[next] != ':' {
+		return false
+	}
+
+	prev := prevNonSpaceIndex(value, start-1)
+	return prev != -1 && (value[prev] == '{' || value[prev] == ',')
+}
+
+func nextNonSpaceIndex(value string, start int) int {
+	for i := start; i < len(value); i++ {
+		switch value[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return i
+		}
+	}
+	return -1
+}
+
+func prevNonSpaceIndex(value string, start int) int {
+	for i := start; i >= 0; i-- {
+		switch value[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return i
+		}
+	}
+	return -1
 }
 
 func findJSStringLiteralEnd(value string, start int, quote byte) (int, bool) {

--- a/pkg/core/codeinjectionutil.go
+++ b/pkg/core/codeinjectionutil.go
@@ -115,7 +115,7 @@ func ReplaceInGitHubScript(stepNode *yaml.Node, replacements map[string]string) 
 					scriptNode := withNode.Content[j+1]
 					if scriptNode.Kind == yaml.ScalarNode {
 						// Apply all replacements
-						scriptNode.Value = applyStringReplacements(scriptNode.Value, replacements)
+						scriptNode.Value = applyGitHubScriptReplacements(scriptNode.Value, replacements)
 					}
 					return nil
 				}
@@ -128,6 +128,18 @@ func ReplaceInGitHubScript(stepNode *yaml.Node, replacements map[string]string) 
 }
 
 func applyStringReplacements(value string, replacements map[string]string) string {
+	keys := sortedReplacementKeys(replacements)
+	return applyStringReplacementsWithKeys(value, replacements, keys)
+}
+
+func applyStringReplacementsWithKeys(value string, replacements map[string]string, keys []string) string {
+	for _, oldExpr := range keys {
+		value = strings.ReplaceAll(value, oldExpr, replacements[oldExpr])
+	}
+	return value
+}
+
+func sortedReplacementKeys(replacements map[string]string) []string {
 	keys := make([]string, 0, len(replacements))
 	for oldExpr := range replacements {
 		keys = append(keys, oldExpr)
@@ -135,8 +147,170 @@ func applyStringReplacements(value string, replacements map[string]string) strin
 	sort.Slice(keys, func(i, j int) bool {
 		return len(keys[i]) > len(keys[j])
 	})
-	for _, oldExpr := range keys {
-		value = strings.ReplaceAll(value, oldExpr, replacements[oldExpr])
+	return keys
+}
+
+func applyGitHubScriptReplacements(value string, replacements map[string]string) string {
+	if len(replacements) == 0 || value == "" {
+		return value
 	}
-	return value
+
+	keys := sortedReplacementKeys(replacements)
+	var builder strings.Builder
+	last := 0
+
+	for i := 0; i < len(value); {
+		if i+1 < len(value) && value[i] == '/' {
+			if value[i+1] == '/' {
+				end := findJSLineCommentEnd(value, i+2)
+				builder.WriteString(applyStringReplacementsWithKeys(value[last:i], replacements, keys))
+				builder.WriteString(applyStringReplacementsWithKeys(value[i:end], replacements, keys))
+				i = end
+				last = i
+				continue
+			}
+			if value[i+1] == '*' {
+				end := findJSBlockCommentEnd(value, i+2)
+				builder.WriteString(applyStringReplacementsWithKeys(value[last:i], replacements, keys))
+				builder.WriteString(applyStringReplacementsWithKeys(value[i:end], replacements, keys))
+				i = end
+				last = i
+				continue
+			}
+		}
+
+		quote := value[i]
+		if quote != '\'' && quote != '"' && quote != '`' {
+			i++
+			continue
+		}
+
+		end, ok := findJSStringLiteralEnd(value, i, quote)
+		if !ok {
+			i++
+			continue
+		}
+
+		builder.WriteString(applyStringReplacementsWithKeys(value[last:i], replacements, keys))
+
+		content := value[i+1 : end]
+		if rewritten, changed := rewriteGitHubScriptStringLiteral(content, quote, replacements, keys); changed {
+			builder.WriteString(rewritten)
+		} else {
+			builder.WriteString(value[i : end+1])
+		}
+
+		i = end + 1
+		last = i
+	}
+
+	if last == 0 {
+		return applyStringReplacementsWithKeys(value, replacements, keys)
+	}
+
+	builder.WriteString(applyStringReplacementsWithKeys(value[last:], replacements, keys))
+	return builder.String()
+}
+
+func findJSLineCommentEnd(value string, start int) int {
+	for i := start; i < len(value); i++ {
+		if value[i] == '\n' || value[i] == '\r' {
+			return i
+		}
+	}
+	return len(value)
+}
+
+func findJSBlockCommentEnd(value string, start int) int {
+	if end := strings.Index(value[start:], "*/"); end >= 0 {
+		return start + end + len("*/")
+	}
+	return len(value)
+}
+
+func findJSStringLiteralEnd(value string, start int, quote byte) (int, bool) {
+	for i := start + 1; i < len(value); i++ {
+		if value[i] == '\\' {
+			i++
+			continue
+		}
+		if value[i] == quote {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+type githubScriptLiteralPart struct {
+	value        string
+	isExpression bool
+}
+
+func rewriteGitHubScriptStringLiteral(content string, quote byte, replacements map[string]string, keys []string) (string, bool) {
+	parts, changed := splitGitHubScriptStringLiteral(content, replacements, keys)
+	if !changed {
+		return "", false
+	}
+
+	terms := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part.value == "" {
+			continue
+		}
+		if part.isExpression {
+			terms = append(terms, part.value)
+			continue
+		}
+		terms = append(terms, quoteJSStringSegment(part.value, quote))
+	}
+	if len(terms) == 0 {
+		return "", false
+	}
+
+	return strings.Join(terms, " + "), true
+}
+
+func splitGitHubScriptStringLiteral(content string, replacements map[string]string, keys []string) ([]githubScriptLiteralPart, bool) {
+	parts := make([]githubScriptLiteralPart, 0)
+	segmentStart := 0
+	changed := false
+
+	for i := 0; i < len(content); {
+		matchedKey := ""
+		for _, key := range keys {
+			if strings.HasPrefix(content[i:], key) {
+				matchedKey = key
+				break
+			}
+		}
+
+		if matchedKey == "" {
+			i++
+			continue
+		}
+
+		if segmentStart < i {
+			parts = append(parts, githubScriptLiteralPart{value: content[segmentStart:i]})
+		}
+		parts = append(parts, githubScriptLiteralPart{
+			value:        replacements[matchedKey],
+			isExpression: true,
+		})
+		i += len(matchedKey)
+		segmentStart = i
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+	if segmentStart < len(content) {
+		parts = append(parts, githubScriptLiteralPart{value: content[segmentStart:]})
+	}
+
+	return parts, true
+}
+
+func quoteJSStringSegment(value string, quote byte) string {
+	return string(quote) + value + string(quote)
 }

--- a/pkg/core/codeinjectionutil_test.go
+++ b/pkg/core/codeinjectionutil_test.go
@@ -45,6 +45,16 @@ fetch('${{ github.event.issue.body }}')`,
 			want: `// user's supplied URL
 fetch(process.env.ISSUE_BODY)`,
 		},
+		{
+			name:   "object literal key becomes computed property key",
+			script: `const headers = { '${{ github.event.issue.body }}': 'x' }`,
+			want:   `const headers = { [process.env.ISSUE_BODY]: 'x' }`,
+		},
+		{
+			name:   "embedded object literal key becomes computed property key",
+			script: `const headers = { 'prefix-${{ github.event.issue.body }}': 'x' }`,
+			want:   `const headers = { ['prefix-' + process.env.ISSUE_BODY]: 'x' }`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/core/codeinjectionutil_test.go
+++ b/pkg/core/codeinjectionutil_test.go
@@ -55,6 +55,21 @@ fetch(process.env.ISSUE_BODY)`,
 			script: `const headers = { 'prefix-${{ github.event.issue.body }}': 'x' }`,
 			want:   `const headers = { ['prefix-' + process.env.ISSUE_BODY]: 'x' }`,
 		},
+		{
+			name:   "object literal method name becomes computed method name",
+			script: `const handlers = { '${{ github.event.issue.body }}'() {} }`,
+			want:   `const handlers = { [process.env.ISSUE_BODY]() {} }`,
+		},
+		{
+			name:   "embedded object literal method name becomes computed method name",
+			script: `const handlers = { 'prefix-${{ github.event.issue.body }}'() {} }`,
+			want:   `const handlers = { ['prefix-' + process.env.ISSUE_BODY]() {} }`,
+		},
+		{
+			name:   "class method name becomes computed method name",
+			script: `class Handler { '${{ github.event.issue.body }}'() {} }`,
+			want:   `class Handler { [process.env.ISSUE_BODY]() {} }`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/core/codeinjectionutil_test.go
+++ b/pkg/core/codeinjectionutil_test.go
@@ -1,0 +1,58 @@
+package core
+
+import "testing"
+
+func TestApplyGitHubScriptReplacements_StripsStringLiteralQuotes(t *testing.T) {
+	replacements := map[string]string{
+		"${{ github.event.issue.body }}":   "process.env.ISSUE_BODY",
+		"${{ github.event.comment.body }}": "process.env.COMMENT_BODY",
+	}
+
+	tests := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{
+			name:   "single quoted exact expression",
+			script: `fetch('${{ github.event.issue.body }}')`,
+			want:   `fetch(process.env.ISSUE_BODY)`,
+		},
+		{
+			name:   "double quoted exact expression",
+			script: `axios.get("${{ github.event.comment.body }}")`,
+			want:   `axios.get(process.env.COMMENT_BODY)`,
+		},
+		{
+			name:   "embedded expression preserves surrounding text",
+			script: `console.log('Comment: ${{ github.event.comment.body }}')`,
+			want:   `console.log('Comment: ' + process.env.COMMENT_BODY)`,
+		},
+		{
+			name:   "multiple expressions in one string literal",
+			script: `console.log('${{ github.event.issue.body }} / ${{ github.event.comment.body }}')`,
+			want:   `console.log(process.env.ISSUE_BODY + ' / ' + process.env.COMMENT_BODY)`,
+		},
+		{
+			name:   "unquoted expression remains a direct replacement",
+			script: `console.log(${{ github.event.comment.body }})`,
+			want:   `console.log(process.env.COMMENT_BODY)`,
+		},
+		{
+			name: "single quote in line comment does not hide later string literal",
+			script: `// user's supplied URL
+fetch('${{ github.event.issue.body }}')`,
+			want: `// user's supplied URL
+fetch(process.env.ISSUE_BODY)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyGitHubScriptReplacements(tt.script, replacements)
+			if got != tt.want {
+				t.Fatalf("applyGitHubScriptReplacements() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/core/cross_file_taint.go
+++ b/pkg/core/cross_file_taint.go
@@ -265,14 +265,18 @@ func (f *ChainFixer) FixStep(step *ast.Step) error {
 					fmt.Sprintf("${{%s}}", sink.InputPath), "$"+envName)
 			}
 		case SinkGitHubScript:
-			scriptReplacements[fmt.Sprintf("${{ %s }}", sink.InputPath)] = "process.env." + envName
-			scriptReplacements[fmt.Sprintf("${{%s}}", sink.InputPath)] = "process.env." + envName
+			spacedExpr := fmt.Sprintf("${{ %s }}", sink.InputPath)
+			compactExpr := fmt.Sprintf("${{%s}}", sink.InputPath)
+			envRef := "process.env." + envName
+			scriptReplacements[spacedExpr] = envRef
+			scriptReplacements[compactExpr] = envRef
 			if action, ok := step.Exec.(*ast.ExecAction); ok {
 				if scriptInput, ok := action.Inputs["script"]; ok && scriptInput != nil && scriptInput.Value != nil {
-					scriptInput.Value.Value = strings.ReplaceAll(scriptInput.Value.Value,
-						fmt.Sprintf("${{ %s }}", sink.InputPath), "process.env."+envName)
-					scriptInput.Value.Value = strings.ReplaceAll(scriptInput.Value.Value,
-						fmt.Sprintf("${{%s}}", sink.InputPath), "process.env."+envName)
+					scriptInput.Value.Value = applyGitHubScriptReplacements(scriptInput.Value.Value,
+						map[string]string{
+							spacedExpr:  envRef,
+							compactExpr: envRef,
+						})
 				}
 			}
 		}

--- a/pkg/core/requestforgery.go
+++ b/pkg/core/requestforgery.go
@@ -556,20 +556,20 @@ func (rule *RequestForgeryRule) FixStep(step *ast.Step) error {
 				)
 			}
 		} else if step.Exec.Kind() == ast.ExecKindAction {
-			scriptReplacements[fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw)] = fmt.Sprintf("process.env.%s", envVarName)
-			scriptReplacements[fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw)] = fmt.Sprintf("process.env.%s", envVarName)
+			spacedExpr := fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw)
+			compactExpr := fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw)
+			envRef := fmt.Sprintf("process.env.%s", envVarName)
+			scriptReplacements[spacedExpr] = envRef
+			scriptReplacements[compactExpr] = envRef
 
 			action := step.Exec.(*ast.ExecAction)
 			if scriptInput, ok := action.Inputs["script"]; ok && scriptInput != nil && scriptInput.Value != nil {
-				scriptInput.Value.Value = strings.ReplaceAll(
+				scriptInput.Value.Value = applyGitHubScriptReplacements(
 					scriptInput.Value.Value,
-					fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw),
-					fmt.Sprintf("process.env.%s", envVarName),
-				)
-				scriptInput.Value.Value = strings.ReplaceAll(
-					scriptInput.Value.Value,
-					fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw),
-					fmt.Sprintf("process.env.%s", envVarName),
+					map[string]string{
+						spacedExpr:  envRef,
+						compactExpr: envRef,
+					},
 				)
 			}
 		}

--- a/pkg/core/requestforgery_test.go
+++ b/pkg/core/requestforgery_test.go
@@ -1,9 +1,12 @@
 package core
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/sisaku-security/sisakulint/pkg/ast"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRequestForgeryCriticalRule(t *testing.T) {
@@ -534,6 +537,103 @@ func TestRequestForgery_EnvVarName(t *testing.T) {
 			result := rule.generateEnvVarName(tt.path)
 			if result != tt.expected {
 				t.Errorf("generateEnvVarName(%q) = %q, want %q", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRequestForgery_AutoFix_GitHubScript_StripsStringLiteralQuotes(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantScript string
+		wantEnvVar string
+	}{
+		{
+			name:       "fetch URL argument",
+			script:     `const response = await fetch('${{ github.event.issue.body }}');`,
+			wantScript: `const response = await fetch(process.env.ISSUE_BODY);`,
+			wantEnvVar: "ISSUE_BODY",
+		},
+		{
+			name:       "axios URL argument",
+			script:     `const response = axios.get("${{ github.event.comment.body }}");`,
+			wantScript: `const response = axios.get(process.env.COMMENT_BODY);`,
+			wantEnvVar: "COMMENT_BODY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := RequestForgeryCriticalRule(nil)
+			workflow := &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "issue_comment"},
+					},
+				},
+			}
+			step := &ast.Step{
+				Exec: &ast.ExecAction{
+					Uses: &ast.String{Value: "actions/github-script@v6"},
+					Inputs: map[string]*ast.Input{
+						"script": {
+							Name: &ast.String{Value: "script"},
+							Value: &ast.String{
+								Value: tt.script,
+								Pos:   &ast.Position{Line: 1, Col: 1},
+							},
+						},
+					},
+				},
+				BaseNode: &yaml.Node{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "uses"},
+						{Kind: yaml.ScalarNode, Value: "actions/github-script@v6"},
+						{Kind: yaml.ScalarNode, Value: "with"},
+						{
+							Kind: yaml.MappingNode,
+							Content: []*yaml.Node{
+								{Kind: yaml.ScalarNode, Value: "script"},
+								{Kind: yaml.ScalarNode, Value: tt.script},
+							},
+						},
+					},
+				},
+			}
+			job := &ast.Job{Steps: []*ast.Step{step}}
+
+			_ = rule.VisitWorkflowPre(workflow)
+			_ = rule.VisitJobPre(job)
+
+			if len(rule.Errors()) == 0 {
+				t.Fatal("Expected errors but got none")
+			}
+			if err := rule.FixStep(step); err != nil {
+				t.Fatalf("FixStep() error = %v", err)
+			}
+
+			action := step.Exec.(*ast.ExecAction)
+			gotScript := action.Inputs["script"].Value.Value
+			if gotScript != tt.wantScript {
+				t.Errorf("AST script = %q, want %q", gotScript, tt.wantScript)
+			}
+
+			var buf bytes.Buffer
+			enc := yaml.NewEncoder(&buf)
+			if err := enc.Encode(step.BaseNode); err != nil {
+				t.Fatalf("Failed to encode YAML: %v", err)
+			}
+			yamlOutput := buf.String()
+			if !strings.Contains(yamlOutput, tt.wantEnvVar+":") {
+				t.Errorf("YAML output should contain env var %q, got:\n%s", tt.wantEnvVar, yamlOutput)
+			}
+			if !strings.Contains(yamlOutput, tt.wantScript) {
+				t.Errorf("YAML output should contain %q, got:\n%s", tt.wantScript, yamlOutput)
+			}
+			if strings.Contains(yamlOutput, "'process.env.") || strings.Contains(yamlOutput, `"process.env.`) {
+				t.Errorf("YAML output should not quote process.env references, got:\n%s", yamlOutput)
 			}
 		})
 	}

--- a/pkg/core/reusable_workflow_taint_rule.go
+++ b/pkg/core/reusable_workflow_taint_rule.go
@@ -561,22 +561,22 @@ func (rule *ReusableWorkflowTaintRule) FixStep(step *ast.Step) error {
 				)
 			}
 		} else {
-			scriptReplacements[fmt.Sprintf("${{ %s }}", taintedInfo.inputPath)] = fmt.Sprintf("process.env.%s", envVarName)
-			scriptReplacements[fmt.Sprintf("${{%s}}", taintedInfo.inputPath)] = fmt.Sprintf("process.env.%s", envVarName)
+			spacedExpr := fmt.Sprintf("${{ %s }}", taintedInfo.inputPath)
+			compactExpr := fmt.Sprintf("${{%s}}", taintedInfo.inputPath)
+			envRef := fmt.Sprintf("process.env.%s", envVarName)
+			scriptReplacements[spacedExpr] = envRef
+			scriptReplacements[compactExpr] = envRef
 
 			// Update AST for github-script
 			if step.Exec.Kind() == ast.ExecKindAction {
 				action := step.Exec.(*ast.ExecAction)
 				if scriptInput, ok := action.Inputs["script"]; ok && scriptInput != nil && scriptInput.Value != nil {
-					scriptInput.Value.Value = strings.ReplaceAll(
+					scriptInput.Value.Value = applyGitHubScriptReplacements(
 						scriptInput.Value.Value,
-						fmt.Sprintf("${{ %s }}", taintedInfo.inputPath),
-						fmt.Sprintf("process.env.%s", envVarName),
-					)
-					scriptInput.Value.Value = strings.ReplaceAll(
-						scriptInput.Value.Value,
-						fmt.Sprintf("${{%s}}", taintedInfo.inputPath),
-						fmt.Sprintf("process.env.%s", envVarName),
+						map[string]string{
+							spacedExpr:  envRef,
+							compactExpr: envRef,
+						},
 					)
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes #504.

This changes the github-script autofix path so expressions lifted into `process.env.X` are emitted as JavaScript expressions, not string literals. For example, `fetch('${{ github.event.issue.body }}')` now becomes `fetch(process.env.ISSUE_BODY)` instead of `fetch('process.env.ISSUE_BODY')`.

## Root Cause

The github-script autofix path reused plain string replacement. When the original `${{ ... }}` expression appeared inside JS quotes, replacing only the expression left the surrounding quotes intact and produced a literal string such as `'process.env.ISSUE_BODY'`.

## Changes

- Added a github-script-specific replacement helper that rewrites JS string literals containing lifted expressions.
- Updated code-injection, request-forgery, reusable workflow taint, and cross-file taint AST updates to use the same helper as YAML rewriting.
- Added regression tests for exact string-literal replacements, embedded string literals, multiple expressions, comments, and the request-forgery `fetch` / `axios` cases from #504.

## Validation

- `go test ./... -count=1`
- `go vet ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* GitHub Scriptの自動修正における置換処理を改善し、文字列リテラルやコメントを正しく処理するようにしました。

## Tests
* GitHub Scriptの置換処理に関する検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->