### PR TITLE
fix(output-clobbering): wrap env-indirected GITHUB_OUTPUT writes in heredoc

### DIFF
--- a/pkg/core/outputclobbering.go
+++ b/pkg/core/outputclobbering.go
@@ -340,13 +340,21 @@ func (rule *OutputClobberingRule) transformToHeredocSyntax(script string, stepIn
 	// Track which lines have been transformed
 	transformedLines := make(map[int]bool)
 
-	// First, identify lines that need transformation
+	// First, identify lines that need transformation.
+	//
+	// A GITHUB_OUTPUT write needs a heredoc if it carries an untrusted value,
+	// whether the value still appears inline as ${{ ... }} or has already been
+	// moved into a step env var by another fixer that ran first (code-injection
+	// rewrites `echo "x=${{ expr }}"` into `echo "x=$EXPR"` + `env: EXPR: ${{ expr }}`).
+	// Env indirection alone does not prevent newline clobbering, so both forms
+	// must be wrapped; matching only the inline form would leave the env-var form
+	// unwrapped and silently vulnerable.
 	for i, line := range lines {
 		if !githubOutputPattern.MatchString(line) {
 			continue
 		}
 
-		// Check if this line has any untrusted expressions
+		// Inline `${{ expr }}` form.
 		for _, untrustedInfo := range stepInfo.untrustedExprs {
 			exprPattern1 := fmt.Sprintf("${{ %s }}", untrustedInfo.expr.raw)
 			exprPattern2 := fmt.Sprintf("${{%s}}", untrustedInfo.expr.raw)
@@ -355,6 +363,11 @@ func (rule *OutputClobberingRule) transformToHeredocSyntax(script string, stepIn
 				transformedLines[i] = true
 				break
 			}
+		}
+
+		// Env-var-indirected form (e.g. after code-injection's fix).
+		if !transformedLines[i] && rule.lineReferencesUntrustedEnvVar(line, stepInfo) {
+			transformedLines[i] = true
 		}
 	}
 
@@ -593,4 +606,58 @@ func (rule *OutputClobberingRule) checkUntrustedInput(expr parsedExpression) []s
 	}
 
 	return paths
