### PR TITLE
feat: add deprecated-node-runtime rule for Node.js 20 EOL migration

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -40,7 +40,7 @@ sisakulint categorizes security rules by severity based on CVSS scores, attack i
 | Severity | Count | CVSS Range | Description |
 |----------|-------|------------|-------------|
 | **Critical** | 14 | 9.0-10.0 | Immediate risk, can lead to RCE or full compromise |
-| **High** | 17 | 7.0-8.9 | Significant risk, enables serious attacks |
+| **High** | 18 | 7.0-8.9 | Significant risk, enables serious attacks |
 | **Medium** | 14 | 4.0-6.9 | Moderate risk, requires specific conditions |
 | **Low** | 5 | 0.1-3.9 | Best practices, minimal direct security impact |
 
@@ -83,6 +83,7 @@ sisakulint categorizes security rules by severity based on CVSS scores, attack i
 | [unmasked-secret-exposure]({{< ref "unmaskedsecretexposure.md" >}}) | High | Detects unmasked secrets derived from fromJson() | Yes |
 | [improper-access-control]({{< ref "improperaccesscontrol.md" >}}) | High | Detects improper access control with label-based approval | Yes |
 | [known-vulnerable-actions]({{< ref "knownvulnerableactions.md" >}}) | Varies | Detects actions with known CVEs (inherits advisory severity) | Yes |
+| [deprecated-node-runtime]({{< ref "deprecatednoderuntime.md" >}}) | 7/10 | Detects actions on the EOL Node.js 20 runtime (removed from runners 2026-09-16) | Yes |
 | [credentials]({{< ref "credentialsrule.md" >}}) | High | Detects hardcoded credentials | Yes |
 
 ### Medium Severity Rules (4.0-6.9)

--- a/docs/deprecatednoderuntime.md
+++ b/docs/deprecatednoderuntime.md
@@ -45,7 +45,7 @@ jobs:
 
 sisakulint reports:
 
