### PR TITLE
fix(untrusted-checkout): detect head.label incl. in compound refs

### DIFF
--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -91,6 +91,16 @@ func TestIsUnsafeCheckoutRef(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "head.label is unsafe",
+			refValue: "${{ github.event.pull_request.head.label }}",
+			want:     true,
+		},
+		{
+			name:     "compound ref mixing safe github.sha and head.label is unsafe",
+			refValue: "${{ github.sha }}-${{ github.event.pull_request.head.label }}",
+			want:     true,
+		},
+		{
 			name:     "unknown expression is unsafe (conservative)",
 			refValue: "${{ steps.unknown.outputs.something }}",
 			want:     true,

--- a/pkg/core/cachepoisoningrule_test.go
+++ b/pkg/core/cachepoisoningrule_test.go
@@ -96,6 +96,11 @@ func TestIsUnsafeCheckoutRef(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "snake_case steps output head_label is unsafe",
+			refValue: "${{ steps.pr.outputs.head_label }}",
+			want:     true,
+		},
+		{
 			name:     "compound ref mixing safe github.sha and head.label is unsafe",
 			refValue: "${{ github.sha }}-${{ github.event.pull_request.head.label }}",
 			want:     true,

--- a/pkg/core/cachepoisoningutil.go
+++ b/pkg/core/cachepoisoningutil.go
@@ -19,10 +19,12 @@ var unsafePatternsLower = []string{
 	"refs/pull/",
 	".head_sha", // Detects steps.*.outputs.head_sha
 	".head_ref", // Detects steps.*.outputs.head_ref
-	".head.sha", // Detects nested head.sha patterns
-	".head.ref", // Detects nested head.ref patterns
-	"head-sha",  // Detects kebab-case variants
-	"head-ref",  // Detects kebab-case variants
+	".head.sha",   // Detects nested head.sha patterns
+	".head.ref",   // Detects nested head.ref patterns
+	".head.label", // Detects head.label (mutable; also bypasses the safe-substring short-circuit in compound refs)
+	"head-sha",    // Detects kebab-case variants
+	"head-ref",    // Detects kebab-case variants
+	"head-label",  // Detects kebab-case head.label variants
 }
 
 // Patterns that are explicitly safe to use with any trigger

--- a/pkg/core/cachepoisoningutil.go
+++ b/pkg/core/cachepoisoningutil.go
@@ -17,8 +17,9 @@ var unsafePatternsLower = []string{
 	"github.event.pull_request.head.ref",
 	"github.head_ref",
 	"refs/pull/",
-	".head_sha", // Detects steps.*.outputs.head_sha
-	".head_ref", // Detects steps.*.outputs.head_ref
+	".head_sha",   // Detects steps.*.outputs.head_sha
+	".head_ref",   // Detects steps.*.outputs.head_ref
+	".head_label", // Detects steps.*.outputs.head_label
 	".head.sha",   // Detects nested head.sha patterns
 	".head.ref",   // Detects nested head.ref patterns
 	".head.label", // Detects head.label (mutable; also bypasses the safe-substring short-circuit in compound refs)


### PR DESCRIPTION
## Problem

`IsUnsafeCheckoutRef` (`pkg/core/cachepoisoningutil.go`) checks `unsafePatternsLower` **first**, then falls back to a conservative rule: any `${{ }}` expression is unsafe unless it contains a known safe substring from `safePatternsLower`.

`github.event.pull_request.head.label` was not in `unsafePatternsLower`, so a **standalone** ref was flagged only via the conservative fallback. In a **compound** ref that also contains a safe substring, the short-circuit wins and the whole ref is treated as safe, so the attacker-controlled `head.label` slips through as a false negative. `head.label` is mutable and attacker-influenced, so this is a checkout of untrusted code.

## Reproduction

Pinned to `c02ca9648a36b6e45c321dc8dc916c7721b82888` (the pre-fix commit) so it stays reproducible after this PR lands:

```bash
git clone https://github.com/sisaku-security/sisakulint && cd sisakulint
git checkout c02ca9648a36b6e45c321dc8dc916c7721b82888
go build -o ./sisakulint ./cmd/sisakulint

mkdir -p repro/.github/workflows && cd repro && git init -q
cat > .github/workflows/w.yml <<'YAML'
name: uc-label
on:
  pull_request_target:
    types: [labeled]
jobs:
  single:      # standalone head.label
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with:
          ref: ${{ github.event.pull_request.head.label }}
  compound:    # github.sha (safe substring) + head.label
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with:
          ref: ${{ github.sha }}-${{ github.event.pull_request.head.label }}
YAML
../sisakulint .github/workflows/w.yml | grep untrusted-checkout
```

At the pinned commit: only the `single` job (line 11) is flagged; the `compound` job (line 17) is a **false negative**.
With this PR applied: both lines 11 and 17 are flagged.

## Fix

Add `.head.label` (and the `head-label` kebab-case variant, matching the existing `head-sha`/`head-ref` entries) to `unsafePatternsLower`. Because unsafe patterns are matched before the safe-substring short-circuit, `head.label` is now flagged directly in both standalone and compound refs.

## Test

Added two regression cases to `TestIsUnsafeCheckoutRef` (standalone `head.label` and the compound `github.sha`-`head.label` mix). `go test ./pkg/core` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * チェックアウト対象の参照判定が改善され、`head.label` を含むケースでも unsafe と判定されるようになりました。
  * 文字列の組み合わせで構成された参照式や、表記ゆれのある `head_label` / `head-label` も検出対象に追加されました。
  * これらの判定条件をカバーするテストケースを追加し、検出精度を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->