+}
+
+// lineReferencesUntrustedEnvVar reports whether the line reads a step env var
+// (as $NAME or ${NAME}) whose value carries one of this step's untrusted
+// expressions. Another fixer (e.g. code-injection) may have already rewritten an
+// inline ${{ ... }} into such an env var; the resulting `echo "$NAME" >> $GITHUB_OUTPUT`
+// is still newline-clobber vulnerable and must be wrapped in a heredoc. The env
+// var is resolved by matching the expression it carries (not by recomputing a
+// name), so it stays correct even if fixers name their env vars differently.
+func (rule *OutputClobberingRule) lineReferencesUntrustedEnvVar(line string, stepInfo *stepWithOutputClobbering) bool {
+	step := stepInfo.step
+	if step == nil || step.Env == nil || step.Env.Vars == nil {
+		return false
+	}
+
+	for _, envVar := range step.Env.Vars {
+		if envVar.Name == nil || envVar.Value == nil || !envVar.Value.ContainsExpression() {
+			continue
+		}
+
+		// Does this env var carry one of the untrusted expressions we flagged?
+		carriesUntrusted := false
+		for _, envExpr := range extractExpressionsFromString(envVar.Value.Value) {
+			for _, untrustedInfo := range stepInfo.untrustedExprs {
+				if normalizeExpression(envExpr) == normalizeExpression(untrustedInfo.expr.raw) {
+					carriesUntrusted = true
+					break
+				}
+			}
+			if carriesUntrusted {
+				break
+			}
+		}
+		if !carriesUntrusted {
+			continue
+		}
+
+		if referencesShellVar(line, envVar.Name.Value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// referencesShellVar reports whether line reads the shell variable name as $NAME
+// or ${NAME}. The unbraced form requires a trailing word boundary so that $FOO
+// does not match a reference to $FOOBAR.
+func referencesShellVar(line, name string) bool {
+	if name == "" {
+		return false
+	}
+	q := regexp.QuoteMeta(name)
+	return regexp.MustCompile(`\$` + q + `\b|\$\{` + q + `\}`).MatchString(line)
 }

--- a/pkg/core/outputclobbering_test.go
+++ b/pkg/core/outputclobbering_test.go
@@ -336,6 +336,68 @@ func TestOutputClobberingCritical_InlineExprFlaggedEvenWhenAlsoInEnv(t *testing.
 	}
 }
 
+// TestOutputClobberingCritical_AutoFixAfterEnvIndirection reproduces the fixer
+// interaction behind the tool-induced false negative: when another fixer (e.g.
+// code-injection) runs first, it moves the untrusted expression into a step env
+// var and rewrites the write to `echo "title=$PR_TITLE" >> $GITHUB_OUTPUT` with
+// no inline ${{ }}. Env indirection does not stop newline clobbering, so the
+// heredoc transform must still recognize and wrap the env-var form; otherwise the
+// auto-fix leaves a clobberable line that the rule then no longer detects.
+func TestOutputClobberingCritical_AutoFixAfterEnvIndirection(t *testing.T) {
+	rule := OutputClobberingCriticalRule()
+
+	workflow := &ast.Workflow{
+		On: []ast.Event{
+			&ast.WebhookEvent{Hook: &ast.String{Value: "pull_request_target"}},
+		},
+	}
+	job := &ast.Job{
+		Steps: []*ast.Step{
+			{
+				Exec: &ast.ExecRun{
+					Run: &ast.String{
+						Value: `echo "title=${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"`,
+						Pos:   &ast.Position{Line: 1, Col: 1},
+					},
+				},
+			},
+		},
+	}
+
+	// Detection runs on the original inline form and registers the step.
+	_ = rule.VisitWorkflowPre(workflow)
+	_ = rule.VisitJobPre(job)
+	if len(rule.Errors()) == 0 {
+		t.Fatal("expected the inline form to be detected")
+	}
+
+	step := job.Steps[0]
+
+	// Simulate code-injection's fix having run first: the untrusted expression is
+	// now carried by a step env var and the run line reads $PR_TITLE.
+	step.Env = &ast.Env{
+		Vars: map[string]*ast.EnvVar{
+			"pr_title": {
+				Name:  &ast.String{Value: "PR_TITLE"},
+				Value: &ast.String{Value: "${{ github.event.pull_request.title }}"},
+			},
+		},
+	}
+	step.Exec.(*ast.ExecRun).Run.Value = `echo "title=$PR_TITLE" >> "$GITHUB_OUTPUT"`
+
+	if err := rule.FixStep(step); err != nil {
+		t.Fatalf("FixStep() returned error: %v", err)
+	}
+
+	got := step.Exec.(*ast.ExecRun).Run.Value
+	if !strings.Contains(got, "<<EOF") {
+		t.Errorf("expected heredoc wrapping of the env-indirected write, got:\n%s", got)
+	}
+	if !strings.Contains(got, "title<<") {
+		t.Errorf("expected the output name 'title' preserved in the heredoc, got:\n%s", got)
+	}
+}
+
 func TestOutputClobberingCritical_VariousOutputPatterns(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Problem

When an untrusted expression is written to `$GITHUB_OUTPUT`, `output-clobbering` and `code-injection` fire on the same line. `code-injection`'s auto-fixer is registered earlier, so it runs first and rewrites

```
echo "title=${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"
```

into

```
echo "title=$PR_TITLE" >> "$GITHUB_OUTPUT"
env:
  PR_TITLE: ${{ github.event.pull_request.title }}
```

`output-clobbering`'s heredoc transform then keyed only on the inline `${{ expr }}` form, so it no longer matched the rewritten line and emitted no heredoc. The `-fix on` output is therefore:

- **still vulnerable** — env indirection stops shell injection, but not newline injection into `$GITHUB_OUTPUT` (a newline in `$PR_TITLE` still injects a second `name=value` entry), and
- **silently so** — re-linting the fixed file reports nothing, because the line no longer carries an inline expression. The auto-fix produces a file that looks clean but is not.

The rule's own auto-fix already produces the correct `env` + heredoc form when it runs in isolation; the defect is purely the interaction with the earlier-applied fixer.

## Fix

Make the heredoc transform order-independent. A `$GITHUB_OUTPUT` line is wrapped when it references a step env var whose value carries one of the untrusted expressions, in addition to the inline `${{ expr }}` form. The env var is resolved by matching the expression it carries — not by recomputing a name — so it stays correct regardless of which fixer ran first or how it named the variable.

**Detection is unchanged**; only the auto-fix is made robust. With the fix, the single-fixer and both-fixer paths converge to the same safe result:

```
run: |-
  {
    echo "title<<EOF_SISAKULINT"
    echo "$PR_TITLE"
    echo "EOF_SISAKULINT"
  } >> "$GITHUB_OUTPUT"
env:
  PR_TITLE: ${{ github.event.pull_request.title }}
```

and re-linting the fixed file reports nothing because it is genuinely safe (heredoc present).

## Tests

Adds `TestOutputClobberingCritical_AutoFixAfterEnvIndirection`, which simulates the post-code-injection state (untrusted expression already moved to a step env var, run line reading `$PR_TITLE`) and asserts the write is heredoc-wrapped. Existing auto-fix and detection tests are unchanged. `go test ./pkg/core/` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `$GITHUB_OUTPUT` への書き込みが、インライン表現だけでなく環境変数経由の参照（環境変数の間接参照を含む）でも自動的に heredoc 形式へ変換されるようになりました。
  * 既存の修正で置き換えられたケースでも、安全な出力処理（改行を含むケース）の確実性が向上しました。

* **Tests**
  * 環境変数間接参照後の自動修正を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->