### PR TITLE
fix(output-clobbering): flag inline GITHUB_OUTPUT writes even when the expression is also in env

### DIFF
--- a/pkg/core/outputclobbering.go
+++ b/pkg/core/outputclobbering.go
@@ -140,7 +140,14 @@ func (rule *OutputClobberingRule) VisitJobPre(node *ast.Job) error {
 				}
 
 				untrustedPaths := rule.checkUntrustedInput(expr)
-				if len(untrustedPaths) > 0 && !rule.isDefinedInEnv(expr, s.Env) {
+				// An inline ${{ ... }} written to $GITHUB_OUTPUT without a heredoc
+				// is vulnerable regardless of whether the same expression is also
+				// defined in the step env: defining an env var does not remove the
+				// inline interpolation on this line, and env indirection would not
+				// stop newline clobbering even if it were used. (Moving the value to
+				// env is the mitigation for shell code-injection, not for output
+				// clobbering — the fix here is heredoc syntax.)
+				if len(untrustedPaths) > 0 {
 					if stepUntrusted == nil {
 						stepUntrusted = &stepWithOutputClobbering{step: s}
 					}
@@ -586,37 +593,4 @@ func (rule *OutputClobberingRule) checkUntrustedInput(expr parsedExpression) []s
 	}
 
 	return paths
-}
-
-// isDefinedInEnv checks if the expression is defined in the step's env section
-func (rule *OutputClobberingRule) isDefinedInEnv(expr parsedExpression, env *ast.Env) bool {
-	if env == nil {
-		return false
-	}
-
-	normalizedExpr := normalizeExpression(expr.raw)
-
-	if env.Vars != nil {
-		for _, envVar := range env.Vars {
-			if envVar.Value != nil && envVar.Value.ContainsExpression() {
-				envExprs := extractExpressionsFromString(envVar.Value.Value)
-				for _, envExpr := range envExprs {
-					if normalizeExpression(envExpr) == normalizedExpr {
-						return true
-					}
-				}
-			}
-		}
-	}
-
-	if env.Expression != nil && env.Expression.ContainsExpression() {
-		envExprs := extractExpressionsFromString(env.Expression.Value)
-		for _, envExpr := range envExprs {
-			if normalizeExpression(envExpr) == normalizedExpr {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/pkg/core/outputclobbering_test.go
+++ b/pkg/core/outputclobbering_test.go
@@ -286,10 +286,17 @@ func TestOutputClobberingCritical_AutoFix(t *testing.T) {
 	}
 }
 
-func TestOutputClobberingCritical_EnvVarDefinedInStep(t *testing.T) {
+// TestOutputClobberingCritical_InlineExprFlaggedEvenWhenAlsoInEnv checks that an
+// inline ${{ ... }} written to $GITHUB_OUTPUT is still flagged when the same
+// expression also happens to be defined in the step env. Defining an env var does
+// not remove the inline interpolation on this line, and env indirection would not
+// stop newline clobbering even if the line used $PR_TITLE — only a heredoc does.
+// (The rule previously suppressed this case, mirroring the injection-family rules
+// where env indirection *is* the mitigation; that suppression hid a real
+// vulnerability here.)
+func TestOutputClobberingCritical_InlineExprFlaggedEvenWhenAlsoInEnv(t *testing.T) {
 	rule := OutputClobberingCriticalRule()
 
-	// Create workflow with privileged trigger
 	workflow := &ast.Workflow{
 		On: []ast.Event{
 			&ast.WebhookEvent{
@@ -298,7 +305,8 @@ func TestOutputClobberingCritical_EnvVarDefinedInStep(t *testing.T) {
 		},
 	}
 
-	// Create job with env var already defined
+	// The expression is defined in the step env, but the run line still writes the
+	// inline ${{ ... }} form (not $PR_TITLE) to $GITHUB_OUTPUT without a heredoc.
 	job := &ast.Job{
 		Steps: []*ast.Step{
 			{
@@ -320,16 +328,11 @@ func TestOutputClobberingCritical_EnvVarDefinedInStep(t *testing.T) {
 		},
 	}
 
-	// Visit workflow and job
 	_ = rule.VisitWorkflowPre(workflow)
 	_ = rule.VisitJobPre(job)
 
-	errors := rule.Errors()
-	if len(errors) != 0 {
-		t.Errorf("expected no errors when env var is already defined, got %d", len(errors))
-		for _, err := range errors {
-			t.Logf("  error: %s", err.Description)
-		}
+	if len(rule.Errors()) == 0 {
+		t.Error("expected the inline GITHUB_OUTPUT write to be flagged even though the expression is also defined in env (env definition does not make the inline, non-heredoc write safe)")
 	}
 }
 


### PR DESCRIPTION
## Problem

`output-clobbering` detection suppressed a finding whenever the untrusted expression was also defined in the step `env:` (`!rule.isDefinedInEnv(...)`).

This mirrors the injection-family rules (`code-injection`, `envvar-injection`, …), where the recommended fix **is** env indirection — moving `${{ ... }}` into an env var and referencing `$VAR` prevents shell injection — so "the expression is in env" is a reasonable "already mitigated" signal there.

That assumption does not hold for output clobbering:

- Defining an env var does **not** remove an inline `${{ ... }}` that is still written on the `$GITHUB_OUTPUT` line. The value is interpolated inline and remains vulnerable.
- Even if the line used `$VAR`, env indirection does not stop newline injection into `$GITHUB_OUTPUT` — only heredoc syntax (or sanitization) does.

So the suppression hid genuinely vulnerable writes. For example, this was silently accepted:

```yaml
steps:
  - env:
      PR_TITLE: ${{ github.event.pull_request.title }}
    run: echo "title=${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"
```

## Fix

Remove the env-definition gate from detection (and the now-unused `isDefinedInEnv` helper).

**Impact is narrow.** The safe and vulnerable fixtures are unchanged — heredoc / sanitized / trusted-input cases are still suppressed by the separate heredoc check. The only behavior change is that an inline `${{ ... }}` write to `$GITHUB_OUTPUT` that also has the expression in env now fires, which is correct (it is vulnerable).

## Tests

The existing test asserted the old (incorrect) suppression — expecting no finding for the vulnerable case above. It is rewritten to assert the write is flagged, with a comment explaining why env definition does not make an inline, non-heredoc write safe. `go test ./pkg/core/` passes; `gofmt`/`go vet` clean.

## Note

This is independent of the auto-fix robustness change in the sibling PR (which makes the heredoc auto-fix order-independent). This PR only corrects detection; it does not touch the injection-family rules, where the env-definition suppression is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `$GITHUB_OUTPUT` へのインライン式書き込みを、同じステップの環境変数に定義されている場合でも、出力クロバリングのリスクとして検出するよう改善しました。

* **テスト**
  * 環境変数に同じ式が定義されているケースでも、適切にエラーが報告されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->