### PR TITLE
fix: debug log printed pointer addresses instead of action metadata values

### DIFF
--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -131,6 +132,21 @@ type ActionMetadata struct {
 	Runs        *ActionRunsMetadata   `yaml:"runs" json:"runs"`
 	SkipInputs  bool                  `json:"skip_inputs"`
 	SkipOutputs bool                  `json:"skip_outputs"`
+}
+
+// String renders ActionMetadata as JSON so debug logs show dereferenced field
+// values instead of raw pointer addresses. Without this, fmt's default %v
+// stops dereferencing pointers nested inside maps/slices (Inputs, Outputs,
+// Runs.Steps), printing them as 0xc000... addresses.
+func (m *ActionMetadata) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Sprintf("ActionMetadata(json marshal err: %v)", err)
+	}
+	return string(b)
 }
 
 type ActionMetadataResolver interface {
@@ -364,7 +380,7 @@ func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata,
 			return nil, fmt.Errorf("failed to parse remote action metadata file %q: %s", metadataPath, msg)
 		}
 
-		c.debug("detected remote action metadata @ %s: %v", spec, meta)
+		c.debug("detected remote action metadata @ %s: %v", spec, &meta)
 		c.writeCache(spec, &meta)
 		return &meta, nil
 	}

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -260,7 +260,7 @@ func (c *LocalActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata, 
 		return nil, fmt.Errorf("failed to parse action metadata file %q: %s", dir, msg)
 	}
 
-	c.debug("detected action metadata @ %s: %v", dir, meta)
+	c.debug("detected action metadata @ %s: %v", dir, &meta)
 	c.writeCache(spec, &meta)
 	return &meta, nil
 }


### PR DESCRIPTION
## Summary

`sisakulint -debug` printed fetched action metadata as raw Go pointer addresses, making the debug output unusable for inspecting what was actually parsed from `action.yml`.

**Before:**
```
[RemoteActionsMetadataCache] detected remote action metadata @ actions/checkout@df4cb1c...:
  {Checkout map[clean:0xc000012b10 fetch-depth:0xc000012b70
   persist-credentials:0xc000012ae0 token:0xc000012a68 ...]
   map[commit:0xc000143030 ref:0xc000143020] 0xc0001813e0 false false}
```

**After:**
```
[RemoteActionsMetadataCache] detected remote action metadata @ actions/checkout@df4cb1c...:
  {"name":"Checkout","inputs":{"clean":{"name":"clean","required":true},
   "fetch-depth":{"name":"fetch-depth","required":true},
   "persist-credentials":{"name":"persist-credentials","required":true}, ...},
   "outputs":{"commit":{"name":"commit"},"ref":{"name":"ref"}},
   "runs":{"using":"node20","steps":null}, "skip_inputs":false,"skip_outputs":false}
```

## Root cause

`ActionMetadata` holds pointers indirectly through maps and slices:

- `Inputs ActionInputsMetadata` → `map[string]*ActionInputMetadata`
- `Outputs ActionOutputsMetadata` → `map[string]*ActionOutputMetadata`
- `Runs *ActionRunsMetadata` with `Steps []*ActionStepMetadata`

Go's `fmt` package only auto-dereferences pointers at `depth == 0` (see `printValue` in `src/fmt/print.go`). Pointers nested inside map values, slice elements, or as struct fields at depth ≥ 1 fall through to `fmtPointer` and print as `0xc000...` addresses.

## Fix

Add a nil-safe `String()` method on `*ActionMetadata` that uses `encoding/json` for output. The struct already carries `json:` tags, so this requires no new metadata. Because the method is on a pointer receiver, the lone call site that passed a value (`meta`) is updated to pass `&meta`; the other two call sites (lines 222 / 330) already pass `*ActionMetadata` from the cache.

`encoding/json` is stdlib — no new dependencies.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/core/ -run "Metadata|Action"` passes
- [x] Verified end-to-end with `sisakulint -debug` on a real repo — output is now readable JSON for all detected actions (`actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `actions/configure-pages`, `actions/setup-node`, `actions/upload-pages-artifact`, `actions/upload-artifact`)
- [x] `nil` case handled (cache-miss negative entries return `*ActionMetadata == nil`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * デバッグ出力の形式を改善し、メタデータの詳細情報をより正確かつ分かりやすく表示するようにしました。内部ログ出力の信頼性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->