### PR TITLE
fix(artipacked): treat commit SHA pin as unknown version to avoid severity misparse

### DIFF
--- a/pkg/core/artipacked.go
+++ b/pkg/core/artipacked.go
@@ -12,6 +12,14 @@ import (
 // checkoutVersionPattern is compiled once at package level for performance.
 var checkoutVersionPattern = regexp.MustCompile(`^v?(\d+)`)
 
+// commitSHAPattern matches a full or abbreviated commit SHA (7-40 hex chars).
+// A SHA pin does not encode a major version, so it must not be run through
+// checkoutVersionPattern (otherwise a SHA whose first hex char is 6-9, e.g.
+// "8ade...", would be misread as "v8" and its severity/credential-location
+// silently downgraded). actions/checkout only tags releases with semver
+// (vN[.M[.P]]), so any all-hex 7-40 char ref here is unambiguously a SHA.
+var commitSHAPattern = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+
 // persistCredentialsKey is the input key for persist-credentials in checkout action.
 const persistCredentialsKey = "persist-credentials"
 
@@ -151,7 +159,17 @@ func (rule *ArtipackedRule) getCheckoutVersion(uses string) int {
 		return 0
 	}
 
-	matches := checkoutVersionPattern.FindStringSubmatch(parts[1])
+	// A commit SHA pin does not encode a major version. Return 0 (unknown) so
+	// its leading hex digits are not misread as a version number, which would
+	// otherwise downgrade severity for SHAs starting with 6-9. Unknown versions
+	// are treated conservatively (credentials assumed in .git/config), matching
+	// the pre-existing behavior for non-numeric refs.
+	ref := parts[1]
+	if commitSHAPattern.MatchString(ref) {
+		return 0
+	}
+
+	matches := checkoutVersionPattern.FindStringSubmatch(ref)
 	if len(matches) >= 2 {
 		major, err := strconv.Atoi(matches[1])
 		if err != nil {

--- a/pkg/core/artipacked_test.go
+++ b/pkg/core/artipacked_test.go
@@ -89,6 +89,11 @@ func TestArtipackedRule_getCheckoutVersion(t *testing.T) {
 		{"v6", "actions/checkout@v6", 6},
 		{"v6.0.0", "actions/checkout@v6.0.0", 6},
 		{"commit SHA", "actions/checkout@abc123def456789012345678901234567890abcd", 0},
+		// A full SHA whose first hex char is 6-9 must not be misread as a major
+		// version (regression: "8ade..." previously returned 8 -> treated as v8).
+		{"commit SHA leading 8", "actions/checkout@8ade1a2b3c4d5e6f70819a2b3c4d5e6f7081a2b3", 0},
+		{"commit SHA leading 3", "actions/checkout@3f2a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1c2", 0},
+		{"abbreviated SHA leading 7", "actions/checkout@7f8e9d0", 0},
 		{"invalid format", "actions/checkout", 0},
 		{"empty", "", 0},
 	}


### PR DESCRIPTION
## Problem

`ArtipackedRule.getCheckoutVersion` derives the checkout major version by running the ref through `^v?(\d+)`. For a commit-SHA pin, this matches the leading hex characters of the SHA. When the SHA starts with a decimal digit `6`-`9` (e.g. `actions/checkout@8ade1a2b...`), it is misread as `v8`, and the `version >= 6` branch treats it as a v6+ checkout:

- severity is downgraded **High → Medium**, and
- the credential-location message is mislabeled `$RUNNER_TEMP` (the v6+ behavior) instead of `.git/config`.

Roughly 25% of commit SHAs (those starting `6`-`9`) are affected. The result is also self-contradictory: the `commit-sha` rule recommends pinning actions by SHA, but doing so silently downgrades this rule's finding. A SHA pin carries no reliable information about the checkout's actual major version, so it should not be inferred from the SHA's leading characters.

## Fix

Detect a commit SHA (7-40 hex chars) and return `0` (unknown version) before applying the version regex. Unknown versions are already handled conservatively elsewhere (credentials assumed in `.git/config` → High), so SHA pins now behave uniformly and safely. Tag refs (`vN`, `vN.M.P`) are unaffected. `actions/checkout` only tags releases with semver, so an all-hex 7-40 char ref here is unambiguously a SHA.

## Behavior

| ref | before | after |
|---|---|---|
| `actions/checkout@8ade…` (SHA, leads `8`) | Medium | **High** |
| `actions/checkout@3f2a…` (SHA, leads `3`) | High | High |
| `actions/checkout@v4` (tag) | High | High |
| `actions/checkout@v6` (tag) | Medium | Medium |

SHA pins are now consistent regardless of the leading hex character.

## Tests

- Adds regression cases to `TestArtipackedRule_getCheckoutVersion` for SHAs leading with `6`-`9` and an abbreviated SHA.
- `go test ./pkg/core/` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SHA形式の参照が先頭の数字だけでバージョンとして誤判定される問題を修正しました。
  * これにより、SHA指定のチェックアウトでは意図しない重大度の判定変更が起きにくくなりました。
  * SHAの先頭が特定の16進文字でも、正しくバージョン不明として扱われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->