### PR TITLE
fix(dangerous-triggers): recognize permissions: {} as a restriction

### DIFF
--- a/pkg/core/dangeroustriggersrule.go
+++ b/pkg/core/dangeroustriggersrule.go
@@ -261,19 +261,22 @@ func hasPermissionsRestriction(perms *ast.Permissions) bool {
 		return false
 	}
 
-	// If permissions.All is set
+	// If permissions.All is set to a scalar keyword, only write-all is not a
+	// restriction.
 	if perms.All != nil && perms.All.Value != "" {
 		value := strings.ToLower(perms.All.Value)
-		// Only "read-all" or empty is a restriction (write-all is not)
-		return value == "read-all" || value == "{}" || value == "none"
+		return value == "read-all" || value == "none"
 	}
 
-	// If individual scopes are set, it's a restriction (not write-all)
-	if len(perms.Scopes) > 0 {
-		return true
-	}
-
-	return false
+	// Any other explicit `permissions:` block restricts access (perms != nil was
+	// checked above, so the key is present):
+	//   - individual scopes, e.g. `permissions: { contents: read }`
+	//   - `permissions: {}` — an empty mapping that grants no permissions at all,
+	//     the most restrictive form and the exact value this rule's own message
+	//     and auto-fix recommend. It parses as an empty MappingNode and arrives
+	//     here with All == nil and no scopes, so the previous `value == "{}"`
+	//     scalar check never matched it (it is a mapping, not a scalar).
+	return true
 }
 
 // checkConditionForMitigations checks a condition string for security-related patterns

--- a/pkg/core/dangeroustriggersrule_test.go
+++ b/pkg/core/dangeroustriggersrule_test.go
@@ -230,10 +230,15 @@ func TestCheckMitigations(t *testing.T) {
 			},
 		},
 		{
-			name: "workflow with empty permissions",
+			// `permissions: {}` parses as an empty mapping: All is nil and there
+			// are no scopes (see parsePermissions). It grants no permissions at
+			// all, so it is a restriction. This previously constructed the AST as
+			// a scalar `All: "{}"`, which the parser never produces, and which
+			// masked the fact that the empty-mapping form was not recognized.
+			name: "workflow with empty permissions ({})",
 			workflow: &ast.Workflow{
 				Permissions: &ast.Permissions{
-					All: &ast.String{Value: "{}"},
+					Scopes: map[string]*ast.PermissionScope{},
 				},
 			},
 			want: MitigationStatus{
@@ -463,6 +468,37 @@ func TestDangerousTriggersCriticalRule(t *testing.T) {
 				},
 				Permissions: &ast.Permissions{
 					All: &ast.String{Value: "read-all", Pos: &ast.Position{Line: 3, Col: 1}},
+				},
+				Jobs: map[string]*ast.Job{
+					"test": {
+						Steps: []*ast.Step{
+							{
+								Exec: &ast.ExecRun{
+									Run: &ast.String{Value: "echo test"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// `permissions: {}` (empty mapping) grants no permissions and is the
+			// mitigation this rule's message and auto-fix recommend. The parser
+			// emits it as All == nil with no scopes, so it must be recognized as a
+			// restriction; otherwise the rule flags the very fix it suggests and
+			// its auto-fix does not converge.
+			name: "safe: pull_request_target with empty permissions ({})",
+			workflow: &ast.Workflow{
+				On: []ast.Event{
+					&ast.WebhookEvent{
+						Hook: &ast.String{Value: "pull_request_target", Pos: &ast.Position{Line: 2, Col: 1}},
+						Pos:  &ast.Position{Line: 2, Col: 1},
+					},
+				},
+				Permissions: &ast.Permissions{
+					Scopes: map[string]*ast.PermissionScope{},
 				},
 				Jobs: map[string]*ast.Job{
 					"test": {


### PR DESCRIPTION
## Problem

`hasPermissionsRestriction` does not recognize `permissions: {}` — an empty mapping that grants **no** permissions at all, i.e. the most restrictive setting. An empty mapping is parsed with `All == nil` and no scopes, but the only handling for `{}` was a `value == "{}"` comparison on the `All` scalar, which the parser never produces for a mapping.

Two consequences:

1. **False positive:** a `pull_request_target` / `workflow_run` / … workflow that sets `permissions: {}` is still flagged as an unmitigated dangerous trigger, even though it has locked down all permissions.
2. **Non-convergent auto-fix:** this rule's own auto-fix inserts `permissions: {}`. Because the rule then fails to recognize that value, re-linting the fixed file re-reports the finding — the fix never satisfies the check that produced it.

## Fix

Treat any explicit `permissions:` block that is not `write-all` as a restriction — individual-scope maps and the empty mapping `{}` alike. The dead `value == "{}"` scalar check is removed (a mapping never arrives as a scalar).

`write-all` and absent `permissions:` are unchanged and still fire.

## Tests

The existing unit test constructed the empty-permissions case as a scalar `All: "{}"`, which the parser never emits — that is what masked the bug. It is corrected to the real parsed shape (`All` nil, no scopes), and a rule-level case is added asserting that a privileged trigger with `permissions: {}` is not flagged.

| input | before | after |
|---|---|---|
| `permissions: {}` | flagged | not flagged |
| `permissions: read-all` | not flagged | not flagged |
| `permissions: write-all` | flagged | flagged |
| no `permissions:` | flagged | flagged |

Auto-fix now converges (insert `permissions: {}` → re-lint reports nothing). `go test ./pkg/core/` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)