-```
+```text
 workflow.yaml:5:15: action 'actions/checkout@v4' runs on the deprecated Node.js runtime 'node20' (EOL since 2026-04-30 and scheduled for removal from the runner on 2026-09-16). Update to actions/checkout@v5 or later, which runs on node24. [deprecated-node-runtime]
 ```
 

--- a/docs/deprecatednoderuntime.md
+++ b/docs/deprecatednoderuntime.md
@@ -1,0 +1,81 @@
+---
+title: "Deprecated Node Runtime Rule"
+weight: 1
+# bookFlatSection: false
+# bookToc: true
+# bookHidden: false
+# bookCollapseSection: false
+# bookComments: false
+# bookSearchExclude: false
+---
+
+## Deprecated Node Runtime Rule Overview
+
+The `deprecated-node-runtime` rule detects GitHub Actions that still run on the Node.js 20 action runtime. Node.js 20 reached end-of-life on 2026-04-30 and no longer receives security fixes, and GitHub removes node20 from the runner on 2026-09-16, after which affected actions stop working. node12 and node16 were already removed. The rule reports every workflow dependency on a deprecated runtime so a repository can migrate before the removal date.
+
+### Rule ID
+
+`deprecated-node-runtime`
+
+### Severity
+
+- **High**: an EOL runtime receives no security patches, and workflows depending on it break outright when the runtime is removed from the runner.
+
+### Detection
+
+| Class | What is reported | Auto-fix |
+|-------|------------------|----------|
+| Direct runtime | An action whose `action.yml` declares `runs.using: node12/node16/node20` | Yes, for known first-party actions |
+| Composite transitive | A composite action whose direct internal steps use a deprecated runtime, depth 1 | No, the fix belongs to the action maintainer |
+| Runner env flags | `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`, which stops working on 2026-09-16, and the removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE20` | No |
+| EOL build target | `node-version: 20` or older in setup-node | No, changing a build target is a semantic change |
+
+### Vulnerable Pattern
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4        # runs.using: node20
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20               # EOL build target
+```
+
+sisakulint reports:
+
+```
+workflow.yaml:5:15: action 'actions/checkout@v4' runs on the deprecated Node.js runtime 'node20' (EOL since 2026-04-30 and scheduled for removal from the runner on 2026-09-16). Update to actions/checkout@v5 or later, which runs on node24. [deprecated-node-runtime]
+```
+
+### Safe Pattern
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5        # runs.using: node24
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+```
+
+### Auto-fix
+
+`sisakulint -fix on` bumps known first-party actions from their node20-generation major to the first node24-capable major, for example `actions/checkout@v4` to `@v5`, `actions/github-script@v7` to `@v8`, and `actions/upload-artifact@v4` to `@v6`. Subpaths such as `actions/cache/restore@v4` are preserved. SHA-pinned references are detected but left to the `commit-sha` rule to re-pin. The three diagnose-only classes in the table above are reported without a fix. Preview changes with `sisakulint -fix dry-run`.
+
+### Resolver and Offline Fallback
+
+The rule resolves each action's `action.yml` at the pinned ref through the GitHub API and treats its `runs.using` value as ground truth. SHA-pinned actions are therefore detected without needing a `# vX` ref comment, and a stale version comment can never cause a false positive. Set a token via `GITHUB_TOKEN` or `-github-token` to avoid the unauthenticated rate limit. When the API is unreachable the rule falls back to an embedded table of known actions plus tag and `# vX` comment heuristics, which is best-effort and may miss third-party actions.
+
+### Known Limitations
+
+- The embedded fallback table is a hand-maintained snapshot of first-party actions.
+- Composite actions are inspected one level deep; runtimes nested deeper and reusable workflows are not tracked.
+
+### References
+
+- [GitHub Changelog: Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
+- [Node.js Release Schedule](https://github.com/nodejs/Release)

--- a/pkg/core/deprecated_node_runtime.go
+++ b/pkg/core/deprecated_node_runtime.go
@@ -52,8 +52,8 @@ type nodeRuntimeUpgrade struct {
 }
 
 // nodeRuntimeUpgrades is an embedded snapshot (verified 2026-07 against each
-// action's action.yml `runs.using` field). A production implementation should
-// generate this table with a scraper, like actionlint's popular_actions DB.
+// action's action.yml `runs.using` field). Maintained by hand: update an
+// entry when the listed action publishes a new major.
 var nodeRuntimeUpgrades = map[string]nodeRuntimeUpgrade{
 	"actions/checkout":          {lastNode20Major: 4, firstNode24Major: 5},
 	"actions/setup-node":        {lastNode20Major: 4, firstNode24Major: 5},
@@ -265,17 +265,16 @@ func parseMajorFromRef(ref string) (int, bool) {
 }
 
 // checkKnownNode20Action matches `uses:` against the embedded table of
-// popular actions with known node20 majors. Returns true when the action was
-// conclusively identified (reported or confirmed up to date), so the caller
-// can skip the metadata-resolver fallback.
-func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, action *ast.ExecAction) bool {
+// popular actions with known node20 majors. Fallback path for when the
+// metadata resolver is unavailable.
+func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, action *ast.ExecAction) {
 	owner, repo, ref := parseUsesValue(action.Uses.Value)
 	if owner == "" || repo == "" || ref == "" {
-		return false
+		return
 	}
 	upgrade, known := nodeRuntimeUpgrades[strings.ToLower(owner+"/"+repo)]
 	if !known {
-		return false
+		return
 	}
 
 	major, isTag := parseMajorFromRef(ref)
@@ -284,16 +283,15 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 		// SHA-pinned refs carry the human-readable tag as a line comment when
 		// pinned by the commit-sha auto-fix (e.g. "# v4.1.1").
 		comment := strings.TrimSpace(strings.TrimPrefix(action.Uses.BaseNode.LineComment, "#"))
-		comment = strings.TrimSpace(comment)
 		if m, ok := parseMajorFromRef(comment); ok {
 			major = m
 		} else {
-			return false
+			return
 		}
 	}
 
 	if major > upgrade.lastNode20Major {
-		return true // already on a node24-capable major
+		return // already on a node24-capable major
 	}
 
 	actionPath := strings.TrimSuffix(action.Uses.Value, "@"+ref)
@@ -303,7 +301,6 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 	if fixable {
 		rule.AddAutoFixer(NewStepFixer(step, rule))
 	}
-	return true
 }
 
 // eolNodeBuildTargets are Node.js majors that are EOL as build targets

--- a/pkg/core/deprecated_node_runtime.go
+++ b/pkg/core/deprecated_node_runtime.go
@@ -1,0 +1,371 @@
+package core
+
+import (
+	"fmt"
+	pathpkg "path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+)
+
+// DeprecatedNodeRuntimeRule detects GitHub Actions workflows that depend on
+// the deprecated Node.js 20 action runtime (or the already-removed node12 /
+// node16 runtimes). Node.js 20 reached end-of-life on 2026-04-30; GitHub
+// switched the default action runtime to node24 on 2026-06-16 and will remove
+// node20 from the runner on 2026-09-16.
+// See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+//
+// Detections (resolver-first):
+//  1. `uses:` references whose action.yml declares a deprecated runtime,
+//     resolved through ActionMetadataResolver (local `./` actions offline,
+//     remote actions via GitHub API). The resolved `runs.using` value is the
+//     ground truth, so SHA-pinned refs are detected without relying on line
+//     comments and the actual runtime (node12/16/20) is reported. Auto-fix
+//     bumps well-known action tags to the first node24-capable major
+//     (embedded table).
+//  2. Composite actions whose direct internal steps run on a deprecated
+//     runtime (depth-1, diagnose-only — the fix belongs to the action
+//     maintainer, so the report points at bumping the composite itself).
+//  3. Fallback when the resolver is unavailable (offline / API failure):
+//     well-known action majors from the embedded table, using the tag or the
+//     `# vX` line comment of SHA-pinned refs. Comments can be stale, so this
+//     path is heuristic by design.
+//  4. Workflow/job/step `env:` entries pinning the deprecated runtime:
+//     ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION (time-limited opt-out that
+//     stops working on 2026-09-16) and FORCE_JAVASCRIPT_ACTIONS_TO_NODE20
+//     (removed from the runner; dead configuration). Diagnose-only.
+//  5. `actions/setup-node` with an EOL `node-version:` build target
+//     (Node.js <= 20). Diagnose-only because changing the build target is a
+//     semantic change the project owner must decide.
+type DeprecatedNodeRuntimeRule struct {
+	BaseRule
+	metadataResolver ActionMetadataResolver
+}
+
+// nodeRuntimeUpgrade describes, for a well-known action, the newest major
+// version still running on node20 and the first major that declares node24.
+type nodeRuntimeUpgrade struct {
+	lastNode20Major  int
+	firstNode24Major int
+}
+
+// nodeRuntimeUpgrades is an embedded snapshot (verified 2026-07 against each
+// action's action.yml `runs.using` field). A production implementation should
+// generate this table with a scraper, like actionlint's popular_actions DB.
+var nodeRuntimeUpgrades = map[string]nodeRuntimeUpgrade{
+	"actions/checkout":          {lastNode20Major: 4, firstNode24Major: 5},
+	"actions/setup-node":        {lastNode20Major: 4, firstNode24Major: 5},
+	"actions/setup-python":      {lastNode20Major: 5, firstNode24Major: 6},
+	"actions/setup-go":          {lastNode20Major: 5, firstNode24Major: 6},
+	"actions/github-script":     {lastNode20Major: 7, firstNode24Major: 8},
+	"actions/cache":             {lastNode20Major: 4, firstNode24Major: 5},
+	"actions/upload-artifact":   {lastNode20Major: 4, firstNode24Major: 6},
+	"actions/download-artifact": {lastNode20Major: 6, firstNode24Major: 7},
+}
+
+// deprecatedNodeRuntimes are `runs.using` values that no longer receive
+// security updates. node12/node16 are already removed from the runner;
+// node20 is EOL and scheduled for removal on 2026-09-16.
+var deprecatedNodeRuntimes = map[string]string{
+	"node12": "removed from the runner",
+	"node16": "removed from the runner",
+	"node20": "EOL since 2026-04-30 and scheduled for removal from the runner on 2026-09-16",
+}
+
+const nodeRuntimeDocURL = "https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/"
+
+func NewDeprecatedNodeRuntimeRule(resolver ActionMetadataResolver) *DeprecatedNodeRuntimeRule {
+	return &DeprecatedNodeRuntimeRule{
+		BaseRule: BaseRule{
+			RuleName: "deprecated-node-runtime",
+			RuleDesc: "Detects actions running on the deprecated Node.js 20 runtime (EOL 2026-04-30, removed from the runner on 2026-09-16) and workflow settings that pin the insecure runtime",
+		},
+		metadataResolver: resolver,
+	}
+}
+
+func (rule *DeprecatedNodeRuntimeRule) VisitWorkflowPre(node *ast.Workflow) error {
+	rule.checkEnvFlags(node.Env)
+	return nil
+}
+
+func (rule *DeprecatedNodeRuntimeRule) VisitJobPre(node *ast.Job) error {
+	rule.checkEnvFlags(node.Env)
+	return nil
+}
+
+func (rule *DeprecatedNodeRuntimeRule) VisitStep(step *ast.Step) error {
+	rule.checkEnvFlags(step.Env)
+
+	action, ok := step.Exec.(*ast.ExecAction)
+	if !ok || action.Uses == nil {
+		return nil
+	}
+	uses := action.Uses.Value
+	if strings.HasPrefix(uses, "docker://") {
+		return nil
+	}
+
+	rule.checkEOLNodeBuildTarget(action)
+
+	// Resolver-first: the action.yml at the pinned ref is the ground truth.
+	// The embedded-table/comment heuristic only runs when resolution is
+	// unavailable, so a stale "# v5" comment next to a node24 SHA cannot
+	// produce a false positive as long as the resolver answers.
+	if meta := rule.resolveMetadata(uses); meta != nil && meta.Runs != nil {
+		using := strings.ToLower(meta.Runs.Using)
+		if reason, deprecated := deprecatedNodeRuntimes[using]; deprecated {
+			rule.reportDeprecatedRuntime(step, action, using, reason)
+			return nil
+		}
+		if using == "composite" {
+			rule.checkCompositeTransitive(action, uses, meta)
+		}
+		return nil
+	}
+
+	rule.checkKnownNode20Action(step, action)
+	return nil
+}
+
+// resolveMetadata wraps the resolver with nil/error handling. Resolution
+// failures are debug-logged and reported as nil so offline runs fall back to
+// the embedded table silently.
+func (rule *DeprecatedNodeRuntimeRule) resolveMetadata(spec string) *ActionMetadata {
+	if rule.metadataResolver == nil {
+		return nil
+	}
+	meta, err := rule.metadataResolver.FindMetadata(spec)
+	if err != nil {
+		rule.Debug("could not resolve metadata for %q: %v", spec, err)
+		return nil
+	}
+	return meta
+}
+
+// reportDeprecatedRuntime reports a resolver-confirmed deprecated runtime and
+// attaches the auto-fixer when the embedded table knows a node24-capable
+// major and the ref is a bumpable tag.
+func (rule *DeprecatedNodeRuntimeRule) reportDeprecatedRuntime(step *ast.Step, action *ast.ExecAction, using, reason string) {
+	uses := action.Uses.Value
+	upgradeHint := "Update the action to a version that declares node24, or contact the action maintainer."
+	fixable := false
+	owner, repo, ref := parseUsesValue(uses)
+	if upgrade, known := nodeRuntimeUpgrades[strings.ToLower(owner+"/"+repo)]; known && ref != "" {
+		actionPath := strings.TrimSuffix(uses, "@"+ref)
+		upgradeHint = fmt.Sprintf("Update to %s@v%d or later, which runs on node24.", actionPath, upgrade.firstNode24Major)
+		if major, isTag := parseMajorFromRef(ref); isTag && major <= upgrade.lastNode20Major {
+			fixable = true
+		}
+	}
+	rule.Errorf(action.Uses.Pos,
+		"action '%s' runs on the deprecated Node.js runtime '%s' (%s). %s See %s",
+		uses, using, reason, upgradeHint, nodeRuntimeDocURL)
+	if fixable {
+		rule.AddAutoFixer(NewStepFixer(step, rule))
+	}
+}
+
+// checkCompositeTransitive resolves the direct internal steps of a composite
+// action and reports the ones running on a deprecated runtime. Depth-1 only:
+// nested composite actions are not followed. Diagnose-only — the workflow
+// author cannot rewrite a third-party composite's internals; the actionable
+// remediation is bumping the composite itself.
+func (rule *DeprecatedNodeRuntimeRule) checkCompositeTransitive(action *ast.ExecAction, parentSpec string, meta *ActionMetadata) {
+	for _, s := range meta.Runs.Steps {
+		if s == nil || s.Uses == "" {
+			continue
+		}
+		inner := s.Uses
+		if strings.HasPrefix(inner, "docker://") {
+			continue
+		}
+		if strings.HasPrefix(inner, "./") {
+			inner = resolveCompositeLocalSpec(parentSpec, inner)
+			if inner == "" {
+				continue
+			}
+		}
+		im := rule.resolveMetadata(inner)
+		if im == nil || im.Runs == nil {
+			continue
+		}
+		using := strings.ToLower(im.Runs.Using)
+		reason, deprecated := deprecatedNodeRuntimes[using]
+		if !deprecated {
+			continue
+		}
+		rule.Errorf(action.Uses.Pos,
+			"composite action '%s' internally runs '%s' on the deprecated Node.js runtime '%s' (%s). The fix belongs to the action maintainer; check whether a newer version of the composite action resolves it. See %s",
+			parentSpec, inner, using, reason, nodeRuntimeDocURL)
+	}
+}
+
+// resolveCompositeLocalSpec turns a composite-internal relative uses (e.g.
+// "./predicate" inside actions/attest-build-provenance@v2) into a resolvable
+// remote spec ("actions/attest-build-provenance/predicate@v2").
+func resolveCompositeLocalSpec(parentSpec, rel string) string {
+	at := strings.LastIndex(parentSpec, "@")
+	if at <= 0 || at == len(parentSpec)-1 {
+		return ""
+	}
+	parentPath, ref := parentSpec[:at], parentSpec[at+1:]
+	parentParts := strings.Split(parentPath, "/")
+	if len(parentParts) < 2 {
+		return ""
+	}
+	joined := pathpkg.Join(parentPath, rel)
+	// Reject anything escaping the parent repository (e.g. "../../x").
+	repoPrefix := parentParts[0] + "/" + parentParts[1]
+	if joined != repoPrefix && !strings.HasPrefix(joined, repoPrefix+"/") {
+		return ""
+	}
+	return joined + "@" + ref
+}
+
+// checkEnvFlags reports env entries that pin workflows to the deprecated
+// runtime. Matching is case-insensitive because GitHub env names are.
+func (rule *DeprecatedNodeRuntimeRule) checkEnvFlags(env *ast.Env) {
+	if env == nil || env.Vars == nil {
+		return
+	}
+	for _, v := range env.Vars {
+		if v == nil || v.Name == nil {
+			continue
+		}
+		switch {
+		case strings.EqualFold(v.Name.Value, "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION"):
+			rule.Errorf(v.Name.Pos,
+				"ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION forces actions to run on the EOL Node.js 20 runtime, which no longer receives security fixes. This opt-out stops working when Node.js 20 is removed from the runner on 2026-09-16. Update the affected actions to node24-compatible versions instead. See %s",
+				nodeRuntimeDocURL)
+		case strings.EqualFold(v.Name.Value, "FORCE_JAVASCRIPT_ACTIONS_TO_NODE20"):
+			rule.Errorf(v.Name.Pos,
+				"FORCE_JAVASCRIPT_ACTIONS_TO_NODE20 was removed from the GitHub Actions runner and has no effect. Remove this dead configuration. See %s",
+				nodeRuntimeDocURL)
+		}
+	}
+}
+
+var nodeMajorTagPattern = regexp.MustCompile(`^v(\d+)(?:\..*)?$`)
+
+// parseMajorFromRef extracts the major version from tag-style refs such as
+// "v4" or "v4.1.2". Returns false for branches, SHAs, and anything else.
+func parseMajorFromRef(ref string) (int, bool) {
+	m := nodeMajorTagPattern.FindStringSubmatch(ref)
+	if m == nil {
+		return 0, false
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return major, true
+}
+
+// checkKnownNode20Action matches `uses:` against the embedded table of
+// popular actions with known node20 majors. Returns true when the action was
+// conclusively identified (reported or confirmed up to date), so the caller
+// can skip the metadata-resolver fallback.
+func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, action *ast.ExecAction) bool {
+	owner, repo, ref := parseUsesValue(action.Uses.Value)
+	if owner == "" || repo == "" || ref == "" {
+		return false
+	}
+	upgrade, known := nodeRuntimeUpgrades[strings.ToLower(owner+"/"+repo)]
+	if !known {
+		return false
+	}
+
+	major, isTag := parseMajorFromRef(ref)
+	fixable := isTag
+	if !isTag {
+		// SHA-pinned refs carry the human-readable tag as a line comment when
+		// pinned by the commit-sha auto-fix (e.g. "# v4.1.1").
+		comment := strings.TrimSpace(strings.TrimPrefix(action.Uses.BaseNode.LineComment, "#"))
+		comment = strings.TrimSpace(comment)
+		if m, ok := parseMajorFromRef(comment); ok {
+			major = m
+		} else {
+			return false
+		}
+	}
+
+	if major > upgrade.lastNode20Major {
+		return true // already on a node24-capable major
+	}
+
+	actionPath := strings.TrimSuffix(action.Uses.Value, "@"+ref)
+	rule.Errorf(action.Uses.Pos,
+		"action '%s@%s' runs on the deprecated Node.js 20 runtime (%s). Update to %s@v%d or later, which runs on node24. See %s",
+		actionPath, ref, deprecatedNodeRuntimes["node20"], actionPath, upgrade.firstNode24Major, nodeRuntimeDocURL)
+	if fixable {
+		rule.AddAutoFixer(NewStepFixer(step, rule))
+	}
+	return true
+}
+
+// eolNodeBuildTargets are Node.js majors that are EOL as build targets
+// (distinct from the action runtime): 16 (2023-09-11), 18 (2025-04-30),
+// 20 (2026-04-30). Source: https://github.com/nodejs/Release
+var eolNodeBuildTargets = map[int]string{
+	12: "2022-04-30",
+	14: "2023-04-30",
+	16: "2023-09-11",
+	18: "2025-04-30",
+	20: "2026-04-30",
+}
+
+// checkEOLNodeBuildTarget warns when actions/setup-node installs an EOL
+// Node.js as the build/test runtime. Diagnose-only: bumping the project's
+// Node target is a semantic change (package compatibility, engines field)
+// that the maintainer must drive, typically via Renovate/Dependabot.
+func (rule *DeprecatedNodeRuntimeRule) checkEOLNodeBuildTarget(action *ast.ExecAction) {
+	owner, repo, _ := parseUsesValue(action.Uses.Value)
+	if !strings.EqualFold(owner, "actions") || !strings.EqualFold(repo, "setup-node") {
+		return
+	}
+	input, ok := action.Inputs["node-version"]
+	if !ok || input == nil || input.Value == nil {
+		return
+	}
+	raw := strings.TrimSpace(input.Value.Value)
+	if raw == "" || strings.Contains(raw, "${{") {
+		return
+	}
+	majorPart := strings.SplitN(strings.TrimPrefix(raw, "v"), ".", 2)[0]
+	major, err := strconv.Atoi(majorPart)
+	if err != nil {
+		return
+	}
+	if eolDate, isEOL := eolNodeBuildTargets[major]; isEOL {
+		rule.Errorf(input.Value.Pos,
+			"Node.js %s specified in 'node-version' reached end-of-life on %s and no longer receives security updates. Migrate the project to a supported Node.js version (>= 22). See https://github.com/nodejs/Release",
+			raw, eolDate)
+	}
+}
+
+// FixStep bumps a known node20-generation action tag to the first
+// node24-capable major (e.g. actions/checkout@v4 -> @v5). SHA-pinned refs are
+// left to the commit-sha rule to re-pin after the bump.
+func (rule *DeprecatedNodeRuntimeRule) FixStep(step *ast.Step) error {
+	action, ok := step.Exec.(*ast.ExecAction)
+	if !ok || action.Uses == nil {
+		return nil
+	}
+	owner, repo, ref := parseUsesValue(action.Uses.Value)
+	upgrade, known := nodeRuntimeUpgrades[strings.ToLower(owner+"/"+repo)]
+	if !known {
+		return nil
+	}
+	major, isTag := parseMajorFromRef(ref)
+	if !isTag || major > upgrade.lastNode20Major {
+		return nil
+	}
+	// Preserve any subpath (e.g. actions/cache/restore@v4 must stay
+	// actions/cache/restore@v5, not become actions/cache@v5).
+	actionPath := strings.TrimSuffix(action.Uses.Value, "@"+ref)
+	action.Uses.BaseNode.Value = fmt.Sprintf("%s@v%d", actionPath, upgrade.firstNode24Major)
+	return nil
+}

--- a/pkg/core/deprecated_node_runtime.go
+++ b/pkg/core/deprecated_node_runtime.go
@@ -10,46 +10,29 @@ import (
 	"github.com/sisaku-security/sisakulint/pkg/ast"
 )
 
-// DeprecatedNodeRuntimeRule detects GitHub Actions workflows that depend on
-// the deprecated Node.js 20 action runtime (or the already-removed node12 /
-// node16 runtimes). Node.js 20 reached end-of-life on 2026-04-30; GitHub
-// switched the default action runtime to node24 on 2026-06-16 and will remove
-// node20 from the runner on 2026-09-16.
-// See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+// DeprecatedNodeRuntimeRule detects workflows depending on deprecated
+// Node.js action runtimes (node20: EOL 2026-04-30, removed from the runner
+// 2026-09-16; node12/16: already removed).
 //
-// Detections (resolver-first):
-//  1. `uses:` references whose action.yml declares a deprecated runtime,
-//     resolved through ActionMetadataResolver (local `./` actions offline,
-//     remote actions via GitHub API). The resolved `runs.using` value is the
-//     ground truth, so SHA-pinned refs are detected without relying on line
-//     comments and the actual runtime (node12/16/20) is reported. Auto-fix
-//     bumps well-known action tags to the first node24-capable major
-//     (embedded table).
-//  2. Composite actions whose direct internal steps run on a deprecated
-//     runtime (depth-1, diagnose-only — the fix belongs to the action
-//     maintainer, so the report points at bumping the composite itself).
-//  3. Fallback when the resolver is unavailable (offline / API failure):
-//     well-known action majors from the embedded table, using the tag or the
-//     `# vX` line comment of SHA-pinned refs. Comments can be stale, so this
-//     path is heuristic by design.
-//  4. Workflow/job/step `env:` entries pinning the deprecated runtime:
-//     ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION (time-limited opt-out that
-//     stops working on 2026-09-16) and FORCE_JAVASCRIPT_ACTIONS_TO_NODE20
-//     (removed from the runner; dead configuration). Diagnose-only.
-//  5. `actions/setup-node` with an EOL `node-version:` build target
-//     (Node.js <= 20). Diagnose-only because changing the build target is a
-//     semantic change the project owner must decide.
+// Detections (resolver-first: the resolved action.yml's `runs.using` is the
+// ground truth):
+//  1. actions declaring a deprecated runtime; auto-fix bumps well-known
+//     tags to the first node24-capable major
+//  2. composite actions with deprecated direct steps (depth-1, diagnose-only)
+//  3. offline fallback via the embedded table when the resolver is unavailable
+//  4. env vars pinning the deprecated runtime (diagnose-only)
+//  5. EOL `node-version:` build targets in setup-node (diagnose-only)
+//
+// See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 type DeprecatedNodeRuntimeRule struct {
 	BaseRule
 	metadataResolver ActionMetadataResolver
 }
 
-// nodeRuntimeFirstNode24Major maps well-known actions to the first major that
-// declares `runs.using: node24`; every lower major is treated as deprecated.
-// This single boundary intentionally covers gap majors such as
-// actions/upload-artifact v5, whose v5.0.0 tag still declares node20.
-// Maintained by hand (verified 2026-07 against each action's action.yml):
-// update an entry when the listed action publishes a new major.
+// First major of each well-known action that declares `runs.using: node24`;
+// every lower major is deprecated, including gap majors such as
+// upload-artifact v5 (v5.0.0 still declares node20). Hand-maintained,
+// verified 2026-07 against each action.yml.
 var nodeRuntimeFirstNode24Major = map[string]int{
 	"actions/checkout":          5,
 	"actions/setup-node":        5,
@@ -61,9 +44,8 @@ var nodeRuntimeFirstNode24Major = map[string]int{
 	"actions/download-artifact": 7,
 }
 
-// deprecatedNodeRuntimes are `runs.using` values that no longer receive
-// security updates. node12/node16 are already removed from the runner;
-// node20 is EOL and scheduled for removal on 2026-09-16.
+// deprecatedNodeRuntimes maps deprecated `runs.using` values to the reason
+// interpolated into reports.
 var deprecatedNodeRuntimes = map[string]string{
 	"node12": "removed from the runner",
 	"node16": "removed from the runner",
@@ -122,8 +104,7 @@ func (rule *DeprecatedNodeRuntimeRule) VisitStep(step *ast.Step) error {
 	return nil
 }
 
-// resolveMetadata wraps the resolver with nil/error handling. Resolution
-// failures are debug-logged and reported as nil so offline runs fall back to
+// resolveMetadata returns nil on resolution failure so callers fall back to
 // the embedded table silently.
 func (rule *DeprecatedNodeRuntimeRule) resolveMetadata(spec string) *ActionMetadata {
 	if rule.metadataResolver == nil {
@@ -137,9 +118,8 @@ func (rule *DeprecatedNodeRuntimeRule) resolveMetadata(spec string) *ActionMetad
 	return meta
 }
 
-// reportDeprecatedRuntime reports a resolver-confirmed deprecated runtime and
-// attaches the auto-fixer when the embedded table knows a node24-capable
-// major and the ref is a bumpable tag.
+// reportDeprecatedRuntime reports the finding; auto-fix only when the table
+// knows the target major and the ref is a bumpable tag.
 func (rule *DeprecatedNodeRuntimeRule) reportDeprecatedRuntime(step *ast.Step, action *ast.ExecAction, using, reason string) {
 	uses := action.Uses.Value
 	upgradeHint := "Update the action to a version that declares node24, or contact the action maintainer."
@@ -160,11 +140,9 @@ func (rule *DeprecatedNodeRuntimeRule) reportDeprecatedRuntime(step *ast.Step, a
 	}
 }
 
-// checkCompositeTransitive resolves the direct internal steps of a composite
-// action and reports the ones running on a deprecated runtime. Depth-1 only:
-// nested composite actions are not followed. Diagnose-only — the workflow
-// author cannot rewrite a third-party composite's internals; the actionable
-// remediation is bumping the composite itself.
+// checkCompositeTransitive reports deprecated runtimes in a composite's
+// direct steps (depth-1 only). Diagnose-only: the fix belongs to the
+// composite's maintainer.
 func (rule *DeprecatedNodeRuntimeRule) checkCompositeTransitive(action *ast.ExecAction, parentSpec string, meta *ActionMetadata) {
 	for _, s := range meta.Runs.Steps {
 		if s == nil || s.Uses == "" {
@@ -195,9 +173,8 @@ func (rule *DeprecatedNodeRuntimeRule) checkCompositeTransitive(action *ast.Exec
 	}
 }
 
-// resolveCompositeLocalSpec turns a composite-internal relative uses (e.g.
-// "./predicate" inside actions/attest-build-provenance@v2) into a resolvable
-// remote spec ("actions/attest-build-provenance/predicate@v2").
+// resolveCompositeLocalSpec turns a composite-internal "./sub" uses into
+// "owner/repo/sub@ref" so it can be resolved remotely.
 func resolveCompositeLocalSpec(parentSpec, rel string) string {
 	at := strings.LastIndex(parentSpec, "@")
 	if at <= 0 || at == len(parentSpec)-1 {
@@ -209,7 +186,7 @@ func resolveCompositeLocalSpec(parentSpec, rel string) string {
 		return ""
 	}
 	joined := pathpkg.Join(parentPath, rel)
-	// Reject anything escaping the parent repository (e.g. "../../x").
+	// Reject "../.." escapes out of the parent repository.
 	repoPrefix := parentParts[0] + "/" + parentParts[1]
 	if joined != repoPrefix && !strings.HasPrefix(joined, repoPrefix+"/") {
 		return ""
@@ -217,8 +194,8 @@ func resolveCompositeLocalSpec(parentSpec, rel string) string {
 	return joined + "@" + ref
 }
 
-// checkEnvFlags reports env entries that pin workflows to the deprecated
-// runtime. Matching is case-insensitive because GitHub env names are.
+// checkEnvFlags reports env vars pinning the deprecated runtime; GitHub env
+// names are case-insensitive.
 func (rule *DeprecatedNodeRuntimeRule) checkEnvFlags(env *ast.Env) {
 	if env == nil || env.Vars == nil {
 		return
@@ -242,8 +219,7 @@ func (rule *DeprecatedNodeRuntimeRule) checkEnvFlags(env *ast.Env) {
 
 var nodeMajorTagPattern = regexp.MustCompile(`^v(\d+)(?:\..*)?$`)
 
-// parseMajorFromRef extracts the major version from tag-style refs such as
-// "v4" or "v4.1.2". Returns false for branches, SHAs, and anything else.
+// parseMajorFromRef parses "v4" / "v4.1.2" tags; false for branches and SHAs.
 func parseMajorFromRef(ref string) (int, bool) {
 	m := nodeMajorTagPattern.FindStringSubmatch(ref)
 	if m == nil {
@@ -256,9 +232,8 @@ func parseMajorFromRef(ref string) (int, bool) {
 	return major, true
 }
 
-// checkKnownNode20Action matches `uses:` against the embedded table of
-// popular actions. Fallback path for when the metadata resolver is
-// unavailable.
+// checkKnownNode20Action is the offline fallback: match `uses:` against the
+// embedded table when the metadata resolver is unavailable.
 func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, action *ast.ExecAction) {
 	owner, repo, ref := parseUsesValue(action.Uses.Value)
 	if owner == "" || repo == "" || ref == "" {
@@ -272,8 +247,7 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 	major, isTag := parseMajorFromRef(ref)
 	fixable := isTag
 	if !isTag {
-		// SHA-pinned refs carry the human-readable tag as a line comment when
-		// pinned by the commit-sha auto-fix (e.g. "# v4.1.1").
+		// SHA pins carry the tag as a "# v4.1.1" comment (commit-sha auto-fix).
 		comment := strings.TrimSpace(strings.TrimPrefix(action.Uses.BaseNode.LineComment, "#"))
 		if m, ok := parseMajorFromRef(comment); ok {
 			major = m
@@ -283,7 +257,7 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 	}
 
 	if major >= first {
-		return // already on a node24-capable major
+		return
 	}
 
 	actionPath := strings.TrimSuffix(action.Uses.Value, "@"+ref)
@@ -295,9 +269,8 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 	}
 }
 
-// eolNodeBuildTargets are Node.js majors that are EOL as build targets
-// (distinct from the action runtime): 16 (2023-09-11), 18 (2025-04-30),
-// 20 (2026-04-30). Source: https://github.com/nodejs/Release
+// EOL dates of Node.js majors as build targets (distinct from the action
+// runtime). Source: https://github.com/nodejs/Release
 var eolNodeBuildTargets = map[int]string{
 	12: "2022-04-30",
 	14: "2023-04-30",
@@ -306,10 +279,8 @@ var eolNodeBuildTargets = map[int]string{
 	20: "2026-04-30",
 }
 
-// checkEOLNodeBuildTarget warns when actions/setup-node installs an EOL
-// Node.js as the build/test runtime. Diagnose-only: bumping the project's
-// Node target is a semantic change (package compatibility, engines field)
-// that the maintainer must drive, typically via Renovate/Dependabot.
+// checkEOLNodeBuildTarget flags EOL `node-version:` in actions/setup-node.
+// Diagnose-only: bumping the build target is the project owner's decision.
 func (rule *DeprecatedNodeRuntimeRule) checkEOLNodeBuildTarget(action *ast.ExecAction) {
 	owner, repo, _ := parseUsesValue(action.Uses.Value)
 	if !strings.EqualFold(owner, "actions") || !strings.EqualFold(repo, "setup-node") {
@@ -335,9 +306,8 @@ func (rule *DeprecatedNodeRuntimeRule) checkEOLNodeBuildTarget(action *ast.ExecA
 	}
 }
 
-// FixStep bumps a known node20-generation action tag to the first
-// node24-capable major (e.g. actions/checkout@v4 -> @v5). SHA-pinned refs are
-// left to the commit-sha rule to re-pin after the bump.
+// FixStep bumps a table-known tag to the first node24-capable major.
+// SHA-pinned refs are left to the commit-sha rule.
 func (rule *DeprecatedNodeRuntimeRule) FixStep(step *ast.Step) error {
 	action, ok := step.Exec.(*ast.ExecAction)
 	if !ok || action.Uses == nil {
@@ -352,8 +322,7 @@ func (rule *DeprecatedNodeRuntimeRule) FixStep(step *ast.Step) error {
 	if !isTag || major >= first {
 		return nil
 	}
-	// Preserve any subpath (e.g. actions/cache/restore@v4 must stay
-	// actions/cache/restore@v5, not become actions/cache@v5).
+	// Keep subpaths: actions/cache/restore@v4 -> actions/cache/restore@v5.
 	actionPath := strings.TrimSuffix(action.Uses.Value, "@"+ref)
 	action.Uses.BaseNode.Value = fmt.Sprintf("%s@v%d", actionPath, first)
 	return nil

--- a/pkg/core/deprecated_node_runtime.go
+++ b/pkg/core/deprecated_node_runtime.go
@@ -44,25 +44,21 @@ type DeprecatedNodeRuntimeRule struct {
 	metadataResolver ActionMetadataResolver
 }
 
-// nodeRuntimeUpgrade describes, for a well-known action, the newest major
-// version still running on node20 and the first major that declares node24.
-type nodeRuntimeUpgrade struct {
-	lastNode20Major  int
-	firstNode24Major int
-}
-
-// nodeRuntimeUpgrades is an embedded snapshot (verified 2026-07 against each
-// action's action.yml `runs.using` field). Maintained by hand: update an
-// entry when the listed action publishes a new major.
-var nodeRuntimeUpgrades = map[string]nodeRuntimeUpgrade{
-	"actions/checkout":          {lastNode20Major: 4, firstNode24Major: 5},
-	"actions/setup-node":        {lastNode20Major: 4, firstNode24Major: 5},
-	"actions/setup-python":      {lastNode20Major: 5, firstNode24Major: 6},
-	"actions/setup-go":          {lastNode20Major: 5, firstNode24Major: 6},
-	"actions/github-script":     {lastNode20Major: 7, firstNode24Major: 8},
-	"actions/cache":             {lastNode20Major: 4, firstNode24Major: 5},
-	"actions/upload-artifact":   {lastNode20Major: 4, firstNode24Major: 6},
-	"actions/download-artifact": {lastNode20Major: 6, firstNode24Major: 7},
+// nodeRuntimeFirstNode24Major maps well-known actions to the first major that
+// declares `runs.using: node24`; every lower major is treated as deprecated.
+// This single boundary intentionally covers gap majors such as
+// actions/upload-artifact v5, whose v5.0.0 tag still declares node20.
+// Maintained by hand (verified 2026-07 against each action's action.yml):
+// update an entry when the listed action publishes a new major.
+var nodeRuntimeFirstNode24Major = map[string]int{
+	"actions/checkout":          5,
+	"actions/setup-node":        5,
+	"actions/setup-python":      6,
+	"actions/setup-go":          6,
+	"actions/github-script":     8,
+	"actions/cache":             5,
+	"actions/upload-artifact":   6,
+	"actions/download-artifact": 7,
 }
 
 // deprecatedNodeRuntimes are `runs.using` values that no longer receive
@@ -110,10 +106,6 @@ func (rule *DeprecatedNodeRuntimeRule) VisitStep(step *ast.Step) error {
 
 	rule.checkEOLNodeBuildTarget(action)
 
-	// Resolver-first: the action.yml at the pinned ref is the ground truth.
-	// The embedded-table/comment heuristic only runs when resolution is
-	// unavailable, so a stale "# v5" comment next to a node24 SHA cannot
-	// produce a false positive as long as the resolver answers.
 	if meta := rule.resolveMetadata(uses); meta != nil && meta.Runs != nil {
 		using := strings.ToLower(meta.Runs.Using)
 		if reason, deprecated := deprecatedNodeRuntimes[using]; deprecated {
@@ -153,10 +145,10 @@ func (rule *DeprecatedNodeRuntimeRule) reportDeprecatedRuntime(step *ast.Step, a
 	upgradeHint := "Update the action to a version that declares node24, or contact the action maintainer."
 	fixable := false
 	owner, repo, ref := parseUsesValue(uses)
-	if upgrade, known := nodeRuntimeUpgrades[strings.ToLower(owner+"/"+repo)]; known && ref != "" {
+	if first, known := nodeRuntimeFirstNode24Major[strings.ToLower(owner+"/"+repo)]; known && ref != "" {
 		actionPath := strings.TrimSuffix(uses, "@"+ref)
-		upgradeHint = fmt.Sprintf("Update to %s@v%d or later, which runs on node24.", actionPath, upgrade.firstNode24Major)
-		if major, isTag := parseMajorFromRef(ref); isTag && major <= upgrade.lastNode20Major {
+		upgradeHint = fmt.Sprintf("Update to %s@v%d or later, which runs on node24.", actionPath, first)
+		if major, isTag := parseMajorFromRef(ref); isTag && major < first {
 			fixable = true
 		}
 	}
@@ -265,14 +257,14 @@ func parseMajorFromRef(ref string) (int, bool) {
 }
 
 // checkKnownNode20Action matches `uses:` against the embedded table of
-// popular actions with known node20 majors. Fallback path for when the
-// metadata resolver is unavailable.
+// popular actions. Fallback path for when the metadata resolver is
+// unavailable.
 func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, action *ast.ExecAction) {
 	owner, repo, ref := parseUsesValue(action.Uses.Value)
 	if owner == "" || repo == "" || ref == "" {
 		return
 	}
-	upgrade, known := nodeRuntimeUpgrades[strings.ToLower(owner+"/"+repo)]
+	first, known := nodeRuntimeFirstNode24Major[strings.ToLower(owner+"/"+repo)]
 	if !known {
 		return
 	}
@@ -290,14 +282,14 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 		}
 	}
 
-	if major > upgrade.lastNode20Major {
+	if major >= first {
 		return // already on a node24-capable major
 	}
 
 	actionPath := strings.TrimSuffix(action.Uses.Value, "@"+ref)
 	rule.Errorf(action.Uses.Pos,
 		"action '%s@%s' runs on the deprecated Node.js 20 runtime (%s). Update to %s@v%d or later, which runs on node24. See %s",
-		actionPath, ref, deprecatedNodeRuntimes["node20"], actionPath, upgrade.firstNode24Major, nodeRuntimeDocURL)
+		actionPath, ref, deprecatedNodeRuntimes["node20"], actionPath, first, nodeRuntimeDocURL)
 	if fixable {
 		rule.AddAutoFixer(NewStepFixer(step, rule))
 	}
@@ -328,7 +320,7 @@ func (rule *DeprecatedNodeRuntimeRule) checkEOLNodeBuildTarget(action *ast.ExecA
 		return
 	}
 	raw := strings.TrimSpace(input.Value.Value)
-	if raw == "" || strings.Contains(raw, "${{") {
+	if raw == "" || input.Value.ContainsExpression() {
 		return
 	}
 	majorPart := strings.SplitN(strings.TrimPrefix(raw, "v"), ".", 2)[0]
@@ -352,17 +344,17 @@ func (rule *DeprecatedNodeRuntimeRule) FixStep(step *ast.Step) error {
 		return nil
 	}
 	owner, repo, ref := parseUsesValue(action.Uses.Value)
-	upgrade, known := nodeRuntimeUpgrades[strings.ToLower(owner+"/"+repo)]
+	first, known := nodeRuntimeFirstNode24Major[strings.ToLower(owner+"/"+repo)]
 	if !known {
 		return nil
 	}
 	major, isTag := parseMajorFromRef(ref)
-	if !isTag || major > upgrade.lastNode20Major {
+	if !isTag || major >= first {
 		return nil
 	}
 	// Preserve any subpath (e.g. actions/cache/restore@v4 must stay
 	// actions/cache/restore@v5, not become actions/cache@v5).
 	actionPath := strings.TrimSuffix(action.Uses.Value, "@"+ref)
-	action.Uses.BaseNode.Value = fmt.Sprintf("%s@v%d", actionPath, upgrade.firstNode24Major)
+	action.Uses.BaseNode.Value = fmt.Sprintf("%s@v%d", actionPath, first)
 	return nil
 }

--- a/pkg/core/deprecated_node_runtime.go
+++ b/pkg/core/deprecated_node_runtime.go
@@ -11,17 +11,17 @@ import (
 )
 
 // DeprecatedNodeRuntimeRule detects workflows depending on deprecated
-// Node.js action runtimes (node20: EOL 2026-04-30, removed from the runner
-// 2026-09-16; node12/16: already removed).
+// Node.js action runtimes. node20 is EOL since 2026-04-30 and will be
+// removed from the runner on 2026-09-16; node12/16 are already removed.
 //
-// Detections (resolver-first: the resolved action.yml's `runs.using` is the
-// ground truth):
+// Detections, resolver-first: the resolved action.yml's `runs.using` is the
+// ground truth.
 //  1. actions declaring a deprecated runtime; auto-fix bumps well-known
 //     tags to the first node24-capable major
-//  2. composite actions with deprecated direct steps (depth-1, diagnose-only)
+//  2. composite actions with deprecated direct steps, depth-1, diagnose-only
 //  3. offline fallback via the embedded table when the resolver is unavailable
-//  4. env vars pinning the deprecated runtime (diagnose-only)
-//  5. EOL `node-version:` build targets in setup-node (diagnose-only)
+//  4. env vars pinning the deprecated runtime, diagnose-only
+//  5. EOL `node-version:` build targets in setup-node, diagnose-only
 //
 // See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 type DeprecatedNodeRuntimeRule struct {
@@ -31,8 +31,8 @@ type DeprecatedNodeRuntimeRule struct {
 
 // First major of each well-known action that declares `runs.using: node24`;
 // every lower major is deprecated, including gap majors such as
-// upload-artifact v5 (v5.0.0 still declares node20). Hand-maintained,
-// verified 2026-07 against each action.yml.
+// upload-artifact v5. Hand-maintained, verified 2026-07 against each
+// action.yml.
 var nodeRuntimeFirstNode24Major = map[string]int{
 	"actions/checkout":          5,
 	"actions/setup-node":        5,
@@ -141,7 +141,7 @@ func (rule *DeprecatedNodeRuntimeRule) reportDeprecatedRuntime(step *ast.Step, a
 }
 
 // checkCompositeTransitive reports deprecated runtimes in a composite's
-// direct steps (depth-1 only). Diagnose-only: the fix belongs to the
+// direct steps, depth-1 only. Diagnose-only: the fix belongs to the
 // composite's maintainer.
 func (rule *DeprecatedNodeRuntimeRule) checkCompositeTransitive(action *ast.ExecAction, parentSpec string, meta *ActionMetadata) {
 	for _, s := range meta.Runs.Steps {
@@ -247,7 +247,7 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 	major, isTag := parseMajorFromRef(ref)
 	fixable := isTag
 	if !isTag {
-		// SHA pins carry the tag as a "# v4.1.1" comment (commit-sha auto-fix).
+		// SHA pins carry the tag as a "# v4.1.1" line comment.
 		comment := strings.TrimSpace(strings.TrimPrefix(action.Uses.BaseNode.LineComment, "#"))
 		if m, ok := parseMajorFromRef(comment); ok {
 			major = m
@@ -269,8 +269,8 @@ func (rule *DeprecatedNodeRuntimeRule) checkKnownNode20Action(step *ast.Step, ac
 	}
 }
 
-// EOL dates of Node.js majors as build targets (distinct from the action
-// runtime). Source: https://github.com/nodejs/Release
+// EOL dates of Node.js majors as build targets.
+// Source: https://github.com/nodejs/Release
 var eolNodeBuildTargets = map[int]string{
 	12: "2022-04-30",
 	14: "2023-04-30",

--- a/pkg/core/deprecated_node_runtime_test.go
+++ b/pkg/core/deprecated_node_runtime_test.go
@@ -80,6 +80,8 @@ func TestDeprecatedNodeRuntimeKnownActions(t *testing.T) {
 		{"github-script v7 is node20", "actions/github-script@v7", "", 1, 1},
 		{"github-script v8 is node24", "actions/github-script@v8", "", 0, 0},
 		{"download-artifact v6 is node20", "actions/download-artifact@v6", "", 1, 1},
+		{"upload-artifact v5 gap major is node20", "actions/upload-artifact@v5", "", 1, 1},
+		{"upload-artifact v6 is node24", "actions/upload-artifact@v6", "", 0, 0},
 		{"sha pinned with tag comment detected but not fixed", "actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675", "# v4.1.1", 1, 0},
 		{"sha pinned without comment falls through silently", "actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675", "", 0, 0},
 		{"unknown action is not matched", "someorg/someaction@v1", "", 0, 0},
@@ -166,8 +168,8 @@ func TestDeprecatedNodeRuntimeResolver(t *testing.T) {
 }
 
 // TestDeprecatedNodeRuntimeResolverFirst verifies that the resolved
-// action.yml wins over the embedded-table/comment heuristic: a stale "# v5"
-// comment next to a node24 SHA must not produce a false positive.
+// action.yml wins over the embedded-table/comment heuristic, so a stale
+// version comment next to a SHA pin cannot flip the verdict either way.
 func TestDeprecatedNodeRuntimeResolverFirst(t *testing.T) {
 	sha := "a309ff8b426b58ec0e2a45f0f869d46889d02405"
 
@@ -409,6 +411,7 @@ func TestDeprecatedNodeRuntimeFixStep(t *testing.T) {
 		{"cache restore subpath preserved", "actions/cache/restore@v4", "actions/cache/restore@v5"},
 		{"cache save subpath preserved", "actions/cache/save@v4", "actions/cache/save@v5"},
 		{"upload-artifact v4 bumped to v6", "actions/upload-artifact@v4", "actions/upload-artifact@v6"},
+		{"upload-artifact v5 gap major bumped to v6", "actions/upload-artifact@v5", "actions/upload-artifact@v6"},
 		{"github-script v7 bumped to v8", "actions/github-script@v7", "actions/github-script@v8"},
 		{"already node24 untouched", "actions/checkout@v5", "actions/checkout@v5"},
 		{"unknown action untouched", "someorg/someaction@v1", "someorg/someaction@v1"},

--- a/pkg/core/deprecated_node_runtime_test.go
+++ b/pkg/core/deprecated_node_runtime_test.go
@@ -1,0 +1,430 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sisaku-security/sisakulint/pkg/ast"
+	"gopkg.in/yaml.v3"
+)
+
+func nodeRuntimeTestStep(uses string, lineComment string) *ast.Step {
+	return &ast.Step{
+		Exec: &ast.ExecAction{
+			Uses: &ast.String{
+				Value: uses,
+				Pos:   &ast.Position{Line: 1, Col: 1},
+				BaseNode: &yaml.Node{
+					Kind:        yaml.ScalarNode,
+					Value:       uses,
+					LineComment: lineComment,
+				},
+			},
+		},
+		Pos: &ast.Position{Line: 1, Col: 1},
+	}
+}
+
+type fakeMetadataResolver struct {
+	meta map[string]*ActionMetadata
+	err  error
+}
+
+func (r *fakeMetadataResolver) FindMetadata(spec string) (*ActionMetadata, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.meta[spec], nil
+}
+
+func TestNewDeprecatedNodeRuntimeRule(t *testing.T) {
+	rule := NewDeprecatedNodeRuntimeRule(nil)
+	if rule.RuleName != "deprecated-node-runtime" {
+		t.Errorf("expected RuleName 'deprecated-node-runtime', got %q", rule.RuleName)
+	}
+}
+
+func TestParseMajorFromRef(t *testing.T) {
+	tests := []struct {
+		ref   string
+		major int
+		ok    bool
+	}{
+		{"v4", 4, true},
+		{"v4.1.2", 4, true},
+		{"v10", 10, true},
+		{"main", 0, false},
+		{"a81bbbf8298c0fa03ea29cdc473d45769f953675", 0, false},
+		{"", 0, false},
+		{"4", 0, false},
+	}
+	for _, tt := range tests {
+		major, ok := parseMajorFromRef(tt.ref)
+		if major != tt.major || ok != tt.ok {
+			t.Errorf("parseMajorFromRef(%q) = (%d, %v), want (%d, %v)", tt.ref, major, ok, tt.major, tt.ok)
+		}
+	}
+}
+
+func TestDeprecatedNodeRuntimeKnownActions(t *testing.T) {
+	tests := []struct {
+		name       string
+		uses       string
+		comment    string
+		wantErrors int
+		wantFixers int
+	}{
+		{"checkout v4 is node20", "actions/checkout@v4", "", 1, 1},
+		{"checkout v4 full semver", "actions/checkout@v4.2.2", "", 1, 1},
+		{"checkout v5 is node24", "actions/checkout@v5", "", 0, 0},
+		{"github-script v7 is node20", "actions/github-script@v7", "", 1, 1},
+		{"github-script v8 is node24", "actions/github-script@v8", "", 0, 0},
+		{"download-artifact v6 is node20", "actions/download-artifact@v6", "", 1, 1},
+		{"sha pinned with tag comment detected but not fixed", "actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675", "# v4.1.1", 1, 0},
+		{"sha pinned without comment falls through silently", "actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675", "", 0, 0},
+		{"unknown action is not matched", "someorg/someaction@v1", "", 0, 0},
+		{"branch ref is not matched", "actions/checkout@main", "", 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewDeprecatedNodeRuntimeRule(nil)
+			step := nodeRuntimeTestStep(tt.uses, tt.comment)
+			if err := rule.VisitStep(step); err != nil {
+				t.Fatalf("VisitStep returned error: %v", err)
+			}
+			if got := len(rule.Errors()); got != tt.wantErrors {
+				t.Errorf("expected %d errors, got %d: %v", tt.wantErrors, got, rule.Errors())
+			}
+			if got := len(rule.AutoFixers()); got != tt.wantFixers {
+				t.Errorf("expected %d autofixers, got %d", tt.wantFixers, got)
+			}
+		})
+	}
+}
+
+func TestDeprecatedNodeRuntimeResolver(t *testing.T) {
+	tests := []struct {
+		name       string
+		uses       string
+		meta       *ActionMetadata
+		resolveErr error
+		wantErrors int
+	}{
+		{
+			name:       "resolved node20 runtime is reported",
+			uses:       "someorg/node20-action@v1",
+			meta:       &ActionMetadata{Runs: &ActionRunsMetadata{Using: "node20"}},
+			wantErrors: 1,
+		},
+		{
+			name:       "resolved node16 runtime is reported",
+			uses:       "someorg/node16-action@v1",
+			meta:       &ActionMetadata{Runs: &ActionRunsMetadata{Using: "node16"}},
+			wantErrors: 1,
+		},
+		{
+			name:       "resolved node24 runtime is fine",
+			uses:       "someorg/node24-action@v1",
+			meta:       &ActionMetadata{Runs: &ActionRunsMetadata{Using: "node24"}},
+			wantErrors: 0,
+		},
+		{
+			name:       "composite action is fine",
+			uses:       "someorg/composite-action@v1",
+			meta:       &ActionMetadata{Runs: &ActionRunsMetadata{Using: "composite"}},
+			wantErrors: 0,
+		},
+		{
+			name:       "resolver failure is skipped silently",
+			uses:       "someorg/unreachable@v1",
+			resolveErr: errors.New("network down"),
+			wantErrors: 0,
+		},
+		{
+			name:       "local action resolved to node20 is reported",
+			uses:       "./local-node20-action",
+			meta:       &ActionMetadata{Runs: &ActionRunsMetadata{Using: "node20"}},
+			wantErrors: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &fakeMetadataResolver{
+				meta: map[string]*ActionMetadata{tt.uses: tt.meta},
+				err:  tt.resolveErr,
+			}
+			rule := NewDeprecatedNodeRuntimeRule(resolver)
+			step := nodeRuntimeTestStep(tt.uses, "")
+			if err := rule.VisitStep(step); err != nil {
+				t.Fatalf("VisitStep returned error: %v", err)
+			}
+			if got := len(rule.Errors()); got != tt.wantErrors {
+				t.Errorf("expected %d errors, got %d: %v", tt.wantErrors, got, rule.Errors())
+			}
+		})
+	}
+}
+
+// TestDeprecatedNodeRuntimeResolverFirst verifies that the resolved
+// action.yml wins over the embedded-table/comment heuristic (issue found in
+// the real-world evaluation: a stale "# v5" comment next to a node24 SHA
+// produced a false positive when the comment was trusted).
+func TestDeprecatedNodeRuntimeResolverFirst(t *testing.T) {
+	sha := "a309ff8b426b58ec0e2a45f0f869d46889d02405"
+
+	t.Run("stale node20 comment on node24 SHA is not flagged", func(t *testing.T) {
+		uses := "actions/setup-python@" + sha
+		resolver := &fakeMetadataResolver{meta: map[string]*ActionMetadata{
+			uses: {Runs: &ActionRunsMetadata{Using: "node24"}},
+		}}
+		rule := NewDeprecatedNodeRuntimeRule(resolver)
+		step := nodeRuntimeTestStep(uses, "# v5")
+		if err := rule.VisitStep(step); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 0 {
+			t.Errorf("expected 0 errors, got %d: %v", len(rule.Errors()), rule.Errors())
+		}
+	})
+
+	t.Run("stale node24 comment on node20 SHA is flagged via resolver", func(t *testing.T) {
+		uses := "actions/setup-python@" + sha
+		resolver := &fakeMetadataResolver{meta: map[string]*ActionMetadata{
+			uses: {Runs: &ActionRunsMetadata{Using: "node20"}},
+		}}
+		rule := NewDeprecatedNodeRuntimeRule(resolver)
+		step := nodeRuntimeTestStep(uses, "# v6.2.0")
+		if err := rule.VisitStep(step); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 1 {
+			t.Errorf("expected 1 error, got %d: %v", len(rule.Errors()), rule.Errors())
+		}
+		if len(rule.AutoFixers()) != 0 {
+			t.Errorf("SHA-pinned ref must not be auto-fixed, got %d fixers", len(rule.AutoFixers()))
+		}
+	})
+
+	t.Run("resolver-confirmed node20 tag of known action gets autofixer", func(t *testing.T) {
+		uses := "actions/checkout@v4"
+		resolver := &fakeMetadataResolver{meta: map[string]*ActionMetadata{
+			uses: {Runs: &ActionRunsMetadata{Using: "node20"}},
+		}}
+		rule := NewDeprecatedNodeRuntimeRule(resolver)
+		step := nodeRuntimeTestStep(uses, "")
+		if err := rule.VisitStep(step); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 1 || len(rule.AutoFixers()) != 1 {
+			t.Errorf("expected 1 error and 1 fixer, got %d/%d", len(rule.Errors()), len(rule.AutoFixers()))
+		}
+	})
+}
+
+func TestDeprecatedNodeRuntimeCompositeTransitive(t *testing.T) {
+	parent := "codecov/codecov-action@v5"
+
+	t.Run("composite with node20 internal step is reported", func(t *testing.T) {
+		resolver := &fakeMetadataResolver{meta: map[string]*ActionMetadata{
+			parent: {Runs: &ActionRunsMetadata{Using: "composite", Steps: []*ActionStepMetadata{
+				{Uses: "actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea"},
+			}}},
+			"actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea": {Runs: &ActionRunsMetadata{Using: "node20"}},
+		}}
+		rule := NewDeprecatedNodeRuntimeRule(resolver)
+		step := nodeRuntimeTestStep(parent, "")
+		if err := rule.VisitStep(step); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 1 {
+			t.Fatalf("expected 1 error, got %d: %v", len(rule.Errors()), rule.Errors())
+		}
+		if len(rule.AutoFixers()) != 0 {
+			t.Errorf("transitive findings must be diagnose-only, got %d fixers", len(rule.AutoFixers()))
+		}
+	})
+
+	t.Run("composite-relative uses resolves within parent repo at same ref", func(t *testing.T) {
+		p := "actions/attest-build-provenance@v2"
+		resolver := &fakeMetadataResolver{meta: map[string]*ActionMetadata{
+			p: {Runs: &ActionRunsMetadata{Using: "composite", Steps: []*ActionStepMetadata{
+				{Uses: "./predicate"},
+			}}},
+			"actions/attest-build-provenance/predicate@v2": {Runs: &ActionRunsMetadata{Using: "node20"}},
+		}}
+		rule := NewDeprecatedNodeRuntimeRule(resolver)
+		step := nodeRuntimeTestStep(p, "")
+		if err := rule.VisitStep(step); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 1 {
+			t.Errorf("expected 1 error, got %d: %v", len(rule.Errors()), rule.Errors())
+		}
+	})
+
+	t.Run("nested composite is not followed beyond depth 1", func(t *testing.T) {
+		resolver := &fakeMetadataResolver{meta: map[string]*ActionMetadata{
+			parent: {Runs: &ActionRunsMetadata{Using: "composite", Steps: []*ActionStepMetadata{
+				{Uses: "someorg/inner-composite@v1"},
+			}}},
+			"someorg/inner-composite@v1": {Runs: &ActionRunsMetadata{Using: "composite", Steps: []*ActionStepMetadata{
+				{Uses: "someorg/deep-node20@v1"},
+			}}},
+			"someorg/deep-node20@v1": {Runs: &ActionRunsMetadata{Using: "node20"}},
+		}}
+		rule := NewDeprecatedNodeRuntimeRule(resolver)
+		step := nodeRuntimeTestStep(parent, "")
+		if err := rule.VisitStep(step); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 0 {
+			t.Errorf("depth-1 only: expected 0 errors, got %d: %v", len(rule.Errors()), rule.Errors())
+		}
+	})
+
+	t.Run("composite with healthy internals is silent", func(t *testing.T) {
+		resolver := &fakeMetadataResolver{meta: map[string]*ActionMetadata{
+			parent: {Runs: &ActionRunsMetadata{Using: "composite", Steps: []*ActionStepMetadata{
+				{Uses: "actions/checkout@v5"},
+				{Uses: "docker://alpine:3"},
+			}}},
+			"actions/checkout@v5": {Runs: &ActionRunsMetadata{Using: "node24"}},
+		}}
+		rule := NewDeprecatedNodeRuntimeRule(resolver)
+		step := nodeRuntimeTestStep(parent, "")
+		if err := rule.VisitStep(step); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 0 {
+			t.Errorf("expected 0 errors, got %d: %v", len(rule.Errors()), rule.Errors())
+		}
+	})
+}
+
+func TestResolveCompositeLocalSpec(t *testing.T) {
+	tests := []struct {
+		parent string
+		rel    string
+		want   string
+	}{
+		{"actions/attest-build-provenance@v2", "./predicate", "actions/attest-build-provenance/predicate@v2"},
+		{"owner/repo/sub@v1", "./inner", "owner/repo/sub/inner@v1"},
+		{"owner/repo@v1", "../../evil", ""},
+		{"owner/repo@v1", "./", "owner/repo@v1"},
+		{"malformed", "./x", ""},
+	}
+	for _, tt := range tests {
+		if got := resolveCompositeLocalSpec(tt.parent, tt.rel); got != tt.want {
+			t.Errorf("resolveCompositeLocalSpec(%q, %q) = %q, want %q", tt.parent, tt.rel, got, tt.want)
+		}
+	}
+}
+
+func TestDeprecatedNodeRuntimeEnvFlags(t *testing.T) {
+	env := func(name string) *ast.Env {
+		return &ast.Env{Vars: map[string]*ast.EnvVar{
+			name: {
+				Name:  &ast.String{Value: name, Pos: &ast.Position{Line: 2, Col: 3}},
+				Value: &ast.String{Value: "true", Pos: &ast.Position{Line: 2, Col: 10}},
+			},
+		}}
+	}
+
+	t.Run("unsecure opt-out on workflow env", func(t *testing.T) {
+		rule := NewDeprecatedNodeRuntimeRule(nil)
+		wf := &ast.Workflow{Env: env("ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION")}
+		if err := rule.VisitWorkflowPre(wf); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 1 {
+			t.Errorf("expected 1 error, got %d", len(rule.Errors()))
+		}
+	})
+
+	t.Run("dead node20 force flag on job env", func(t *testing.T) {
+		rule := NewDeprecatedNodeRuntimeRule(nil)
+		job := &ast.Job{Env: env("FORCE_JAVASCRIPT_ACTIONS_TO_NODE20")}
+		if err := rule.VisitJobPre(job); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 1 {
+			t.Errorf("expected 1 error, got %d", len(rule.Errors()))
+		}
+	})
+
+	t.Run("node24 force flag is not flagged", func(t *testing.T) {
+		rule := NewDeprecatedNodeRuntimeRule(nil)
+		wf := &ast.Workflow{Env: env("FORCE_JAVASCRIPT_ACTIONS_TO_NODE24")}
+		if err := rule.VisitWorkflowPre(wf); err != nil {
+			t.Fatal(err)
+		}
+		if len(rule.Errors()) != 0 {
+			t.Errorf("expected 0 errors, got %d: %v", len(rule.Errors()), rule.Errors())
+		}
+	})
+}
+
+func TestDeprecatedNodeRuntimeEOLBuildTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		wantErrors int
+	}{
+		{"node 20 is EOL", "20", 1},
+		{"node 20.x is EOL", "20.11.1", 1},
+		{"node 18 is EOL", "18", 1},
+		{"node 22 is supported", "22", 0},
+		{"node 24 is supported", "24", 0},
+		{"expression is skipped", "${{ matrix.node }}", 0},
+		{"non-numeric is skipped", "lts/*", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewDeprecatedNodeRuntimeRule(nil)
+			// v6 of setup-node is node24-capable, so only the build target check fires.
+			step := nodeRuntimeTestStep("actions/setup-node@v6", "")
+			action := step.Exec.(*ast.ExecAction)
+			action.Inputs = map[string]*ast.Input{
+				"node-version": {
+					Name:  &ast.String{Value: "node-version", Pos: &ast.Position{Line: 3, Col: 5}},
+					Value: &ast.String{Value: tt.version, Pos: &ast.Position{Line: 3, Col: 20}},
+				},
+			}
+			if err := rule.VisitStep(step); err != nil {
+				t.Fatal(err)
+			}
+			if got := len(rule.Errors()); got != tt.wantErrors {
+				t.Errorf("expected %d errors, got %d: %v", tt.wantErrors, got, rule.Errors())
+			}
+		})
+	}
+}
+
+func TestDeprecatedNodeRuntimeFixStep(t *testing.T) {
+	tests := []struct {
+		name      string
+		uses      string
+		wantValue string
+	}{
+		{"checkout v4 bumped to v5", "actions/checkout@v4", "actions/checkout@v5"},
+		{"cache restore subpath preserved", "actions/cache/restore@v4", "actions/cache/restore@v5"},
+		{"cache save subpath preserved", "actions/cache/save@v4", "actions/cache/save@v5"},
+		{"upload-artifact v4 bumped to v6", "actions/upload-artifact@v4", "actions/upload-artifact@v6"},
+		{"github-script v7 bumped to v8", "actions/github-script@v7", "actions/github-script@v8"},
+		{"already node24 untouched", "actions/checkout@v5", "actions/checkout@v5"},
+		{"unknown action untouched", "someorg/someaction@v1", "someorg/someaction@v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewDeprecatedNodeRuntimeRule(nil)
+			step := nodeRuntimeTestStep(tt.uses, "")
+			if err := rule.FixStep(step); err != nil {
+				t.Fatalf("FixStep returned error: %v", err)
+			}
+			got := step.Exec.(*ast.ExecAction).Uses.BaseNode.Value
+			if got != tt.wantValue {
+				t.Errorf("expected %q, got %q", tt.wantValue, got)
+			}
+		})
+	}
+}

--- a/pkg/core/deprecated_node_runtime_test.go
+++ b/pkg/core/deprecated_node_runtime_test.go
@@ -166,9 +166,8 @@ func TestDeprecatedNodeRuntimeResolver(t *testing.T) {
 }
 
 // TestDeprecatedNodeRuntimeResolverFirst verifies that the resolved
-// action.yml wins over the embedded-table/comment heuristic (issue found in
-// the real-world evaluation: a stale "# v5" comment next to a node24 SHA
-// produced a false positive when the comment was trusted).
+// action.yml wins over the embedded-table/comment heuristic: a stale "# v5"
+// comment next to a node24 SHA must not produce a false positive.
 func TestDeprecatedNodeRuntimeResolverFirst(t *testing.T) {
 	sha := "a309ff8b426b58ec0e2a45f0f869d46889d02405"
 

--- a/pkg/core/known_vulnerable_actions_test.go
+++ b/pkg/core/known_vulnerable_actions_test.go
@@ -91,7 +91,7 @@ func TestKnownVulnerableActionsRuleExplicitTokenOverridesEnvironment(t *testing.
 }
 
 func TestMakeRulesPassesGitHubTokenToKnownVulnerableActionsRule(t *testing.T) {
-	rules := makeRules(".github/workflows/ci.yml", false, "flag-token", nil, nil)
+	rules := makeRules(".github/workflows/ci.yml", false, "flag-token", nil, nil, nil)
 
 	for _, rule := range rules {
 		known, ok := rule.(*KnownVulnerableActionsRule)

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -121,7 +121,7 @@ type Linter struct {
 	// 追跡し、複数ファイル並行 validate でログが重複しないようにするためのセット。
 	loggedConfigs sync.Map
 	// remoteActionsCache は lint 実行全体で共有する remote action.yml の
-	// キャッシュ (per-file 生成だと同一アクションを重複 fetch するため)。
+	// キャッシュ。
 	remoteActionsCache *RemoteActionsMetadataCache
 }
 
@@ -599,7 +599,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 	if localActions != nil {
 		debugOut = localActions.dbg
 	}
-	// remoteActions is run-wide (from the Linter); nil gets a per-call cache.
+	// remoteActions is run-wide; nil gets a per-call cache.
 	if remoteActions == nil {
 		remoteActions = NewRemoteActionsMetadataCache(debugOut)
 	}
@@ -651,7 +651,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 		NewUnsoundContainsRule(),                                      // Detects bypassable contains() function usage in conditions
 		NewSelfHostedRunnersRule(),                                    // Detects self-hosted runner usage which may be dangerous in public repos
 		NewArchivedUsesRule(),                                         // Detects usage of archived actions/reusable workflows
-		NewDeprecatedNodeRuntimeRule(actionMetadata),                  // Detects actions on the deprecated node20 runtime (EOL) and unsecure runtime pinning
+		NewDeprecatedNodeRuntimeRule(actionMetadata),                  // Detects actions on the EOL node20 runtime and unsecure runtime pinning
 		NewUnpinnedImagesRule(),                                       // Detects container images not pinned by SHA256 digest
 		NewSecretsInArtifactsRule(),                                   // Detects secrets exposure in artifact uploads (CWE-312)
 		NewSecretExfiltrationRule(),                                   // Detects secret exfiltration via network commands

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -120,6 +120,10 @@ type Linter struct {
 	// loggedConfigs は、`setting configuration: ...` をすでに出力済みの *Config を
 	// 追跡し、複数ファイル並行 validate でログが重複しないようにするためのセット。
 	loggedConfigs sync.Map
+	// remoteActionsCache は lint 実行全体で共有されるリモート action.yml の
+	// メタデータキャッシュ。per-file に生成すると同じアクションを何度も
+	// fetch してしまうため、Linter 単位で 1 つ持つ (内部は mutex で並行安全)。
+	remoteActionsCache *RemoteActionsMetadataCache
 }
 
 // NewLinterは新しいLinterインスタンスを作成する
@@ -196,11 +200,17 @@ func NewLinter(errorOutput io.Writer, options *LinterOptions) (*Linter, error) {
 		}
 	}
 
+	var metadataDebug io.Writer
+	if logLevel >= LogLevelAllOutputIncludingDebug {
+		metadataDebug = logOutput
+	}
+
 	return &Linter{
 		projectInformation:       NewProjects(),
 		errorOutput:              errorOutput,
 		logOutput:                logOutput,
 		loggingLevel:             logLevel,
+		remoteActionsCache:       NewRemoteActionsMetadataCache(metadataDebug),
 		shellcheckExecutablePath: options.ShellcheckExecutable,
 		errorIgnorePatterns:      ignorePatterns,
 		defaultConfiguration:     config,
@@ -580,7 +590,7 @@ func (l *Linter) Lint(filepath string, content []byte, project *Project) (*Valid
 	return result, nil
 }
 
-func makeRules(filePath string, isRemote bool, gitHubToken string, localActions *LocalActionsMetadataCache, localReusableWorkflow *LocalReusableWorkflowCache) []Rule {
+func makeRules(filePath string, isRemote bool, gitHubToken string, localActions *LocalActionsMetadataCache, remoteActions *RemoteActionsMetadataCache, localReusableWorkflow *LocalReusableWorkflowCache) []Rule {
 	// WorkflowTaintMap is shared between Critical and Medium variants of
 	// CodeInjection, EnvVarInjection, ArgumentInjection, and RequestForgery rules
 	// to enable cross-job taint propagation tracking via needs.*.outputs.*
@@ -590,7 +600,13 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 	if localActions != nil {
 		debugOut = localActions.dbg
 	}
-	actionMetadata := NewMultiActionMetadataResolver(localActions, NewRemoteActionsMetadataCache(debugOut))
+	// remoteActions is shared across all files of a lint run (passed down from
+	// the Linter) so each remote action.yml is fetched at most once per run.
+	// Tests and other callers may pass nil to get a per-call cache.
+	if remoteActions == nil {
+		remoteActions = NewRemoteActionsMetadataCache(debugOut)
+	}
+	actionMetadata := NewMultiActionMetadataResolver(localActions, remoteActions)
 
 	return []Rule{
 		// MatrixRule(),
@@ -719,7 +735,7 @@ func (l *Linter) validate(
 	// dependabot config / composite action / unparseable workflow would
 	// silently skip the rule-name check and the user's CLI typo would not
 	// be reported until a parseable workflow happened to reach validate().
-	rules := makeRules(filePath, l.isRemote, l.gitHubToken, localActions, localReusableWorkflow)
+	rules := makeRules(filePath, l.isRemote, l.gitHubToken, localActions, l.remoteActionsCache, localReusableWorkflow)
 	filteredRules, optErr := applyOptInRules(rules, l.enabledOptInRules)
 	if optErr != nil {
 		return nil, optErr

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -120,9 +120,8 @@ type Linter struct {
 	// loggedConfigs は、`setting configuration: ...` をすでに出力済みの *Config を
 	// 追跡し、複数ファイル並行 validate でログが重複しないようにするためのセット。
 	loggedConfigs sync.Map
-	// remoteActionsCache は lint 実行全体で共有されるリモート action.yml の
-	// メタデータキャッシュ。per-file に生成すると同じアクションを何度も
-	// fetch してしまうため、Linter 単位で 1 つ持つ (内部は mutex で並行安全)。
+	// remoteActionsCache は lint 実行全体で共有する remote action.yml の
+	// キャッシュ (per-file 生成だと同一アクションを重複 fetch するため)。
 	remoteActionsCache *RemoteActionsMetadataCache
 }
 
@@ -600,9 +599,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 	if localActions != nil {
 		debugOut = localActions.dbg
 	}
-	// remoteActions is shared across all files of a lint run (passed down from
-	// the Linter) so each remote action.yml is fetched at most once per run.
-	// Tests and other callers may pass nil to get a per-call cache.
+	// remoteActions is run-wide (from the Linter); nil gets a per-call cache.
 	if remoteActions == nil {
 		remoteActions = NewRemoteActionsMetadataCache(debugOut)
 	}

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -654,6 +654,7 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 		NewUnsoundContainsRule(),                                      // Detects bypassable contains() function usage in conditions
 		NewSelfHostedRunnersRule(),                                    // Detects self-hosted runner usage which may be dangerous in public repos
 		NewArchivedUsesRule(),                                         // Detects usage of archived actions/reusable workflows
+		NewDeprecatedNodeRuntimeRule(actionMetadata),                  // Detects actions on the deprecated node20 runtime (EOL) and unsecure runtime pinning
 		NewUnpinnedImagesRule(),                                       // Detects container images not pinned by SHA256 digest
 		NewSecretsInArtifactsRule(),                                   // Detects secrets exposure in artifact uploads (CWE-312)
 		NewSecretExfiltrationRule(),                                   // Detects secret exfiltration via network commands

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -316,7 +316,7 @@ type remoteActionSpec struct {
 
 const (
 	// remoteMetadataFetchAttempts bounds retries per spec for transient
-	// errors (timeouts, 5xx). 404 is definitive and never retried.
+	// errors. 404 is definitive and never retried.
 	remoteMetadataFetchAttempts = 3
 	// remoteMetadataBreakerThreshold is the number of consecutive specs that
 	// must exhaust their retry budget before the circuit breaker opens.
@@ -456,9 +456,9 @@ func isRemoteNotFoundError(err error) bool {
 
 // resolveRemote fetches and parses the action metadata with bounded retries.
 // Caching policy:
-//   - parsed metadata        -> cached (definitive)
-//   - 404 on every candidate -> cached as nil (definitive: no metadata)
-//   - unparseable content    -> cached as nil (definitive: not an action)
+//   - parsed metadata        -> cached
+//   - 404 on every candidate -> cached as nil
+//   - unparseable content    -> cached as nil
 //   - transient failure      -> NOT cached; recorded in failed so repeat
 //     lookups fail fast this run and a fresh run can retry
 func (c *RemoteActionsMetadataCache) resolveRemote(spec string, actionSpec *remoteActionSpec) (*ActionMetadata, error) {

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -289,19 +289,13 @@ type RemoteActionsMetadataCache struct {
 	fetcher     *remote.Fetcher
 	fetcherErr  error
 	cache       map[string]*ActionMetadata
-	// failed records specs whose fetch exhausted the retry budget on
-	// transient errors. Unlike cache (which stores definitive results such as
-	// parsed metadata or a confirmed 404), a failed entry keeps returning the
-	// original error so callers can tell "the action has no metadata" apart
-	// from "resolution was degraded this run" — a transient failure must
-	// never be converted into a silent nil, which would nondeterministically
-	// suppress every resolver-backed rule for the rest of the run.
+	// failed keeps transient-failure errors separate from cache so they are
+	// never converted into a definitive nil, which would silently suppress
+	// every resolver-backed rule for the rest of the run.
 	failed map[string]error
-	// consecutiveTransientFailures drives a run-wide circuit breaker: when
-	// this many spec resolutions in a row exhaust their retry budget without
-	// any success in between, the network is considered unavailable and
-	// further fetches fail fast instead of burning attempts*paths*timeout per
-	// remaining spec (e.g. a token set but no connectivity).
+	// consecutiveTransientFailures drives a run-wide circuit breaker: after
+	// this many spec resolutions fail in a row, further fetches fail fast
+	// instead of burning attempts*paths*timeout per remaining spec.
 	consecutiveTransientFailures int
 	breakerOpen                  bool
 	flight                       singleflight.Group
@@ -396,9 +390,8 @@ func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata,
 		return nil, nil
 	}
 
-	// singleflight collapses concurrent lookups of the same spec (parallel
-	// files of a run share this cache), so each action.yml is in flight at
-	// most once regardless of how many workflows reference it.
+	// singleflight: each action.yml is in flight at most once across the
+	// parallel files sharing this cache.
 	v, err, _ := c.flight.Do(spec, func() (interface{}, error) {
 		if m, ok := c.readCache(spec); ok {
 			return m, nil
@@ -418,9 +411,9 @@ func (c *RemoteActionsMetadataCache) readFailed(spec string) error {
 	return c.failed[spec]
 }
 
-// noteTransientOutcome updates the circuit-breaker state. success resets the
-// consecutive-failure counter; a spec that exhausted its retry budget
-// increments it and may open the breaker for the rest of the run.
+// noteTransientOutcome updates the circuit-breaker state: success resets the
+// consecutive-failure counter; an exhausted retry budget increments it and
+// may open the breaker for the rest of the run.
 func (c *RemoteActionsMetadataCache) noteTransientOutcome(success bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -454,9 +447,8 @@ func (c *RemoteActionsMetadataCache) doFetch(ctx context.Context, repo *remote.R
 	return fetcher.FetchFile(ctx, repo, filePath, ref)
 }
 
-// isRemoteNotFoundError reports whether err is a definitive HTTP 404 — the
-// file does not exist at that ref. Everything else (timeouts, 5xx, decode
-// failures) is treated as transient and eligible for retry.
+// isRemoteNotFoundError reports a definitive HTTP 404; everything else is
+// treated as transient and eligible for retry.
 func isRemoteNotFoundError(err error) bool {
 	var ghErr *github.ErrorResponse
 	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound
@@ -464,12 +456,11 @@ func isRemoteNotFoundError(err error) bool {
 
 // resolveRemote fetches and parses the action metadata with bounded retries.
 // Caching policy:
-//   - parsed metadata          -> cached (definitive)
-//   - 404 on every candidate   -> cached as nil (definitive: no metadata)
-//   - unparseable content      -> cached as nil (definitive: not an action)
-//   - transient failure        -> NOT cached; recorded in failed so repeat
-//     lookups this run return the error immediately instead of re-burning
-//     the retry budget, and a fresh run can succeed again
+//   - parsed metadata        -> cached (definitive)
+//   - 404 on every candidate -> cached as nil (definitive: no metadata)
+//   - unparseable content    -> cached as nil (definitive: not an action)
+//   - transient failure      -> NOT cached; recorded in failed so repeat
+//     lookups fail fast this run and a fresh run can retry
 func (c *RemoteActionsMetadataCache) resolveRemote(spec string, actionSpec *remoteActionSpec) (*ActionMetadata, error) {
 	if c.isBreakerOpen() {
 		return nil, errRemoteMetadataCircuitOpen
@@ -501,9 +492,8 @@ func (c *RemoteActionsMetadataCache) resolveRemote(spec string, actionSpec *remo
 					continue
 				}
 				if IsGitHubRateLimitError(err) {
-					// Retrying cannot succeed until the rate window resets.
-					// Not cached: a later authenticated run must be able to
-					// resolve this spec.
+					// Retrying cannot succeed until the rate window resets;
+					// not cached so a later authenticated run can resolve it.
 					return nil, fmt.Errorf("failed to fetch remote action metadata for %q: %w", spec, err)
 				}
 				transientErr = err
@@ -525,8 +515,7 @@ func (c *RemoteActionsMetadataCache) resolveRemote(spec string, actionSpec *remo
 		}
 
 		if transientErr == nil && notFound == len(paths) {
-			// Every candidate path answered 404: the action metadata does
-			// not exist at this ref. Definitive, not an error.
+			// All candidate paths 404'd: definitively no metadata at this ref.
 			c.writeCache(spec, nil)
 			c.noteTransientOutcome(true)
 			return nil, nil

--- a/pkg/core/metadata.go
+++ b/pkg/core/metadata.go
@@ -3,8 +3,10 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	pathpkg "path"
 	"path/filepath"
@@ -12,7 +14,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/go-github/v68/github"
 	"github.com/sisaku-security/sisakulint/pkg/remote"
+	"golang.org/x/sync/singleflight"
 	"gopkg.in/yaml.v3"
 )
 
@@ -285,7 +289,28 @@ type RemoteActionsMetadataCache struct {
 	fetcher     *remote.Fetcher
 	fetcherErr  error
 	cache       map[string]*ActionMetadata
-	dbg         io.Writer
+	// failed records specs whose fetch exhausted the retry budget on
+	// transient errors. Unlike cache (which stores definitive results such as
+	// parsed metadata or a confirmed 404), a failed entry keeps returning the
+	// original error so callers can tell "the action has no metadata" apart
+	// from "resolution was degraded this run" — a transient failure must
+	// never be converted into a silent nil, which would nondeterministically
+	// suppress every resolver-backed rule for the rest of the run.
+	failed map[string]error
+	// consecutiveTransientFailures drives a run-wide circuit breaker: when
+	// this many spec resolutions in a row exhaust their retry budget without
+	// any success in between, the network is considered unavailable and
+	// further fetches fail fast instead of burning attempts*paths*timeout per
+	// remaining spec (e.g. a token set but no connectivity).
+	consecutiveTransientFailures int
+	breakerOpen                  bool
+	flight                       singleflight.Group
+	dbg                          io.Writer
+	// fetchFile is a test seam; when nil, the lazily-constructed
+	// remote.Fetcher is used.
+	fetchFile func(ctx context.Context, repo *remote.RepositoryInfo, filePath, ref string) ([]byte, error)
+	// sleep is a test seam for the retry backoff.
+	sleep func(time.Duration)
 }
 
 type remoteActionSpec struct {
@@ -295,8 +320,24 @@ type remoteActionSpec struct {
 	ref   string
 }
 
+const (
+	// remoteMetadataFetchAttempts bounds retries per spec for transient
+	// errors (timeouts, 5xx). 404 is definitive and never retried.
+	remoteMetadataFetchAttempts = 3
+	// remoteMetadataBreakerThreshold is the number of consecutive specs that
+	// must exhaust their retry budget before the circuit breaker opens.
+	remoteMetadataBreakerThreshold = 5
+)
+
+var errRemoteMetadataCircuitOpen = errors.New("remote action metadata resolution disabled for this run: too many consecutive network failures")
+
 func NewRemoteActionsMetadataCache(dbg io.Writer) *RemoteActionsMetadataCache {
-	return &RemoteActionsMetadataCache{cache: make(map[string]*ActionMetadata), dbg: dbg}
+	return &RemoteActionsMetadataCache{
+		cache:  make(map[string]*ActionMetadata),
+		failed: make(map[string]error),
+		dbg:    dbg,
+		sleep:  time.Sleep,
+	}
 }
 
 // ensureFetcher constructs the underlying remote.Fetcher on first use. The
@@ -346,15 +387,92 @@ func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata,
 		c.debug("cache hit @ %s: %v", spec, m)
 		return m, nil
 	}
+	if err := c.readFailed(spec); err != nil {
+		return nil, err
+	}
 
 	actionSpec, ok := parseRemoteActionSpec(spec)
 	if !ok {
 		return nil, nil
 	}
 
+	// singleflight collapses concurrent lookups of the same spec (parallel
+	// files of a run share this cache), so each action.yml is in flight at
+	// most once regardless of how many workflows reference it.
+	v, err, _ := c.flight.Do(spec, func() (interface{}, error) {
+		if m, ok := c.readCache(spec); ok {
+			return m, nil
+		}
+		if err := c.readFailed(spec); err != nil {
+			return nil, err
+		}
+		return c.resolveRemote(spec, actionSpec)
+	})
+	meta, _ := v.(*ActionMetadata)
+	return meta, err
+}
+
+func (c *RemoteActionsMetadataCache) readFailed(spec string) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.failed[spec]
+}
+
+// noteTransientOutcome updates the circuit-breaker state. success resets the
+// consecutive-failure counter; a spec that exhausted its retry budget
+// increments it and may open the breaker for the rest of the run.
+func (c *RemoteActionsMetadataCache) noteTransientOutcome(success bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if success {
+		c.consecutiveTransientFailures = 0
+		return
+	}
+	c.consecutiveTransientFailures++
+	if !c.breakerOpen && c.consecutiveTransientFailures >= remoteMetadataBreakerThreshold {
+		c.breakerOpen = true
+		if c.dbg != nil {
+			fmt.Fprintf(c.dbg, "[RemoteActionsMetadataCache] circuit breaker opened after %d consecutive fetch failures; remote metadata resolution disabled for this run\n", c.consecutiveTransientFailures)
+		}
+	}
+}
+
+func (c *RemoteActionsMetadataCache) isBreakerOpen() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.breakerOpen
+}
+
+func (c *RemoteActionsMetadataCache) doFetch(ctx context.Context, repo *remote.RepositoryInfo, filePath, ref string) ([]byte, error) {
+	if c.fetchFile != nil {
+		return c.fetchFile(ctx, repo, filePath, ref)
+	}
 	fetcher := c.ensureFetcher()
 	if fetcher == nil {
-		return nil, nil
+		return nil, c.fetcherErr
+	}
+	return fetcher.FetchFile(ctx, repo, filePath, ref)
+}
+
+// isRemoteNotFoundError reports whether err is a definitive HTTP 404 — the
+// file does not exist at that ref. Everything else (timeouts, 5xx, decode
+// failures) is treated as transient and eligible for retry.
+func isRemoteNotFoundError(err error) bool {
+	var ghErr *github.ErrorResponse
+	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound
+}
+
+// resolveRemote fetches and parses the action metadata with bounded retries.
+// Caching policy:
+//   - parsed metadata          -> cached (definitive)
+//   - 404 on every candidate   -> cached as nil (definitive: no metadata)
+//   - unparseable content      -> cached as nil (definitive: not an action)
+//   - transient failure        -> NOT cached; recorded in failed so repeat
+//     lookups this run return the error immediately instead of re-burning
+//     the retry budget, and a fresh run can succeed again
+func (c *RemoteActionsMetadataCache) resolveRemote(spec string, actionSpec *remoteActionSpec) (*ActionMetadata, error) {
+	if c.isBreakerOpen() {
+		return nil, errRemoteMetadataCircuitOpen
 	}
 
 	repo := &remote.RepositoryInfo{
@@ -364,32 +482,64 @@ func (c *RemoteActionsMetadataCache) FindMetadata(spec string) (*ActionMetadata,
 	}
 
 	var lastErr error
-	for _, metadataPath := range remoteActionMetadataPaths(actionSpec.dir) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		b, err := fetcher.FetchFile(ctx, repo, metadataPath, actionSpec.ref)
-		cancel()
-		if err != nil {
-			lastErr = err
-			continue
+	for attempt := 0; attempt < remoteMetadataFetchAttempts; attempt++ {
+		if attempt > 0 {
+			c.debug("retrying metadata fetch for %s (attempt %d/%d) after transient error: %v", spec, attempt+1, remoteMetadataFetchAttempts, lastErr)
+			c.sleep(time.Duration(attempt) * 500 * time.Millisecond)
 		}
 
-		var meta ActionMetadata
-		if err := yaml.Unmarshal(b, &meta); err != nil {
+		var transientErr error
+		notFound := 0
+		paths := remoteActionMetadataPaths(actionSpec.dir)
+		for _, metadataPath := range paths {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			b, err := c.doFetch(ctx, repo, metadataPath, actionSpec.ref)
+			cancel()
+			if err != nil {
+				if isRemoteNotFoundError(err) {
+					notFound++
+					continue
+				}
+				if IsGitHubRateLimitError(err) {
+					// Retrying cannot succeed until the rate window resets.
+					// Not cached: a later authenticated run must be able to
+					// resolve this spec.
+					return nil, fmt.Errorf("failed to fetch remote action metadata for %q: %w", spec, err)
+				}
+				transientErr = err
+				continue
+			}
+
+			var meta ActionMetadata
+			if err := yaml.Unmarshal(b, &meta); err != nil {
+				c.writeCache(spec, nil)
+				c.noteTransientOutcome(true)
+				msg := strings.ReplaceAll(err.Error(), "\n", " ")
+				return nil, fmt.Errorf("failed to parse remote action metadata file %q: %s", metadataPath, msg)
+			}
+
+			c.debug("detected remote action metadata @ %s: %v", spec, &meta)
+			c.writeCache(spec, &meta)
+			c.noteTransientOutcome(true)
+			return &meta, nil
+		}
+
+		if transientErr == nil && notFound == len(paths) {
+			// Every candidate path answered 404: the action metadata does
+			// not exist at this ref. Definitive, not an error.
 			c.writeCache(spec, nil)
-			msg := strings.ReplaceAll(err.Error(), "\n", " ")
-			return nil, fmt.Errorf("failed to parse remote action metadata file %q: %s", metadataPath, msg)
+			c.noteTransientOutcome(true)
+			return nil, nil
 		}
-
-		c.debug("detected remote action metadata @ %s: %v", spec, &meta)
-		c.writeCache(spec, &meta)
-		return &meta, nil
+		lastErr = transientErr
 	}
 
-	c.writeCache(spec, nil)
-	if lastErr != nil {
-		return nil, fmt.Errorf("failed to fetch remote action metadata for %q: %w", spec, lastErr)
-	}
-	return nil, nil
+	err := fmt.Errorf("failed to fetch remote action metadata for %q after %d attempts: %w", spec, remoteMetadataFetchAttempts, lastErr)
+	c.mu.Lock()
+	c.failed[spec] = err
+	c.mu.Unlock()
+	c.noteTransientOutcome(false)
+	return nil, err
 }
 
 func parseRemoteActionSpec(spec string) (*remoteActionSpec, bool) {

--- a/pkg/core/metadata_test.go
+++ b/pkg/core/metadata_test.go
@@ -1,9 +1,17 @@
 package core
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/google/go-github/v68/github"
+	"github.com/sisaku-security/sisakulint/pkg/remote"
 	"gopkg.in/yaml.v3"
 )
 
@@ -136,5 +144,195 @@ func TestRemoteActionsMetadataCacheDeferFetcherConstruction(t *testing.T) {
 		if c.fetcher != nil {
 			t.Fatalf("fetcher must remain nil after FindMetadata(%q)", spec)
 		}
+	}
+}
+
+// --- retry / caching policy tests for RemoteActionsMetadataCache. A
+// transient fetch failure must never be cached as "no metadata": that would
+// silently disable every resolver-backed rule for the rest of the run and
+// make lint results nondeterministic.
+
+func newTestRemoteCache(fetch func(ctx context.Context, repo *remote.RepositoryInfo, filePath, ref string) ([]byte, error)) *RemoteActionsMetadataCache {
+	c := NewRemoteActionsMetadataCache(nil)
+	c.fetchFile = fetch
+	c.sleep = func(time.Duration) {} // no backoff in tests
+	return c
+}
+
+func notFoundErr() error {
+	return &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}
+}
+
+func TestRemoteCacheRetriesTransientErrorThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	c := newTestRemoteCache(func(_ context.Context, _ *remote.RepositoryInfo, filePath, _ string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("dial tcp: i/o timeout")
+		}
+		if filePath == "action.yml" {
+			return []byte("runs:\n  using: node20\n"), nil
+		}
+		return nil, notFoundErr()
+	})
+
+	meta, err := c.FindMetadata("owner/repo@v1")
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got error: %v", err)
+	}
+	if meta == nil || meta.Runs == nil || meta.Runs.Using != "node20" {
+		t.Fatalf("unexpected metadata: %v", meta)
+	}
+	// Cached: a second lookup must not fetch again.
+	before := calls
+	if _, err := c.FindMetadata("owner/repo@v1"); err != nil {
+		t.Fatal(err)
+	}
+	if calls != before {
+		t.Errorf("expected cache hit, but fetch was called again (%d -> %d)", before, calls)
+	}
+}
+
+func TestRemoteCacheDefinitive404IsNegativeCached(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	c := newTestRemoteCache(func(_ context.Context, _ *remote.RepositoryInfo, _, _ string) ([]byte, error) {
+		calls++
+		return nil, notFoundErr()
+	})
+
+	meta, err := c.FindMetadata("owner/repo@v1")
+	if err != nil {
+		t.Fatalf("definitive 404 must not be an error, got: %v", err)
+	}
+	if meta != nil {
+		t.Fatalf("expected nil metadata, got %v", meta)
+	}
+	if calls != 2 { // action.yml + action.yaml, no retries for 404
+		t.Errorf("expected 2 fetch calls, got %d", calls)
+	}
+	if _, err := c.FindMetadata("owner/repo@v1"); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Errorf("404 must be cached; got %d fetch calls after second lookup", calls)
+	}
+}
+
+func TestRemoteCacheTransientFailureIsNotSilentlyNil(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	c := newTestRemoteCache(func(_ context.Context, _ *remote.RepositoryInfo, _, _ string) ([]byte, error) {
+		calls++
+		return nil, fmt.Errorf("dial tcp: i/o timeout")
+	})
+
+	meta, err := c.FindMetadata("owner/repo@v1")
+	if err == nil {
+		t.Fatal("exhausted transient retries must surface an error, not a silent nil")
+	}
+	if meta != nil {
+		t.Fatalf("expected nil metadata, got %v", meta)
+	}
+	wantCalls := remoteMetadataFetchAttempts * 2 // both candidate paths per attempt
+	if calls != wantCalls {
+		t.Errorf("expected %d fetch calls, got %d", wantCalls, calls)
+	}
+	// Repeat lookups return the recorded error without re-burning the budget.
+	if _, err2 := c.FindMetadata("owner/repo@v1"); err2 == nil {
+		t.Fatal("expected recorded failure error on repeat lookup")
+	}
+	if calls != wantCalls {
+		t.Errorf("repeat lookup must not fetch again: %d calls", calls)
+	}
+}
+
+func TestRemoteCacheRateLimitAbortsWithoutRetryOrCaching(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	c := newTestRemoteCache(func(_ context.Context, _ *remote.RepositoryInfo, _, _ string) ([]byte, error) {
+		calls++
+		return nil, &github.RateLimitError{}
+	})
+
+	if _, err := c.FindMetadata("owner/repo@v1"); err == nil {
+		t.Fatal("expected rate-limit error")
+	}
+	if calls != 1 {
+		t.Errorf("rate limit must abort immediately, got %d fetch calls", calls)
+	}
+	// Not recorded as failed: a later lookup (e.g. after the window resets)
+	// is allowed to try again.
+	if _, err := c.FindMetadata("owner/repo@v1"); err == nil {
+		t.Fatal("expected rate-limit error on retry lookup")
+	}
+	if calls != 2 {
+		t.Errorf("rate-limited spec must stay retryable, got %d fetch calls", calls)
+	}
+}
+
+func TestRemoteCacheCircuitBreakerOpensAfterConsecutiveFailures(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	c := newTestRemoteCache(func(_ context.Context, _ *remote.RepositoryInfo, _, _ string) ([]byte, error) {
+		calls++
+		return nil, fmt.Errorf("dial tcp: network is unreachable")
+	})
+
+	for i := 0; i < remoteMetadataBreakerThreshold; i++ {
+		spec := fmt.Sprintf("owner/repo%d@v1", i)
+		if _, err := c.FindMetadata(spec); err == nil {
+			t.Fatalf("expected error for %s", spec)
+		}
+	}
+	before := calls
+	if _, err := c.FindMetadata("owner/last@v1"); !errors.Is(err, errRemoteMetadataCircuitOpen) {
+		t.Fatalf("expected circuit-open error, got: %v", err)
+	}
+	if calls != before {
+		t.Errorf("breaker open must fail fast without fetching, got %d extra calls", calls-before)
+	}
+}
+
+func TestRemoteCacheSingleflightCollapsesConcurrentLookups(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	calls := 0
+	release := make(chan struct{})
+	c := newTestRemoteCache(func(_ context.Context, _ *remote.RepositoryInfo, filePath, _ string) ([]byte, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		<-release
+		if filePath == "action.yml" {
+			return []byte("runs:\n  using: node24\n"), nil
+		}
+		return nil, notFoundErr()
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			meta, err := c.FindMetadata("owner/repo@v1")
+			if err != nil || meta == nil {
+				t.Errorf("unexpected result: %v %v", meta, err)
+			}
+		}()
+	}
+	close(release)
+	wg.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Errorf("expected 1 collapsed fetch, got %d", calls)
 	}
 }

--- a/script/README.md
+++ b/script/README.md
@@ -52,6 +52,8 @@ Contains example GitHub Actions workflow files that demonstrate various security
 | `secret-exfiltration-allowed-hosts.yaml` | Demonstrates the `secret-exfiltration.allowed-hosts` config — paired with a `.github/sisakulint.yaml` listing vendor/internal hosts the rule should trust |
 | `secret-exfiltration-per-workflow-override.yaml` | Demonstrates the `# sisakulint:secret-exfiltration.allowed-hosts:` per-workflow comment directive for scoping extra trusted hosts to a single workflow |
 | `dependabot-ecosystem.yaml` | Uses `actions/setup-node` (npm), `setup-go` (gomod), `setup-python` (pip), and `setup-java` (maven/gradle/sbt ambiguous) across separate jobs to exercise DependabotEcosystemRule on every supported setup-action shape. |
+| `deprecated-node-runtime.yaml` | Actions on the deprecated Node.js 20 runtime (node20 majors of checkout/setup-node/github-script/upload-artifact), the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out, the removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE20` flag, and an EOL `node-version:` build target |
+| `deprecated-node-runtime-safe.yaml` | Safe counterparts: node24-capable action majors and a supported `node-version` |
 
 ### Usage
 

--- a/script/actions/deprecated-node-runtime-safe.yaml
+++ b/script/actions/deprecated-node-runtime-safe.yaml
@@ -1,0 +1,28 @@
+# Safe counterpart of deprecated-node-runtime.yaml: every action major
+# declares `runs.using: node24` and the build target is a supported Node.js.
+name: deprecated-node-runtime-safe
+on: push
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # OK: actions/checkout v5+ declares `runs.using: node24`.
+      - uses: actions/checkout@v5
+      # OK: actions/setup-node v5+ is node24 and Node.js 24 is in support.
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      # OK: actions/github-script v8+ declares `runs.using: node24`.
+      - uses: actions/github-script@v8
+        with:
+          script: console.log("hello")
+      # OK: actions/upload-artifact v6+ declares `runs.using: node24`.
+      - uses: actions/upload-artifact@v6
+        with:
+          name: dist
+          path: dist/

--- a/script/actions/deprecated-node-runtime.yaml
+++ b/script/actions/deprecated-node-runtime.yaml
@@ -1,0 +1,37 @@
+# Demonstrates workflows that still depend on the deprecated Node.js 20
+# action runtime (EOL 2026-04-30, removed from the runner on 2026-09-16).
+name: deprecated-node-runtime
+on: push
+
+# NG: pins the whole workflow to the EOL Node.js 20 runtime. This opt-out
+# stops working when node20 is removed from the runner on 2026-09-16.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # NG: this variable was removed from the runner and has no effect.
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: "true"
+    steps:
+      # NG: actions/checkout v4 declares `runs.using: node20`.
+      - uses: actions/checkout@v4
+      # NG: actions/setup-node v4 is node20, and Node.js 20 as a build
+      # target reached end-of-life on 2026-04-30.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # NG: actions/github-script v7 declares `runs.using: node20`.
+      - uses: actions/github-script@v7
+        with:
+          script: console.log("hello")
+      # NG: actions/upload-artifact v4 declares `runs.using: node20`.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/


### PR DESCRIPTION
Closes #526

## 概要

Node.js 20 EOL（2026-04-30）/ runner からの node20 削除（2026-09-16）に対応する `deprecated-node-runtime` ルールを追加します。調査・実世界評価の詳細は #526 を参照してください。

3 コミット構成で、下 2 つはルールと独立に価値のあるインフラ変更です：

| commit | 内容 |
|---|---|
| `fix: make RemoteActionsMetadataCache resilient to transient fetch failures` | transient 失敗の negative cache 廃止（既存の潜在欠陥修正） |
| `refactor: share RemoteActionsMetadataCache across all files of a lint run` | per-file キャッシュを Linter 単位の共有に |
| `feat: add deprecated-node-runtime rule` | ルール本体・autofix・テスト・example・ドキュメント |

## 実装解説

### 1. RemoteActionsMetadataCache の堅牢化（`pkg/core/metadata.go`）

従来は**あらゆる fetch 失敗**を `writeCache(spec, nil)` で「メタデータなし」として run 全体に記憶しており、タイムアウト 1 回で resolver 依存ルール（本ルール、cache-poisoning）がその spec について沈黙する非決定的 FN 源でした。新ポリシー：

- **確定結果のみキャッシュ**: パース成功 / 全候補パス 404 / 非 action コンテンツ
- **transient エラー**: 最大 3 試行 + backoff。枯渇後は spec 単位でエラーを記録し、以降の lookup は silent nil ではなく**エラーを返す**（「メタデータなし」と「解決が劣化」を呼び出し側が区別可能）。キャッシュは汚さないので次の run は成功できる
- **rate limit**: リトライ無意味なので即中断、再試行可能なまま
- **singleflight**: 並行ファイル間の同一 spec fetch を 1 回に集約
- **circuit breaker**: 連続 5 spec の試行枯渇で run 内を fail-fast（token 設定済みオフライン環境で 試行×パス×5 秒 × spec 数の停止を防止）

テストは `fetchFile` seam を追加してネットワークなしで 6 ケースを検証しています。

### 2. キャッシュの run 全体共有（`pkg/core/linter.go`）

`makeRules()` が per-file に `RemoteActionsMetadataCache` を生成していたため、N ファイルが参照する同一アクションを最大 N 回 fetch していました。Linter が 1 つ保持して `makeRules` に注入する形に変更（内部は mutex + singleflight で並行安全）。`nil` を渡す既存呼び出し（テスト等）は従来挙動を維持します。

### 3. deprecated-node-runtime ルール（`pkg/core/deprecated_node_runtime.go`）

**resolver-first 設計**: pinned ref で解決した action.yml の `runs.using` を真実とします。これにより

- SHA ピンでも行コメント不要で検出（`# v5` のような **stale コメントによる誤検出が原理的に発生しない** — 評価で実例を確認済み）
- 実際の runtime 名（node12/16/20）で報告
- tj-actions/changed-files 等のサードパーティも網羅

検出クラス：

1. **direct**: `runs.using` が node12/16/20 のアクション。埋め込みテーブル（first-party 8 アクションの node20 世代 major → 最初の node24 対応 major）に載っていれば autofix を付与（例: `actions/checkout@v4` → `@v5`、`actions/cache/restore@v4` → `actions/cache/restore@v5` とサブパス保持）。SHA ピンは commit-sha ルールの再ピンに委譲
2. **composite transitive（depth-1、diagnose-only）**: composite の直下 steps の deprecated runtime を報告。`./predicate` 形式の内部相対参照は親リポジトリ + 同一 ref で解決（リポジトリ外エスケープは拒否）。修正責任は action 保守者側のため fix なし
3. **env フラグ（diagnose-only）**: `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`（2026-09-16 に失効する opt-out）と撤去済み `FORCE_JAVASCRIPT_ACTIONS_TO_NODE20`
4. **EOL ビルドターゲット（diagnose-only）**: setup-node の `node-version: 20` 等。ビルドターゲット変更は意味論的変更のため fix しない

resolver 不可時（オフライン / API 失敗）はテーブル + tag / `# vX` コメントのヒューリスティックにフォールバックします（best-effort と明記）。

## 品質保証

- ユニットテスト: ルール 40+ ケース、キャッシュポリシー 6 ケース、全スイートパス
- 各コミットを独立 worktree で build + test 検証（bisect 安全）
- **実世界評価**（46 top-starred repos / 3,090 アクション参照、GT は action.yml を独立取得）:
  - resolver モード precision **1.000** / recall **1.000**、2 回実行で byte-identical、composite transitive 49 件
  - テーブルのみフォールバック precision 0.998 / recall 0.675
  - autofix 412 参照、YAML 破壊 0、書き換え先 tag 全て実在 + node24 宣言を検証
- `sisakulint script/actions/deprecated-node-runtime.yaml` で 7 検出 / safe 版 0 検出、`-fix dry-run` で期待どおりの bump を確認

## 既知の限界（follow-up 候補）

- 埋め込みテーブルは手書きスナップショット → scraper 自動生成
- composite depth-2 以上、reusable workflow 内は未追跡
- API 消費 ~1,571/run（46 repo 一括時）→ ETag / conditional request
- autofix の全ファイル YAML 再エンコードによる diff noise は製品共通の書き込み経路の課題（本 PR のスコープ外）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GitHub Actions ワークフロー内の非推奨 Node.js ランタイム（例: node20 EOL など）を検出できるようになりました。
  * 条件に応じて、対象アクションの世代更新（自動修正）を提案します。
* **改善**
  * リモートでのアクション情報取得を強化し、失敗時の再試行・回路遮断・同時実行の整理を行いました。
* **ドキュメント**
  * 非推奨ランタイム向けの検出ルール説明と、検出用/安全なサンプルワークフローを追加しました。
* **テスト**
  * 検出・フォールバック・自動修正・キャッシュ挙動のテストを拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->