### PR TITLE
fix(artifact-poisoning-medium): widen untrusted trigger set to match canonical

### DIFF
--- a/pkg/core/artifactpoisoningmedium_test.go
+++ b/pkg/core/artifactpoisoningmedium_test.go
@@ -81,6 +81,21 @@ func TestArtifactPoisoningMedium_VisitWorkflowPre(t *testing.T) {
 			wantUnsafeTriggers: 1,
 		},
 		{
+			name:               "issues trigger",
+			triggers:           []string{"issues"},
+			wantUnsafeTriggers: 1,
+		},
+		{
+			name:               "discussion_comment trigger",
+			triggers:           []string{"discussion_comment"},
+			wantUnsafeTriggers: 1,
+		},
+		{
+			name:               "pull_request_review trigger",
+			triggers:           []string{"pull_request_review"},
+			wantUnsafeTriggers: 1,
+		},
+		{
 			name:               "multiple untrusted triggers",
 			triggers:           []string{"workflow_run", "pull_request_target"},
 			wantUnsafeTriggers: 2,

--- a/pkg/core/artifactpoisoningutil.go
+++ b/pkg/core/artifactpoisoningutil.go
@@ -7,10 +7,20 @@ import "gopkg.in/yaml.v3"
 // - workflow_run: Triggered by completion of another workflow (may be from PR)
 // - pull_request_target: Runs in the context of the base branch but with PR info
 // - issue_comment: Triggered by comments which can be from external contributors
+// - issues: Can be opened/edited by external users
+// - discussion_comment: Triggered by untrusted discussion comments
+// - pull_request_review: Review body is attacker-controlled
+//
+// This mirrors the canonical PrivilegedTriggers set (privilegedtriggers.go); the
+// artifact-poisoning-medium rule previously used a narrower 3-entry subset, so a
+// third-party artifact download under e.g. an `issues` trigger was a false negative.
 var UntrustedTriggers = map[string]bool{
 	"workflow_run":        true,
 	"pull_request_target": true,
 	"issue_comment":       true,
+	"issues":              true,
+	"discussion_comment":  true,
+	"pull_request_review": true,
 }
 
 // AddPathToWithSection adds or updates the path input in the with section of a step node.


### PR DESCRIPTION
## Problem

`artifact-poisoning-medium` gates on `UntrustedTriggers` (`pkg/core/artifactpoisoningutil.go`), which held only 3 entries: `workflow_run`, `pull_request_target`, `issue_comment`. The canonical `PrivilegedTriggers` set (`pkg/core/privilegedtriggers.go`) has 6, adding `issues`, `discussion_comment`, and `pull_request_review` — all of which carry attacker-controlled input. So a third-party artifact download under, e.g., an `issues` trigger was a false negative.

## Reproduction

Pinned to `c02ca9648a36b6e45c321dc8dc916c7721b82888` (the pre-fix commit):

```bash
git clone https://github.com/sisaku-security/sisakulint && cd sisakulint
git checkout c02ca9648a36b6e45c321dc8dc916c7721b82888
go build -o ./sisakulint ./cmd/sisakulint

mkdir -p repro/.github/workflows && cd repro && git init -q
# same dangerous step, differing only in trigger
cat > .github/workflows/issues.yml <<'YAML'
name: ap-issues
on:
  issues:
    types: [opened]
jobs:
  dl:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: dawidd6/action-download-artifact@v2
        with:
          name: pr_number
      - run: sh cmd.sh
YAML
cat > .github/workflows/wfrun.yml <<'YAML'
name: ap-wfrun
on:
  workflow_run:
    workflows: ["CI"]
    types: [completed]
jobs:
  dl:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: dawidd6/action-download-artifact@v2
        with:
          name: pr_number
      - run: sh cmd.sh
YAML
echo "issues:      $(../sisakulint .github/workflows/issues.yml | grep -c artifact-poisoning-medium)"
echo "workflow_run:$(../sisakulint .github/workflows/wfrun.yml  | grep -c artifact-poisoning-medium)"
```

At the pinned commit: `issues` → 0 (false negative), `workflow_run` → 1 (control).
With this PR applied: both → 1.

## Fix

Expand `UntrustedTriggers` to the 6-entry canonical set. `UntrustedTriggers` is consumed only by `artifact-poisoning-medium` (`grep -rn UntrustedTriggers pkg/`), so the change is scoped to that rule. Added `issues` / `discussion_comment` / `pull_request_review` cases to `TestArtifactPoisoningMedium_VisitWorkflowPre`; `go test ./pkg/core` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)