### PR TITLE
feat(remote): add immutable pull request snapshot scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Static-analysis tools sit upstream of runtime tools — sisakulint catches bugs 
 ## Table of contents
 
 - [Quick start](#quick-start)
+- [Remote pull request scans](#remote-pull-request-scans)
 - [Installation](#installation)
 - [What it detects](#what-it-detects)
 - [Rule reference](#rule-reference)
@@ -84,6 +85,38 @@ sisakulint -enable-rule missing-timeout-minutes   # opt-in rule
 ```
 
 Exit codes: `0` = clean, `1` = findings, `2` = bad CLI args, `3` = fatal error.
+
+---
+
+## Remote pull request scans
+
+Scan the exact PR head without cloning it yourself:
+
+```bash
+sisakulint -remote sisaku-security/sisakulint-agent -pr 18
+
+# Service/CI callers should pin the webhook revision to prevent stale jobs from
+# scanning a newer head. Repeat -remote-target to limit report/fix scope while
+# every workflow in the snapshot remains available for cross-file analysis.
+sisakulint \
+  -remote sisaku-security/sisakulint-agent \
+  -pr 18 \
+  -expected-head-sha 0123456789abcdef0123456789abcdef01234567 \
+  -remote-target .github/workflows/deploy.yml \
+  -format "{{sarif .}}"
+```
+
+Pull request URLs are recognized as well (`-remote https://github.com/owner/repo/pull/18`).
+The command downloads an archive at the resolved immutable head SHA, safely
+materializes the complete repository, analyses all workflows with local project
+context, and reports only workflows changed in the PR. Private repositories
+require `-github-token` or one of the documented token environment variables.
+
+`-fix dry-run` can preview remote fixes. Applying `-fix on` requires a new,
+explicit `-remote-checkout-dir`; sisakulint never writes directly to GitHub.
+PR-mode fixes are limited to the explicitly selected workflow files. Fixers
+which mutate repository files such as `.github/dependabot.yaml` remain enabled
+for local scans but are disabled for this workflow-only response contract.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,15 +108,19 @@ sisakulint \
 
 Pull request URLs are recognized as well (`-remote https://github.com/owner/repo/pull/18`).
 The command downloads an archive at the resolved immutable head SHA, safely
-materializes the complete repository, analyses all workflows with local project
-context, and reports only workflows changed in the PR. Private repositories
-require `-github-token` or one of the documented token environment variables.
+materializes the complete repository, analyzes all workflows with local project
+context, and reports only workflows changed in the PR. Private repositories can
+authenticate with `-github-token`, `SISAKULINT_GITHUB_TOKEN`, `GITHUB_TOKEN`,
+`GH_TOKEN`, an existing `gh auth` session, or Git credentials. Remote scanning
+currently supports GitHub.com only; GitHub Enterprise Server and custom GitHub
+API base URLs are not supported.
 
 `-fix dry-run` can preview remote fixes. Applying `-fix on` requires a new,
 explicit `-remote-checkout-dir`; sisakulint never writes directly to GitHub.
-PR-mode fixes are limited to the explicitly selected workflow files. Fixers
-which mutate repository files such as `.github/dependabot.yaml` remain enabled
-for local scans but are disabled for this workflow-only response contract.
+PR-mode fixes are limited to workflows changed in the PR and, when provided,
+the `-remote-target` selection. Fixers which mutate repository files such as
+`.github/dependabot.yaml` remain enabled for local scans but are disabled for
+this workflow-only response contract.
 
 ---
 

--- a/docs/dependabotecosystemrule.md
+++ b/docs/dependabotecosystemrule.md
@@ -18,7 +18,8 @@ The `github-actions` ecosystem is intentionally out of scope here; it is handled
 - **Lockfile Signals**: Infers ecosystems from lockfiles in the repository root.
 - **Setup-action Signals**: Infers ecosystems from `setup-*` actions in workflow steps.
 - **Local-scan Only**: Reads the local filesystem to locate lockfiles and the Dependabot config. The
-  check is skipped in remote-scan mode.
+  check is skipped in legacy API-only remote-scan mode. Pull-request snapshot
+  scans materialize repository context locally and therefore run this check.
 - **Diagnose-only**: Reports findings only; it does not auto-fix the Dependabot configuration.
 - **Renovate Aware**: When a Renovate configuration extends a broad preset (e.g.
   `config:recommended`), the check is skipped entirely. Otherwise only the ecosystems Renovate
@@ -103,7 +104,8 @@ updates:
 
 ### Limitations
 
-- Local-scan only; remote-scan mode skips the check.
+- Requires local repository context. Legacy API-only remote scans skip the
+  check; pull-request snapshot scans provide that context and run it.
 - Lockfiles are inferred from the repository root only (no recursive scan), so monorepo dependencies
   nested in subdirectories are not detected.
 - Matching is based on the presence of a `package-ecosystem`; the Dependabot `directory` value is not

--- a/docs/superpowers/specs/2026-08-01-pr-snapshot-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-01-pr-snapshot-scanning-design.md
@@ -1,0 +1,132 @@
++++
+title = "Immutable pull-request snapshot scanning"
+date = 2026-08-01
+draft = false
++++
+
+# Immutable pull-request snapshot scanning
+
+Date: 2026-08-01
+
+## Problem
+
+The original sisakulint-agent integration sends changed workflow contents to
+sisakulint-api. That request has no general repository model. Rules which need
+`.github/dependabot.yaml`, Renovate configuration, root lockfiles, local actions,
+or local reusable workflows either skip checks or make decisions from incomplete
+context. Adding one special agent-side fetch per rule does not scale and can scan
+a different revision from the workflow itself.
+
+## Decision
+
+Repository acquisition belongs to sisakulint's remote implementation. The API
+is a transport/execution boundary, and the agent remains GitHub orchestration.
+
+The agent sends this descriptor to the existing `/lint` or `/fix` endpoint:
+
+```json
+{
+  "repository": {
+    "owner": "sisaku-security",
+    "repo": "sisakulint-agent",
+    "pullNumber": 18,
+    "expectedHeadSha": "0123456789abcdef0123456789abcdef01234567",
+    "targets": [".github/workflows/deploy.yml"]
+  }
+}
+```
+
+The short-lived GitHub App installation token is carried in the HTTP
+`Authorization: Bearer` header. sisakulint-api injects it only into the child
+process environment and never places it in command arguments or responses.
+Legacy `files` requests remain supported.
+
+## Scan semantics
+
+- Snapshot revision: the PR's current `head.sha`, verified against
+  `expectedHeadSha` from the webhook before archive download. The PR's head and
+  base SHA are read again after the mutable files endpoint is paginated; a
+  change to either side aborts before archive resolution.
+- Analysis scope: every workflow in the complete head snapshot. This enables
+  project rules and cross-file analysis.
+- Report scope: changed, non-removed workflow paths listed in `targets`.
+- Fix scope: the same explicit targets. sisakulint never writes to GitHub; the
+  agent previews and commits returned target changes. Project-file fixers such
+  as Dependabot configuration creation are disabled in this mode because the
+  workflow-only response cannot persist those mutations.
+- Context-only changes: do not currently produce a report when no workflow was
+  changed. Base/head finding comparison is a follow-up below.
+
+## Snapshot safety constraints
+
+- Capture the mutable PR revision, then download the archive by its full head
+  SHA only after the changed-file listing is revalidated.
+- Revalidate both PR head and base after listing changed files so the target
+  list and immutable archive cannot describe different PR revisions.
+- Cap compressed data at 100 MiB, extracted data at 400 MiB, individual files
+  at 50 MiB, and archive entries at 100,000.
+- Refuse PRs beyond GitHub's 3,000-file listing cap instead of treating a
+  truncated target list as complete.
+- Require one archive top-level directory and reject absolute paths, `..`
+  components, duplicates, links, devices, and FIFOs.
+- Ignore only POSIX PAX metadata records; never execute hooks, repository code,
+  or submodules.
+- Use a separate unauthenticated client for the pre-signed archive URL so a
+  GitHub token cannot cross the API redirect boundary.
+- Create an empty `.git` marker only after extraction for sisakulint project
+  discovery.
+
+## Result and writeback concurrency
+
+- Repository-mode lint treats the sisakulint exit status and SARIF document as
+  one contract. A finding exit without results, a clean exit with results,
+  missing locations, and results for paths outside `targets` all fail closed.
+- Each scan invocation uses a head-specific comment instead of reusing one
+  mutable comment across revisions. Before publishing, the agent verifies that
+  the PR still points to the scanned head SHA; stale comments are minimized and
+  cannot overwrite a newer invocation's result or failure message.
+- Before autofix and between each write, the agent checks the expected branch
+  head. Contents API updates use the blob SHA read from the scanned revision,
+  never a freshly fetched mutable blob SHA, so a concurrent edit to the same
+  workflow produces a conflict instead of being overwritten.
+
+## Rollout order
+
+The three changes are intentionally deployable only in this order:
+
+1. Merge sisakulint and release `v0.3.6`.
+2. Merge sisakulint-api, whose container pins `v0.3.6`, and verify `/health` plus
+   one repository-mode `/lint` call.
+3. Rebase/replace sisakulint-agent PR #18 with the repository-descriptor client,
+   then deploy it.
+
+The agent requires `resolvedHeadSha` and one result per target, so deploying it
+against the legacy API fails visibly instead of silently reporting a clean scan.
+
+## Acceptance evidence
+
+- Unit tests cover PR URL parsing, head-SHA mismatch, revision changes during
+  file pagination, archive traversal/link rejection, PAX headers, full-context
+  extraction, report filtering, API input validation, token forwarding,
+  fail-closed SARIF validation, stale writeback, original-blob compare-and-swap,
+  SARIF snippets, and legacy-response rejection.
+- A live private-repository scan of sisakulint-agent PR #18 materialized the
+  exact expected head SHA successfully.
+- A live cross-repository (fork) PR also materialized its head SHA through the
+  base repository archive endpoint.
+- A live scan of a workflow-changing PR reported only its changed workflow and
+  detected the `gomod` ecosystem from the snapshot's root `go.sum`, proving that
+  repository context was used without transporting that file through the API.
+
+## Follow-ups
+
+1. Scan both base and head and compare stable finding fingerprints so
+   context-only changes can report newly introduced findings without flooding a
+   PR with pre-existing issues.
+2. Add service-to-service authentication for sisakulint-api independently of
+   the forwarded GitHub installation credential.
+3. Replace per-file Contents API autofix commits with one Git tree/commit for
+   atomic multi-file updates.
+4. Decide whether safely materialized in-repository symlinks are worth
+   supporting; the MVP fails closed on all link entries.
+5. Add archive and lint duration/size metrics before raising any snapshot limit.

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"sort"
 	"strings"
 
 	"github.com/sisaku-security/sisakulint/pkg/remote"
@@ -56,6 +58,8 @@ $ sisakulint -format "{{sarif .}}"
 # Remote scanning: scan GitHub repositories directly via API
 
 $ sisakulint -remote owner/repo
+$ sisakulint -remote owner/repo -pr 123
+$ sisakulint -remote https://github.com/owner/repo/pull/123
 $ sisakulint -remote "org:kubernetes"
 $ sisakulint -remote owner/repo -r -D 5
 
@@ -129,7 +133,7 @@ func (cmd *Command) runLint(args []string, linterOpts *LinterOptions, initConfig
 // runAutofix returns true if any fixer hit the GitHub API rate limit, so
 // Main can surface a non-zero exit and skip the affected file's write
 // (issue #474).
-func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool) (rateLimited bool) {
+func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool, baseDir string) (rateLimited bool) {
 	for _, res := range results {
 		if len(res.AutoFixers) == 0 {
 			continue
@@ -166,10 +170,14 @@ func (cmd *Command) runAutofix(results []*ValidateResult, isDryRun bool) (rateLi
 			fmt.Fprintf(cmd.Stderr, "Skipping write for %s due to GitHub API rate limit; re-run after authenticating to complete the fix.\n", res.FilePath)
 			continue
 		}
-		err = os.WriteFile(res.FilePath, data, 0644) //nolint:gosec // auto-fix overwrites existing workflow files; preserving 0644 for git and CI compatibility
+		writePath := res.FilePath
+		if baseDir != "" && !filepath.IsAbs(writePath) {
+			writePath = filepath.Join(baseDir, writePath)
+		}
+		err = os.WriteFile(writePath, data, 0644) //nolint:gosec // auto-fix overwrites existing workflow files; preserving 0644 for git and CI compatibility
 		if err != nil {
 			fmt.Fprintf(cmd.Stderr, "Error while writing the fixed workflow: %v\n", err)
-			err := os.WriteFile(res.FilePath, res.Source, 0644) //nolint:gosec // restore original workflow file
+			err := os.WriteFile(writePath, res.Source, 0644) //nolint:gosec // restore original workflow file
 			if err != nil {
 				fmt.Fprintf(cmd.Stderr, "Error while restoring the original workflow: %v\n", err)
 			}
@@ -200,6 +208,17 @@ func (e *enabledRuleFlags) Set(v string) error {
 	return nil
 }
 
+type remoteTargetFlags []string
+
+func (t *remoteTargetFlags) String() string {
+	return "repository-relative workflow path to report or fix"
+}
+
+func (t *remoteTargetFlags) Set(v string) error {
+	*t = append(*t, v)
+	return nil
+}
+
 // todo: sisakulintのmain関数
 func (cmd *Command) Main(args []string) int {
 	var showVersion bool
@@ -216,6 +235,10 @@ func (cmd *Command) Main(args []string) int {
 	var parallelism int
 	var limit int
 	var githubTokenFlag string
+	var pullRequest int
+	var expectedHeadSHA string
+	var remoteCheckoutDir string
+	var remoteTargets remoteTargetFlags
 
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flags.SetOutput(cmd.Stderr)
@@ -234,6 +257,10 @@ func (cmd *Command) Main(args []string) int {
 	flags.StringVar(&linterOpts.StdinInputFileName, "stdin-filename", "", "File name when reading input from stdin")
 	flags.StringVar(&autoFixMode, "fix", "off", "Enable auto-fix mode. Available options: off, on, dry-run")
 	flags.StringVar(&remoteInput, "remote", "", "Remote repository to scan (owner/repo, URL, or search query like 'org:kubernetes')")
+	flags.IntVar(&pullRequest, "pr", 0, "Pull request number to scan at its immutable head (-remote only)")
+	flags.StringVar(&expectedHeadSHA, "expected-head-sha", "", "Fail if the pull request head no longer matches this SHA (-remote -pr only)")
+	flags.StringVar(&remoteCheckoutDir, "remote-checkout-dir", "", "Extract the pull request snapshot into this new directory instead of a temporary directory (-remote -pr only)")
+	flags.Var(&remoteTargets, "remote-target", "Repository-relative changed workflow path to report or fix; repeatable (-remote -pr only)")
 	flags.BoolVar(&recursive, "r", false, "Enable recursive scanning of reusable workflows (-remote only)")
 	flags.IntVar(&maxDepth, "D", 3, "Max recursion depth for recursive scanning (-remote only)")
 	flags.IntVar(&parallelism, "p", 3, "Number of parallel scans (-remote only)")
@@ -258,6 +285,28 @@ func (cmd *Command) Main(args []string) int {
 	if autoFixMode != "off" && autoFixMode != "on" && autoFixMode != FileFixDryRun {
 		fmt.Fprintf(cmd.Stderr, "Invalid value for -fix: %s\n", autoFixMode)
 		return ExitStatusInvalidCommandOption
+	}
+	if pullRequest < 0 {
+		fmt.Fprintln(cmd.Stderr, "Invalid value for -pr: must not be negative")
+		return ExitStatusInvalidCommandOption
+	}
+	if remoteInput == "" && (pullRequest != 0 || expectedHeadSHA != "" || remoteCheckoutDir != "" || len(remoteTargets) > 0) {
+		fmt.Fprintln(cmd.Stderr, "-pr, -expected-head-sha, -remote-checkout-dir, and -remote-target require -remote")
+		return ExitStatusInvalidCommandOption
+	}
+	if pullRequest == 0 && remoteInput != "" && (expectedHeadSHA != "" || remoteCheckoutDir != "" || len(remoteTargets) > 0) {
+		parsed, err := remote.ParseInput(remoteInput)
+		if err != nil || parsed.PullNumber == 0 {
+			fmt.Fprintln(cmd.Stderr, "-expected-head-sha, -remote-checkout-dir, and -remote-target require a pull request URL or -pr")
+			return ExitStatusInvalidCommandOption
+		}
+	}
+	if remoteInput != "" && autoFixMode == "on" && remoteCheckoutDir == "" {
+		parsed, _ := remote.ParseInput(remoteInput)
+		if pullRequest > 0 || (parsed != nil && parsed.PullNumber > 0) {
+			fmt.Fprintln(cmd.Stderr, "-remote pull request scans require -remote-checkout-dir when -fix on is used")
+			return ExitStatusInvalidCommandOption
+		}
 	}
 
 	if showVersion {
@@ -294,6 +343,29 @@ func (cmd *Command) Main(args []string) int {
 	}
 
 	if remoteInput != "" {
+		parsed, err := remote.ParseInput(remoteInput)
+		if err != nil {
+			fmt.Fprintf(cmd.Stderr, "Invalid remote input: %v\n", err)
+			return ExitStatusInvalidCommandOption
+		}
+		if parsed.PullNumber > 0 {
+			if pullRequest > 0 && pullRequest != parsed.PullNumber {
+				fmt.Fprintf(cmd.Stderr, "Pull request number mismatch: URL specifies #%d but -pr specifies #%d\n", parsed.PullNumber, pullRequest)
+				return ExitStatusInvalidCommandOption
+			}
+			pullRequest = parsed.PullNumber
+		}
+		if pullRequest > 0 {
+			return cmd.runRemotePullRequestScan(
+				parsed,
+				pullRequest,
+				expectedHeadSHA,
+				remoteCheckoutDir,
+				remoteTargets,
+				autoFixMode,
+				&linterOpts,
+			)
+		}
 		return cmd.runRemoteScan(remoteInput, &linterOpts, &remote.ScannerOptions{
 			Parallelism: parallelism,
 			Recursive:   recursive,
@@ -301,6 +373,7 @@ func (cmd *Command) Main(args []string) int {
 			Limit:       limit,
 			Verbose:     linterOpts.IsVerboseOutputEnabled,
 			Output:      cmd.Stderr,
+			GitHubToken: linterOpts.GitHubToken,
 		})
 	}
 
@@ -318,7 +391,7 @@ func (cmd *Command) Main(args []string) int {
 	}
 	if hasErrors {
 		if enableAutofix {
-			if rateLimited := cmd.runAutofix(errs, autoFixMode == FileFixDryRun); rateLimited {
+			if rateLimited := cmd.runAutofix(errs, autoFixMode == FileFixDryRun, ""); rateLimited {
 				fmt.Fprintln(cmd.Stderr,
 					"sisakulint: commit-sha autofix aborted because the GitHub API rate limit was exceeded. "+
 						"Re-run with GITHUB_TOKEN / GH_TOKEN / SISAKULINT_GITHUB_TOKEN set or with -github-token to complete the fix.")
@@ -378,4 +451,162 @@ func (cmd *Command) runRemoteScan(input string, linterOpts *LinterOptions, scann
 
 	fmt.Fprintf(cmd.Stdout, "No problems found.\n")
 	return ExitStatusSuccessNoProblem
+}
+
+// runRemotePullRequestScan materializes the exact PR head as a local project,
+// analyses every workflow for repository and cross-file context, and reports
+// (or fixes) only workflows changed by the pull request.
+func (cmd *Command) runRemotePullRequestScan(
+	input *remote.ParsedInput,
+	pullNumber int,
+	expectedHeadSHA string,
+	checkoutDir string,
+	requestedTargets []string,
+	autoFixMode string,
+	linterOpts *LinterOptions,
+) int {
+	if input.Type == remote.InputTypeSearchQuery || input.Owner == "" || input.Repo == "" {
+		fmt.Fprintln(cmd.Stderr, "Pull request scanning requires a single owner/repo repository")
+		return ExitStatusInvalidCommandOption
+	}
+	if input.Ref != "" {
+		fmt.Fprintln(cmd.Stderr, "A /tree/<ref> URL cannot be combined with pull request scanning")
+		return ExitStatusInvalidCommandOption
+	}
+
+	var fetcher *remote.Fetcher
+	var err error
+	if linterOpts.GitHubToken == "" {
+		// Keep direct CLI scans compatible with gh auth and git credential
+		// fallback when no flag/environment token was supplied.
+		fetcher, err = remote.NewFetcher(1)
+	} else {
+		fetcher, err = remote.NewFetcherWithToken(1, linterOpts.GitHubToken)
+	}
+	if err != nil {
+		fmt.Fprintf(cmd.Stderr, "Error initializing remote fetcher: %v\n", err)
+		return ExitStatusFailure
+	}
+	snapshot, err := fetcher.MaterializePullRequest(
+		context.Background(),
+		input.Owner,
+		input.Repo,
+		pullNumber,
+		&remote.PullRequestSnapshotOptions{
+			ExpectedHeadSHA: expectedHeadSHA,
+			Destination:     checkoutDir,
+		},
+	)
+	if err != nil {
+		fmt.Fprintf(cmd.Stderr, "Error preparing pull request snapshot: %v\n", err)
+		return ExitStatusFailure
+	}
+	defer func() {
+		if err := snapshot.Close(); err != nil {
+			fmt.Fprintf(cmd.Stderr, "Warning: failed to remove pull request snapshot: %v\n", err)
+		}
+	}()
+
+	targets, err := selectRemoteTargets(requestedTargets, snapshot.TargetWorkflowPaths)
+	if err != nil {
+		fmt.Fprintf(cmd.Stderr, "Invalid remote target: %v\n", err)
+		return ExitStatusInvalidCommandOption
+	}
+	if len(targets) == 0 {
+		if linterOpts.IsVerboseOutputEnabled {
+			fmt.Fprintf(cmd.Stderr, "Pull request #%d has no changed workflow files at %s\n", pullNumber, snapshot.HeadSHA)
+		}
+		return ExitStatusSuccessNoProblem
+	}
+	if len(snapshot.WorkflowPaths) == 0 {
+		fmt.Fprintln(cmd.Stderr, "Pull request snapshot contains no workflow files")
+		return ExitStatusFailure
+	}
+
+	linterOpts.IsRemote = false
+	linterOpts.CurrentWorkingDirectoryPath = snapshot.Root
+	linterOpts.ReportFilePaths = targets
+	linterOpts.DisableRepositoryFileAutoFixers = true
+	linter, err := NewLinter(cmd.Stdout, linterOpts)
+	if err != nil {
+		fmt.Fprintf(cmd.Stderr, "Error initializing linter: %v\n", err)
+		return ExitStatusFailure
+	}
+
+	workflowFiles := make([]string, 0, len(snapshot.WorkflowPaths))
+	for _, workflow := range snapshot.WorkflowPaths {
+		workflowFiles = append(workflowFiles, filepath.Join(snapshot.Root, filepath.FromSlash(workflow)))
+	}
+	results, err := linter.LintFiles(workflowFiles, nil)
+	if err != nil {
+		fmt.Fprintf(cmd.Stderr, "Error linting pull request snapshot: %v\n", err)
+		return ExitStatusFailure
+	}
+
+	targetResults := filterRemoteResults(results, targets)
+	hasErrors := false
+	for _, result := range targetResults {
+		if len(result.Errors) > 0 {
+			hasErrors = true
+			break
+		}
+	}
+	if !hasErrors {
+		return ExitStatusSuccessNoProblem
+	}
+
+	if autoFixMode == "on" || autoFixMode == FileFixDryRun {
+		if rateLimited := cmd.runAutofix(targetResults, autoFixMode == FileFixDryRun, snapshot.Root); rateLimited {
+			fmt.Fprintln(cmd.Stderr,
+				"sisakulint: commit-sha autofix aborted because the GitHub API rate limit was exceeded. "+
+					"Re-run with GITHUB_TOKEN / GH_TOKEN / SISAKULINT_GITHUB_TOKEN set or with -github-token to complete the fix.")
+			return ExitStatusFailure
+		}
+	}
+	return ExitStatusSuccessProblemFound
+}
+
+func selectRemoteTargets(requested, changed []string) ([]string, error) {
+	changedSet := make(map[string]struct{}, len(changed))
+	for _, target := range changed {
+		changedSet[normalizeReportPath(target)] = struct{}{}
+	}
+	if len(requested) == 0 {
+		result := append([]string(nil), changed...)
+		sort.Strings(result)
+		return result, nil
+	}
+
+	seen := make(map[string]struct{}, len(requested))
+	result := make([]string, 0, len(requested))
+	for _, target := range requested {
+		normalized := normalizeReportPath(target)
+		if filepath.IsAbs(target) || normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") {
+			return nil, fmt.Errorf("unsafe repository-relative path %q", target)
+		}
+		if _, ok := changedSet[normalized]; !ok {
+			return nil, fmt.Errorf("%q is not a changed workflow in this pull request", target)
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func filterRemoteResults(results []*ValidateResult, targets []string) []*ValidateResult {
+	targetSet := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		targetSet[normalizeReportPath(target)] = struct{}{}
+	}
+	filtered := make([]*ValidateResult, 0, len(targets))
+	for _, result := range results {
+		if _, ok := targetSet[normalizeReportPath(result.FilePath)]; ok {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
 }

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -211,7 +211,10 @@ func (e *enabledRuleFlags) Set(v string) error {
 type remoteTargetFlags []string
 
 func (t *remoteTargetFlags) String() string {
-	return "repository-relative workflow path to report or fix"
+	if t == nil {
+		return ""
+	}
+	return strings.Join(*t, ",")
 }
 
 func (t *remoteTargetFlags) Set(v string) error {

--- a/pkg/core/command_remote_test.go
+++ b/pkg/core/command_remote_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestRemoteTargetFlagsString(t *testing.T) {
+	var targets remoteTargetFlags
+	if got := targets.String(); got != "" {
+		t.Fatalf("zero-value String() = %q, want empty string", got)
+	}
+	if err := targets.Set(".github/workflows/ci.yml"); err != nil {
+		t.Fatal(err)
+	}
+	if err := targets.Set(".github/workflows/release.yml"); err != nil {
+		t.Fatal(err)
+	}
+	if got := targets.String(); got != ".github/workflows/ci.yml,.github/workflows/release.yml" {
+		t.Fatalf("String() = %q", got)
+	}
+	var nilTargets *remoteTargetFlags
+	if got := nilTargets.String(); got != "" {
+		t.Fatalf("nil String() = %q, want empty string", got)
+	}
+}
+
 func TestSelectRemoteTargetsDefaultsToChangedWorkflows(t *testing.T) {
 	changed := []string{
 		".github/workflows/z.yml",
@@ -42,6 +62,7 @@ func TestSelectRemoteTargetsRestrictsExplicitScope(t *testing.T) {
 	for _, requested := range []string{
 		".github/workflows/not-changed.yml",
 		"../outside.yml",
+		"/etc/passwd",
 	} {
 		if _, err := selectRemoteTargets([]string{requested}, changed); err == nil {
 			t.Fatalf("unsafe or unchanged target %q was accepted", requested)

--- a/pkg/core/command_remote_test.go
+++ b/pkg/core/command_remote_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSelectRemoteTargetsDefaultsToChangedWorkflows(t *testing.T) {
+	changed := []string{
+		".github/workflows/z.yml",
+		".github/workflows/a.yaml",
+	}
+	targets, err := selectRemoteTargets(nil, changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		".github/workflows/a.yaml",
+		".github/workflows/z.yml",
+	}
+	if !slices.Equal(targets, want) {
+		t.Fatalf("targets = %#v, want %#v", targets, want)
+	}
+}
+
+func TestSelectRemoteTargetsRestrictsExplicitScope(t *testing.T) {
+	changed := []string{
+		".github/workflows/a.yml",
+		".github/workflows/b.yml",
+	}
+	targets, err := selectRemoteTargets([]string{
+		".github/workflows/b.yml",
+		".github/workflows/b.yml",
+	}, changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(targets, []string{".github/workflows/b.yml"}) {
+		t.Fatalf("targets = %#v", targets)
+	}
+
+	for _, requested := range []string{
+		".github/workflows/not-changed.yml",
+		"../outside.yml",
+	} {
+		if _, err := selectRemoteTargets([]string{requested}, changed); err == nil {
+			t.Fatalf("unsafe or unchanged target %q was accepted", requested)
+		}
+	}
+}

--- a/pkg/core/dependabot_ecosystem.go
+++ b/pkg/core/dependabot_ecosystem.go
@@ -46,6 +46,10 @@ type DependabotEcosystemRule struct {
 	workflowPath string
 	isRemote     bool
 	projectRoot  string
+	// reportProjectFindings is false for context-only workflows in a
+	// pull-request scan. Those workflows must not consume the run-wide dedupe
+	// key for root-lockfile findings that should be anchored to a target file.
+	reportProjectFindings bool
 	// setupActionReqs collects ecosystem requirements derived from setup actions in the
 	// current workflow, anchored to the step position for precise reporting.
 	setupActionReqs []ecosystemRequirement
@@ -69,8 +73,9 @@ func NewDependabotEcosystemRule(workflowPath string, isRemote bool) *DependabotE
 			RuleName: "dependabot-ecosystem",
 			RuleDesc: "Check if dependabot config covers package ecosystems detected from lockfiles and setup actions",
 		},
-		workflowPath: workflowPath,
-		isRemote:     isRemote,
+		workflowPath:          workflowPath,
+		isRemote:              isRemote,
+		reportProjectFindings: true,
 	}
 	if !isRemote {
 		rule.projectRoot = dependabotFindProjectRoot(workflowPath)
@@ -224,6 +229,9 @@ func (rule *DependabotEcosystemRule) VisitWorkflowPost(_ *ast.Workflow) error {
 		// workflow files does not emit the same line-1 warning N times. Setup-action
 		// findings carry a step anchor and stay per-workflow.
 		if req.pos == nil {
+			if !rule.reportProjectFindings {
+				continue
+			}
 			repoKey := rule.projectRoot + "\x00" + req.label + "\x00" + key
 			if _, loaded := dependabotEcosystemReported.LoadOrStore(repoKey, struct{}{}); loaded {
 				continue

--- a/pkg/core/dependabot_github_actions.go
+++ b/pkg/core/dependabot_github_actions.go
@@ -25,6 +25,10 @@ type DependabotGitHubActionsRule struct {
 	// isRemote indicates whether we are running in remote scan mode.
 	// In remote mode the dependabot file cannot be checked via the local filesystem.
 	isRemote bool
+	// allowRepositoryFileAutoFixers is false when a caller can only persist the
+	// workflow file returned in ValidateResult, such as repository-mode API
+	// scans. Local CLI scans keep the historical project-file fixes enabled.
+	allowRepositoryFileAutoFixers bool
 }
 
 // NewDependabotGitHubActionsRule creates a new DependabotGitHubActionsRule instance.
@@ -37,9 +41,10 @@ func NewDependabotGitHubActionsRule(workflowPath string, isRemote bool) *Dependa
 			RuleName: "dependabot-github-actions",
 			RuleDesc: "Check if dependabot.yaml has github-actions ecosystem configured when unpinned actions are detected",
 		},
-		workflowPath:   workflowPath,
-		alreadyChecked: make(map[string]bool),
-		isRemote:       isRemote,
+		workflowPath:                  workflowPath,
+		alreadyChecked:                make(map[string]bool),
+		isRemote:                      isRemote,
+		allowRepositoryFileAutoFixers: true,
 	}
 	// Find project root from workflow path only for local scans
 	if !isRemote {
@@ -142,9 +147,11 @@ func (rule *DependabotGitHubActionsRule) VisitWorkflowPost(_ *ast.Workflow) erro
 			"dependabot.yaml does not exist. Without Dependabot, major version updates (e.g., v3 -> v4) for GitHub Actions won't be automated. "+
 				"Create .github/dependabot.yaml with github-actions ecosystem. See https://sisaku-security.github.io/lint/docs/rules/dependabotgithubactionsrule/",
 		)
-		rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
-			return createDependabotFile(rule.projectRoot)
-		}))
+		if rule.allowRepositoryFileAutoFixers {
+			rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
+				return createDependabotFile(rule.projectRoot)
+			}))
+		}
 		return nil
 	}
 
@@ -162,9 +169,11 @@ func (rule *DependabotGitHubActionsRule) VisitWorkflowPost(_ *ast.Workflow) erro
 				"Without it, major version updates (e.g., v3 -> v4) for GitHub Actions won't be automated. "+
 				"See https://sisaku-security.github.io/lint/docs/rules/dependabotgithubactionsrule/",
 		)
-		rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
-			return updateDependabotFile(dependabotPath)
-		}))
+		if rule.allowRepositoryFileAutoFixers {
+			rule.AddAutoFixer(NewFuncFixer(rule.RuleName, func() error {
+				return updateDependabotFile(dependabotPath)
+			}))
+		}
 	}
 
 	return nil

--- a/pkg/core/known_vulnerable_actions_test.go
+++ b/pkg/core/known_vulnerable_actions_test.go
@@ -91,7 +91,7 @@ func TestKnownVulnerableActionsRuleExplicitTokenOverridesEnvironment(t *testing.
 }
 
 func TestMakeRulesPassesGitHubTokenToKnownVulnerableActionsRule(t *testing.T) {
-	rules := makeRules(".github/workflows/ci.yml", false, "flag-token", nil, nil, nil)
+	rules := makeRules(".github/workflows/ci.yml", false, "flag-token", nil, nil, nil, nil, true, true)
 
 	for _, rule := range rules {
 		known, ok := rule.(*KnownVulnerableActionsRule)

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -85,7 +85,7 @@ type LinterOptions struct {
 	// 空文字なら未認証 60 req/h 制限が適用される。
 	GitHubToken string
 	// ReportFilePaths limits rendered findings to the listed repository-relative
-	// paths while still analysing every file passed to LintFiles. This is used
+	// paths while still analyzing every file passed to LintFiles. This is used
 	// for pull-request scans: unchanged workflows provide cross-file context but
 	// do not create unrelated review findings. An empty slice reports all files.
 	ReportFilePaths []string

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -84,6 +84,16 @@ type LinterOptions struct {
 	// GitHubToken は GitHub API を呼ぶルールに提示するトークン。
 	// 空文字なら未認証 60 req/h 制限が適用される。
 	GitHubToken string
+	// ReportFilePaths limits rendered findings to the listed repository-relative
+	// paths while still analysing every file passed to LintFiles. This is used
+	// for pull-request scans: unchanged workflows provide cross-file context but
+	// do not create unrelated review findings. An empty slice reports all files.
+	ReportFilePaths []string
+	// DisableRepositoryFileAutoFixers prevents fixers from mutating files other
+	// than the workflow represented by a ValidateResult. Pull-request API scans
+	// enable this because their fix response contract returns workflow targets
+	// only; silently modifying and then discarding a project file is unsafe.
+	DisableRepositoryFileAutoFixers bool
 }
 
 // Linterは、workflowをlintするための構造体
@@ -117,6 +127,11 @@ type Linter struct {
 	// gitHubToken は GitHub API を呼ぶルールに提示するトークン。
 	// 空文字なら未認証 60 req/h 制限が適用される。
 	gitHubToken string
+	// reportFilePaths is the normalized set corresponding to
+	// LinterOptions.ReportFilePaths. nil means report every result.
+	reportFilePaths map[string]struct{}
+	// disableRepositoryFileAutoFixers mirrors the corresponding option.
+	disableRepositoryFileAutoFixers bool
 	// loggedConfigs は、`setting configuration: ...` をすでに出力済みの *Config を
 	// 追跡し、複数ファイル並行 validate でログが重複しないようにするためのセット。
 	loggedConfigs sync.Map
@@ -129,6 +144,9 @@ type Linter struct {
 // outパラメータは、Linterインスタンスからのエラーを出力するために使用される。出力を望まない場合は、io.Discardを設定してください。
 // optsパラメータは、lintの動作を設定するLinterOptionsインスタンス
 func NewLinter(errorOutput io.Writer, options *LinterOptions) (*Linter, error) {
+	if options == nil {
+		options = &LinterOptions{}
+	}
 	//log levelの設定
 	var logLevel = LogLevelNoOutput
 	if options.IsVerboseOutputEnabled {
@@ -204,23 +222,50 @@ func NewLinter(errorOutput io.Writer, options *LinterOptions) (*Linter, error) {
 		metadataDebug = logOutput
 	}
 
+	var reportFilePaths map[string]struct{}
+	if len(options.ReportFilePaths) > 0 {
+		reportFilePaths = make(map[string]struct{}, len(options.ReportFilePaths))
+		for _, path := range options.ReportFilePaths {
+			normalized := normalizeReportPath(path)
+			reportFilePaths[normalized] = struct{}{}
+		}
+	}
+
 	return &Linter{
-		projectInformation:       NewProjects(),
-		errorOutput:              errorOutput,
-		logOutput:                logOutput,
-		loggingLevel:             logLevel,
-		remoteActionsCache:       NewRemoteActionsMetadataCache(metadataDebug),
-		shellcheckExecutablePath: options.ShellcheckExecutable,
-		errorIgnorePatterns:      ignorePatterns,
-		defaultConfiguration:     config,
-		boilerplateGeneration:    boiler,
-		errorFormatter:           errorFormatter,
-		currentWorkingDirectory:  workDir,
-		modifyCheckRules:         options.OnCheckRulesModified,
-		isRemote:                 options.IsRemote,
-		enabledOptInRules:        options.EnabledOptInRules,
-		gitHubToken:              options.GitHubToken,
+		projectInformation:              NewProjects(),
+		errorOutput:                     errorOutput,
+		logOutput:                       logOutput,
+		loggingLevel:                    logLevel,
+		remoteActionsCache:              NewRemoteActionsMetadataCache(metadataDebug),
+		shellcheckExecutablePath:        options.ShellcheckExecutable,
+		errorIgnorePatterns:             ignorePatterns,
+		defaultConfiguration:            config,
+		boilerplateGeneration:           boiler,
+		errorFormatter:                  errorFormatter,
+		currentWorkingDirectory:         workDir,
+		modifyCheckRules:                options.OnCheckRulesModified,
+		isRemote:                        options.IsRemote,
+		enabledOptInRules:               options.EnabledOptInRules,
+		gitHubToken:                     options.GitHubToken,
+		reportFilePaths:                 reportFilePaths,
+		disableRepositoryFileAutoFixers: options.DisableRepositoryFileAutoFixers,
 	}, nil
+}
+
+func normalizeReportPath(path string) string {
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func (l *Linter) shouldReport(path string) bool {
+	if l.reportFilePaths == nil {
+		return true
+	}
+	_, ok := l.reportFilePaths[normalizeReportPath(path)]
+	return ok
+}
+
+func (l *Linter) shouldReportProjectFindings(path string) bool {
+	return l.shouldReport(path)
 }
 
 // logはlog levelがDetailedOutput以上の場合にログを出力する
@@ -450,7 +495,9 @@ func (l *Linter) LintFiles(filepaths []string, project *Project) ([]*ValidateRes
 	// Preallocate allResult with the capacity equal to the number of workspaces
 	allResult := make([]*ValidateResult, 0, len(workspaces))
 	for i := range workspaces {
-		totalErrors += len(workspaces[i].result.Errors)
+		if l.shouldReport(workspaces[i].result.FilePath) {
+			totalErrors += len(workspaces[i].result.Errors)
+		}
 		allResult = append(allResult, workspaces[i].result)
 	}
 
@@ -458,6 +505,9 @@ func (l *Linter) LintFiles(filepaths []string, project *Project) ([]*ValidateRes
 		templateFields := make([]*TemplateFields, 0, totalErrors)
 		for i := range workspaces {
 			ws := &workspaces[i]
+			if !l.shouldReport(ws.result.FilePath) {
+				continue
+			}
 			for _, err := range ws.result.Errors {
 				templateFields = append(templateFields, err.ExtractTemplateFields(ws.source))
 			}
@@ -470,6 +520,9 @@ func (l *Linter) LintFiles(filepaths []string, project *Project) ([]*ValidateRes
 	} else {
 		for i := range workspaces {
 			ws := &workspaces[i]
+			if !l.shouldReport(ws.result.FilePath) {
+				continue
+			}
 			l.displayErrors(ws.result.Errors, ws.source)
 			//allErrors = append(allErrors, ws.result.Errors...)
 			//allAutoFixers = append(allAutoFixers, ws.result.AutoFixers...)
@@ -535,12 +588,14 @@ func (l *Linter) LintFile(file string, project *Project) (*ValidateResult, error
 	if err != nil {
 		return nil, err
 	}
-	if l.errorFormatter != nil {
-		if err := l.errorFormatter.PrintErrors(l.errorOutput, result.Errors, source); err != nil {
-			return nil, fmt.Errorf("error formatting output: %w", err)
+	if l.shouldReport(result.FilePath) {
+		if l.errorFormatter != nil {
+			if err := l.errorFormatter.PrintErrors(l.errorOutput, result.Errors, source); err != nil {
+				return nil, fmt.Errorf("error formatting output: %w", err)
+			}
+		} else {
+			l.displayErrors(result.Errors, source)
 		}
-	} else {
-		l.displayErrors(result.Errors, source)
 	}
 	return result, nil
 }
@@ -579,17 +634,19 @@ func (l *Linter) Lint(filepath string, content []byte, project *Project) (*Valid
 		return nil, err
 	}
 
-	if l.errorFormatter != nil {
-		if err := l.errorFormatter.PrintErrors(l.errorOutput, result.Errors, content); err != nil {
-			return nil, fmt.Errorf("error formatting output: %w", err)
+	if l.shouldReport(result.FilePath) {
+		if l.errorFormatter != nil {
+			if err := l.errorFormatter.PrintErrors(l.errorOutput, result.Errors, content); err != nil {
+				return nil, fmt.Errorf("error formatting output: %w", err)
+			}
+		} else {
+			l.displayErrors(result.Errors, content)
 		}
-	} else {
-		l.displayErrors(result.Errors, content)
 	}
 	return result, nil
 }
 
-func makeRules(filePath string, isRemote bool, gitHubToken string, localActions *LocalActionsMetadataCache, remoteActions *RemoteActionsMetadataCache, localReusableWorkflow *LocalReusableWorkflowCache) []Rule {
+func makeRules(filePath string, isRemote bool, gitHubToken string, localActions *LocalActionsMetadataCache, remoteActions *RemoteActionsMetadataCache, localReusableWorkflow *LocalReusableWorkflowCache, project *Project, reportProjectFindings bool, allowRepositoryFileAutoFixers bool) []Rule {
 	// WorkflowTaintMap is shared between Critical and Medium variants of
 	// CodeInjection, EnvVarInjection, ArgumentInjection, and RequestForgery rules
 	// to enable cross-job taint propagation tracking via needs.*.outputs.*
@@ -604,6 +661,17 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 		remoteActions = NewRemoteActionsMetadataCache(debugOut)
 	}
 	actionMetadata := NewMultiActionMetadataResolver(localActions, remoteActions)
+	dependabotGitHubActions := NewDependabotGitHubActionsRule(filePath, isRemote)
+	dependabotGitHubActions.allowRepositoryFileAutoFixers = allowRepositoryFileAutoFixers
+	dependabotEcosystem := NewDependabotEcosystemRule(filePath, isRemote)
+	dependabotEcosystem.reportProjectFindings = reportProjectFindings
+	// Library and remote-snapshot callers may lint a project whose root differs
+	// from the process working directory. Prefer the already-resolved Project
+	// over rediscovering the root from a display-relative workflow path.
+	if project != nil && !isRemote {
+		dependabotGitHubActions.projectRoot = project.RootDirectory()
+		dependabotEcosystem.projectRoot = project.RootDirectory()
+	}
 
 	return []Rule{
 		// MatrixRule(),
@@ -628,9 +696,9 @@ func makeRules(filePath string, isRemote bool, gitHubToken string, localActions 
 		OutputClobberingCriticalRule(),          // Detects output clobbering in privileged workflow triggers
 		OutputClobberingMediumRule(),            // Detects output clobbering in normal workflow triggers
 		CommitShaRule(gitHubToken),
-		NewDependabotGitHubActionsRule(filePath, isRemote), // Checks dependabot.yaml has github-actions ecosystem when unpinned actions found
-		NewDependabotEcosystemRule(filePath, isRemote),     // Checks dependabot config covers ecosystems from lockfiles and setup actions
-		NewDependencyReviewSettingsRule(),                  // Checks dependency-review-action settings against required permissions
+		dependabotGitHubActions,           // Checks dependabot.yaml has github-actions ecosystem when unpinned actions found
+		dependabotEcosystem,               // Checks dependabot config covers ecosystems from lockfiles and setup actions
+		NewDependencyReviewSettingsRule(), // Checks dependency-review-action settings against required permissions
 		ArtifactPoisoningRule(),
 		NewArtifactPoisoningMediumRule(),
 		NewActionListRule(),
@@ -733,7 +801,7 @@ func (l *Linter) validate(
 	// dependabot config / composite action / unparseable workflow would
 	// silently skip the rule-name check and the user's CLI typo would not
 	// be reported until a parseable workflow happened to reach validate().
-	rules := makeRules(filePath, l.isRemote, l.gitHubToken, localActions, l.remoteActionsCache, localReusableWorkflow)
+	rules := makeRules(filePath, l.isRemote, l.gitHubToken, localActions, l.remoteActionsCache, localReusableWorkflow, project, l.shouldReportProjectFindings(filePath), !l.disableRepositoryFileAutoFixers)
 	filteredRules, optErr := applyOptInRules(rules, l.enabledOptInRules)
 	if optErr != nil {
 		return nil, optErr

--- a/pkg/core/linter_report_filter_test.go
+++ b/pkg/core/linter_report_filter_test.go
@@ -1,0 +1,175 @@
+package core
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLintFilesReportsTargetsButAnalyzesAllFiles(t *testing.T) {
+	root := makeTestProject(t)
+	reported := filepath.Join(root, ".github", "workflows", "reported.yml")
+	contextFile := filepath.Join(root, ".github", "workflows", "context.yml")
+	writeTestFile(t, reported, "jobs: [\n")
+	writeTestFile(t, contextFile, "on: [\n")
+
+	var output bytes.Buffer
+	linter, err := NewLinter(&output, &LinterOptions{
+		CurrentWorkingDirectoryPath: root,
+		CustomErrorMessageFormat:    "{{json .}}",
+		ReportFilePaths:             []string{".github/workflows/reported.yml"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	results, err := linter.LintFiles([]string{reported, contextFile}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("LintFiles returned %d results, want 2 analysis results", len(results))
+	}
+	if !strings.Contains(output.String(), ".github/workflows/reported.yml") {
+		t.Fatalf("reported file missing from output: %s", output.String())
+	}
+	if strings.Contains(output.String(), ".github/workflows/context.yml") {
+		t.Fatalf("context-only file leaked into output: %s", output.String())
+	}
+}
+
+func TestLintFileUsesResolvedProjectRootOutsideProcessWorkingDirectory(t *testing.T) {
+	root := makeTestProject(t)
+	workflow := filepath.Join(root, ".github", "workflows", "ci.yml")
+	writeTestFile(t, workflow, `name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`)
+
+	linter, err := NewLinter(&bytes.Buffer{}, &LinterOptions{
+		CurrentWorkingDirectoryPath: root,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := linter.LintFile(workflow, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, lintError := range result.Errors {
+		if lintError.Type == "dependabot-github-actions" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("errors = %#v, want missing Dependabot finding", result.Errors)
+	}
+}
+
+func TestRepositoryFileAutoFixersCanBeDisabled(t *testing.T) {
+	root := makeTestProject(t)
+	workflow := filepath.Join(root, ".github", "workflows", "ci.yml")
+	writeTestFile(t, workflow, `name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`)
+
+	for _, tt := range []struct {
+		name      string
+		disabled  bool
+		wantFixer bool
+	}{
+		{name: "local scan keeps project fixer", wantFixer: true},
+		{name: "repository response scope disables project fixer", disabled: true, wantFixer: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			linter, err := NewLinter(&bytes.Buffer{}, &LinterOptions{
+				CurrentWorkingDirectoryPath:     root,
+				DisableRepositoryFileAutoFixers: tt.disabled,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := linter.LintFile(workflow, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, fixer := range result.AutoFixers {
+				if fixer.RuleName() == "dependabot-github-actions" {
+					found = true
+					break
+				}
+			}
+			if found != tt.wantFixer {
+				t.Fatalf("dependabot project fixer present = %v, want %v", found, tt.wantFixer)
+			}
+		})
+	}
+}
+
+func TestContextWorkflowDoesNotConsumeProjectFindingDedupe(t *testing.T) {
+	root := makeTestProject(t)
+	contextFile := filepath.Join(root, ".github", "workflows", "a-context.yml")
+	targetFile := filepath.Join(root, ".github", "workflows", "z-target.yml")
+	workflow := `name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`
+	writeTestFile(t, contextFile, workflow)
+	writeTestFile(t, targetFile, workflow)
+	writeTestFile(t, filepath.Join(root, "go.sum"), "example.invalid/module v1.0.0 h1:test\n")
+
+	var output bytes.Buffer
+	linter, err := NewLinter(&output, &LinterOptions{
+		CurrentWorkingDirectoryPath: root,
+		CustomErrorMessageFormat:    "{{json .}}",
+		ReportFilePaths:             []string{".github/workflows/z-target.yml"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := linter.LintFiles([]string{contextFile, targetFile}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "dependabot-ecosystem") {
+		t.Fatalf("project finding was lost to context-file dedupe: %s", output.String())
+	}
+	if strings.Contains(output.String(), ".github/workflows/a-context.yml") {
+		t.Fatalf("context-only path leaked into project finding output: %s", output.String())
+	}
+}
+
+func makeTestProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func writeTestFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/remote/fetcher.go
+++ b/pkg/remote/fetcher.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v68/github"
 )
@@ -43,8 +44,10 @@ func NewFetcher(limit int) (*Fetcher, error) {
 // NewFetcherWithToken creates a Fetcher with an explicitly resolved token.
 // CLI callers should use this constructor so -github-token and the standard
 // environment fallback chain are shared by remote scans and lint rules.
+// The fetcher targets GitHub.com; custom API base URLs and GitHub Enterprise
+// Server are not currently supported.
 func NewFetcherWithToken(limit int, token string) (*Fetcher, error) {
-	apiClient := &http.Client{}
+	apiClient := &http.Client{Timeout: 2 * time.Minute}
 	if token != "" {
 		apiClient.Transport = &tokenTransport{
 			token: token,
@@ -117,7 +120,7 @@ func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clonedReq := req.Clone(req.Context())
 	// Never forward a GitHub token to the signed archive host (or any other
 	// redirect target). The archive downloader intentionally uses a separate
-	// unauthenticated client as a second line of defence.
+	// unauthenticated client as a second line of defense.
 	if !isGitHubAPIHost(req.URL.Hostname()) {
 		clonedReq.Header.Del("Authorization")
 		return base.RoundTrip(clonedReq)
@@ -197,7 +200,7 @@ func (f *Fetcher) FetchWorkflows(ctx context.Context, repo *RepositoryInfo) ([]*
 }
 
 // FetchWorkflowsAtRef retrieves workflow files from a repository at ref.
-// An empty ref preserves the GitHub API default-branch behaviour.
+// An empty ref preserves the GitHub API default-branch behavior.
 func (f *Fetcher) FetchWorkflowsAtRef(ctx context.Context, repo *RepositoryInfo, ref string) ([]*WorkflowFile, error) {
 	var getOptions *github.RepositoryContentGetOptions
 	if ref != "" {

--- a/pkg/remote/fetcher.go
+++ b/pkg/remote/fetcher.go
@@ -16,6 +16,7 @@ type RepositoryInfo struct {
 	Owner    string
 	Name     string
 	FullName string // "owner/repo"
+	Ref      string // optional immutable or named ref for workflow retrieval
 }
 
 // WorkflowFile represents workflow file information
@@ -27,26 +28,36 @@ type WorkflowFile struct {
 
 // Fetcher retrieves repositories and workflows from GitHub API
 type Fetcher struct {
-	client *github.Client
-	limit  int
+	client        *github.Client
+	archiveClient *http.Client
+	// allowInsecureArchive is test-only; production archive URLs must use TLS.
+	allowInsecureArchive bool
+	limit                int
 }
 
 // NewFetcher creates a new Fetcher
 func NewFetcher(limit int) (*Fetcher, error) {
-	var httpClient *http.Client
+	return NewFetcherWithToken(limit, getToken())
+}
 
-	token := getToken()
+// NewFetcherWithToken creates a Fetcher with an explicitly resolved token.
+// CLI callers should use this constructor so -github-token and the standard
+// environment fallback chain are shared by remote scans and lint rules.
+func NewFetcherWithToken(limit int, token string) (*Fetcher, error) {
+	apiClient := &http.Client{}
 	if token != "" {
-		httpClient = &http.Client{
-			Transport: &tokenTransport{token: token},
+		apiClient.Transport = &tokenTransport{
+			token: token,
+			base:  http.DefaultTransport,
 		}
 	}
 
-	client := github.NewClient(httpClient)
+	client := github.NewClient(apiClient)
 
 	return &Fetcher{
-		client: client,
-		limit:  limit,
+		client:        client,
+		archiveClient: newArchiveHTTPClient(),
+		limit:         limit,
 	}, nil
 }
 
@@ -95,19 +106,41 @@ func getTokenFromGitCredential() (string, error) {
 // tokenTransport is a Transport that adds token to GitHub API requests
 type tokenTransport struct {
 	token string
+	base  http.RoundTripper
 }
 
 func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
 	clonedReq := req.Clone(req.Context())
+	// Never forward a GitHub token to the signed archive host (or any other
+	// redirect target). The archive downloader intentionally uses a separate
+	// unauthenticated client as a second line of defence.
+	if !isGitHubAPIHost(req.URL.Hostname()) {
+		clonedReq.Header.Del("Authorization")
+		return base.RoundTrip(clonedReq)
+	}
 	clonedReq.Header.Set("Authorization", "Bearer "+t.token)
-	return http.DefaultTransport.RoundTrip(clonedReq)
+	return base.RoundTrip(clonedReq)
+}
+
+func isGitHubAPIHost(host string) bool {
+	return host == "api.github.com" || host == "uploads.github.com"
 }
 
 // FetchRepositories retrieves repositories based on input
 func (f *Fetcher) FetchRepositories(ctx context.Context, input *ParsedInput) ([]*RepositoryInfo, error) {
 	switch input.Type {
 	case InputTypeURL, InputTypeOwnerRepo:
-		return f.fetchSingleRepo(ctx, input.Owner, input.Repo)
+		repositories, err := f.fetchSingleRepo(ctx, input.Owner, input.Repo)
+		if err == nil && input.Ref != "" {
+			for _, repository := range repositories {
+				repository.Ref = input.Ref
+			}
+		}
+		return repositories, err
 	case InputTypeSearchQuery:
 		return f.searchRepositories(ctx, input.Query)
 	default:
@@ -160,12 +193,22 @@ func (f *Fetcher) searchRepositories(ctx context.Context, query string) ([]*Repo
 
 // FetchWorkflows retrieves workflow files from repository
 func (f *Fetcher) FetchWorkflows(ctx context.Context, repo *RepositoryInfo) ([]*WorkflowFile, error) {
+	return f.FetchWorkflowsAtRef(ctx, repo, "")
+}
+
+// FetchWorkflowsAtRef retrieves workflow files from a repository at ref.
+// An empty ref preserves the GitHub API default-branch behaviour.
+func (f *Fetcher) FetchWorkflowsAtRef(ctx context.Context, repo *RepositoryInfo, ref string) ([]*WorkflowFile, error) {
+	var getOptions *github.RepositoryContentGetOptions
+	if ref != "" {
+		getOptions = &github.RepositoryContentGetOptions{Ref: ref}
+	}
 	_, contents, _, err := f.client.Repositories.GetContents(
 		ctx,
 		repo.Owner,
 		repo.Name,
 		".github/workflows",
-		nil,
+		getOptions,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch workflow directory: %w", err)
@@ -186,7 +229,7 @@ func (f *Fetcher) FetchWorkflows(ctx context.Context, repo *RepositoryInfo) ([]*
 			repo.Owner,
 			repo.Name,
 			content.GetPath(),
-			nil,
+			getOptions,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch workflow file %s: %w", content.GetPath(), err)

--- a/pkg/remote/fetcher_test.go
+++ b/pkg/remote/fetcher_test.go
@@ -1,0 +1,68 @@
+package remote
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestNewFetcherWithTokenSetsAPITimeout(t *testing.T) {
+	fetcher, err := NewFetcherWithToken(1, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fetcher.client.Client().Timeout; got != 2*time.Minute {
+		t.Fatalf("API timeout = %s, want 2m", got)
+	}
+}
+
+func TestTokenTransportRestrictsCredentialsToGitHubAPIHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantAuth string
+	}{
+		{name: "GitHub API", host: "api.github.com", wantAuth: "Bearer test-token"},
+		{name: "GitHub uploads", host: "uploads.github.com", wantAuth: "Bearer test-token"},
+		{name: "custom host", host: "github.example.com", wantAuth: ""},
+		{name: "archive host", host: "objects.githubusercontent.com", wantAuth: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotAuth string
+			transport := &tokenTransport{
+				token: "test-token",
+				base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					gotAuth = request.Header.Get("Authorization")
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body:       http.NoBody,
+						Request:    request,
+					}, nil
+				}),
+			}
+			request, err := http.NewRequest(http.MethodGet, "https://"+tt.host+"/resource", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request.Header.Set("Authorization", "Basic original")
+			if _, err := transport.RoundTrip(request); err != nil {
+				t.Fatal(err)
+			}
+			if gotAuth != tt.wantAuth {
+				t.Fatalf("Authorization = %q, want %q", gotAuth, tt.wantAuth)
+			}
+			if got := request.Header.Get("Authorization"); got != "Basic original" {
+				t.Fatalf("original request header mutated to %q", got)
+			}
+		})
+	}
+}

--- a/pkg/remote/input.go
+++ b/pkg/remote/input.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -17,10 +18,12 @@ const (
 
 // ParsedInput represents parsed input
 type ParsedInput struct {
-	Type  InputType
-	Owner string // for URL/OwnerRepo
-	Repo  string // for URL/OwnerRepo
-	Query string // for search
+	Type       InputType
+	Owner      string // for URL/OwnerRepo
+	Repo       string // for URL/OwnerRepo
+	Query      string // for search
+	Ref        string // for /tree/<ref> URLs
+	PullNumber int    // for /pull/<number> URLs
 }
 
 // ParseInput automatically detects and parses the input string
@@ -49,17 +52,51 @@ func parseURL(input string) (*ParsedInput, error) {
 		return nil, fmt.Errorf("URLs other than github.com are not supported: %s", u.Host)
 	}
 
-	// Expecting /owner/repo format
-	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	// Expecting /owner/repo with an optional /tree/<ref> or /pull/<number>
+	// suffix. In particular, do not silently discard a pull request number:
+	// doing so scans the default branch while presenting a PR URL to the user.
+	parts := strings.Split(strings.Trim(strings.TrimPrefix(u.Path, "/"), "/"), "/")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid GitHub URL format: %s", input)
 	}
+	owner := parts[0]
+	repo := strings.TrimSuffix(parts[1], ".git")
+	if owner == "" || repo == "" {
+		return nil, fmt.Errorf("invalid GitHub URL format: %s", input)
+	}
 
-	return &ParsedInput{
+	parsed := &ParsedInput{
 		Type:  InputTypeURL,
-		Owner: parts[0],
-		Repo:  parts[1],
-	}, nil
+		Owner: owner,
+		Repo:  repo,
+	}
+	if len(parts) == 2 {
+		return parsed, nil
+	}
+
+	switch parts[2] {
+	case "tree":
+		if len(parts) < 4 {
+			return nil, fmt.Errorf("GitHub tree URL is missing a ref: %s", input)
+		}
+		parsed.Ref = strings.Join(parts[3:], "/")
+	case "pull":
+		if len(parts) < 4 {
+			return nil, fmt.Errorf("GitHub pull request URL is missing a number: %s", input)
+		}
+		number, err := strconv.Atoi(parts[3])
+		if err != nil || number <= 0 {
+			return nil, fmt.Errorf("invalid GitHub pull request number %q", parts[3])
+		}
+		if len(parts) > 5 || (len(parts) > 4 && parts[4] != "files" && parts[4] != "commits" && parts[4] != "checks") {
+			return nil, fmt.Errorf("unsupported GitHub pull request URL path: %s", input)
+		}
+		parsed.PullNumber = number
+	default:
+		return nil, fmt.Errorf("unsupported GitHub URL path: %s", input)
+	}
+
+	return parsed, nil
 }
 
 func parseOwnerRepo(input string) (*ParsedInput, error) {

--- a/pkg/remote/input.go
+++ b/pkg/remote/input.go
@@ -88,7 +88,7 @@ func parseURL(input string) (*ParsedInput, error) {
 		if err != nil || number <= 0 {
 			return nil, fmt.Errorf("invalid GitHub pull request number %q", parts[3])
 		}
-		if len(parts) > 5 || (len(parts) > 4 && parts[4] != "files" && parts[4] != "commits" && parts[4] != "checks") {
+		if len(parts) > 4 && parts[4] != "files" && parts[4] != "commits" && parts[4] != "checks" {
 			return nil, fmt.Errorf("unsupported GitHub pull request URL path: %s", input)
 		}
 		parsed.PullNumber = number

--- a/pkg/remote/input_test.go
+++ b/pkg/remote/input_test.go
@@ -64,12 +64,14 @@ func TestParseInput_OwnerRepo(t *testing.T) {
 
 func TestParseInput_URL(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantType  InputType
-		wantOwner string
-		wantRepo  string
-		wantErr   bool
+		name           string
+		input          string
+		wantType       InputType
+		wantOwner      string
+		wantRepo       string
+		wantRef        string
+		wantPullNumber int
+		wantErr        bool
 	}{
 		{
 			name:      "valid https URL",
@@ -85,7 +87,24 @@ func TestParseInput_URL(t *testing.T) {
 			wantType:  InputTypeURL,
 			wantOwner: "owner",
 			wantRepo:  "repo",
+			wantRef:   "main",
 			wantErr:   false,
+		},
+		{
+			name:           "pull request URL",
+			input:          "https://github.com/sisaku-security/sisakulint-agent/pull/18#issuecomment-5027897981",
+			wantType:       InputTypeURL,
+			wantOwner:      "sisaku-security",
+			wantRepo:       "sisakulint-agent",
+			wantPullNumber: 18,
+		},
+		{
+			name:           "pull request files URL",
+			input:          "https://github.com/owner/repo/pull/42/files",
+			wantType:       InputTypeURL,
+			wantOwner:      "owner",
+			wantRepo:       "repo",
+			wantPullNumber: 42,
 		},
 		{
 			name:    "non-github URL",
@@ -95,6 +114,16 @@ func TestParseInput_URL(t *testing.T) {
 		{
 			name:    "invalid URL path",
 			input:   "https://github.com/onlyowner",
+			wantErr: true,
+		},
+		{
+			name:    "invalid pull request number",
+			input:   "https://github.com/owner/repo/pull/not-a-number",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported trailing path",
+			input:   "https://github.com/owner/repo/issues/1",
 			wantErr: true,
 		},
 	}
@@ -117,6 +146,12 @@ func TestParseInput_URL(t *testing.T) {
 			}
 			if got.Repo != tt.wantRepo {
 				t.Errorf("ParseInput() Repo = %v, want %v", got.Repo, tt.wantRepo)
+			}
+			if got.Ref != tt.wantRef {
+				t.Errorf("ParseInput() Ref = %v, want %v", got.Ref, tt.wantRef)
+			}
+			if got.PullNumber != tt.wantPullNumber {
+				t.Errorf("ParseInput() PullNumber = %v, want %v", got.PullNumber, tt.wantPullNumber)
 			}
 		})
 	}

--- a/pkg/remote/input_test.go
+++ b/pkg/remote/input_test.go
@@ -91,6 +91,14 @@ func TestParseInput_URL(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "URL with slash-containing ref",
+			input:     "https://github.com/owner/repo/tree/feature/nested",
+			wantType:  InputTypeURL,
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantRef:   "feature/nested",
+		},
+		{
 			name:           "pull request URL",
 			input:          "https://github.com/sisaku-security/sisakulint-agent/pull/18#issuecomment-5027897981",
 			wantType:       InputTypeURL,
@@ -105,6 +113,19 @@ func TestParseInput_URL(t *testing.T) {
 			wantOwner:      "owner",
 			wantRepo:       "repo",
 			wantPullNumber: 42,
+		},
+		{
+			name:           "pull request commit URL",
+			input:          "https://github.com/owner/repo/pull/42/commits/0123456789abcdef",
+			wantType:       InputTypeURL,
+			wantOwner:      "owner",
+			wantRepo:       "repo",
+			wantPullNumber: 42,
+		},
+		{
+			name:    "unsupported pull request subpath",
+			input:   "https://github.com/owner/repo/pull/42/unknown/value",
+			wantErr: true,
 		},
 		{
 			name:    "non-github URL",

--- a/pkg/remote/scanner.go
+++ b/pkg/remote/scanner.go
@@ -51,6 +51,7 @@ type ScannerOptions struct {
 	Verbose     bool
 	Output      io.Writer
 	LintFunc    LintFunc
+	GitHubToken string
 }
 
 // NewScanner creates a new Scanner
@@ -68,7 +69,15 @@ func NewScanner(opts *ScannerOptions) (*Scanner, error) {
 		return nil, fmt.Errorf("LintFunc is not specified")
 	}
 
-	fetcher, err := NewFetcher(opts.Limit)
+	var fetcher *Fetcher
+	var err error
+	if opts.GitHubToken == "" {
+		// Preserve the library/CLI fallback chain (environment, gh CLI, then
+		// git credential) when no explicit token was resolved by the caller.
+		fetcher, err = NewFetcher(opts.Limit)
+	} else {
+		fetcher, err = NewFetcherWithToken(opts.Limit, opts.GitHubToken)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Fetcher: %w", err)
 	}
@@ -152,7 +161,7 @@ func (s *Scanner) scanRepository(ctx context.Context, repo *RepositoryInfo) *Sca
 		fmt.Fprintf(s.output, "Scanning repository: %s\n", repo.FullName)
 	}
 
-	workflows, err := s.fetcher.FetchWorkflows(ctx, repo)
+	workflows, err := s.fetcher.FetchWorkflowsAtRef(ctx, repo, repo.Ref)
 	if err != nil {
 		return &ScanResult{
 			Repository: repo,

--- a/pkg/remote/scanner_test.go
+++ b/pkg/remote/scanner_test.go
@@ -284,6 +284,27 @@ func TestNewScanner_Validation(t *testing.T) {
 	}
 }
 
+func TestNewScannerPreservesEnvironmentTokenFallback(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "fallback-token")
+	t.Setenv("GH_TOKEN", "")
+
+	scanner, err := NewScanner(&ScannerOptions{
+		Parallelism: 1,
+		Limit:       1,
+		LintFunc:    func(string, []byte) (bool, error) { return false, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport, ok := scanner.fetcher.client.Client().Transport.(*tokenTransport)
+	if !ok {
+		t.Fatalf("transport = %T, want *tokenTransport", scanner.fetcher.client.Client().Transport)
+	}
+	if transport.token != "fallback-token" {
+		t.Fatalf("transport token = %q, want environment fallback token", transport.token)
+	}
+}
+
 func TestFetchSingleWorkflowUsesRequestedRef(t *testing.T) {
 	const wantRef = "v1.2.3"
 	const workflowPath = ".github/workflows/reusable.yml"
@@ -322,6 +343,39 @@ func TestFetchSingleWorkflowUsesRequestedRef(t *testing.T) {
 	}
 	if string(workflow.Content) != "name: reusable\non: workflow_call\n" {
 		t.Fatalf("workflow content = %q", string(workflow.Content))
+	}
+}
+
+func TestFetchRepositoriesPreservesTreeURLRef(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"name":"repo","full_name":"owner/repo","owner":{"login":"owner"}}`)
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := github.NewClient(server.Client())
+	client.BaseURL = baseURL
+	client.UploadURL = baseURL
+	fetcher := &Fetcher{client: client, limit: 1}
+
+	repositories, err := fetcher.FetchRepositories(context.Background(), &ParsedInput{
+		Type:  InputTypeURL,
+		Owner: "owner",
+		Repo:  "repo",
+		Ref:   "feature/ref",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repositories) != 1 || repositories[0].Ref != "feature/ref" {
+		t.Fatalf("repositories = %#v, want propagated ref", repositories)
 	}
 }
 

--- a/pkg/remote/snapshot.go
+++ b/pkg/remote/snapshot.go
@@ -1,0 +1,485 @@
+package remote
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+)
+
+const (
+	defaultMaxArchiveBytes   int64 = 100 << 20 // 100 MiB compressed
+	defaultMaxExtractedBytes int64 = 400 << 20 // 400 MiB uncompressed (fits default Lambda /tmp)
+	defaultMaxFileBytes      int64 = 50 << 20  // 50 MiB per file
+	defaultMaxArchiveFiles         = 100_000
+	maxArchiveRedirects            = 3
+	maxPullRequestFiles            = 3_000
+)
+
+// PullRequestSnapshotOptions controls immutable PR snapshot materialization.
+type PullRequestSnapshotOptions struct {
+	// ExpectedHeadSHA, when non-empty, must exactly match the current PR head.
+	// Services should always set this to the SHA from the verified webhook so a
+	// delayed request cannot accidentally scan a newer revision.
+	ExpectedHeadSHA string
+	// Destination must not already exist. When empty, a temporary directory is
+	// created and removed by Snapshot.Close.
+	Destination string
+}
+
+// RepositorySnapshot is a local, immutable view of a pull request head.
+type RepositorySnapshot struct {
+	Root                string
+	HeadSHA             string
+	WorkflowPaths       []string
+	TargetWorkflowPaths []string
+	removeOnClose       bool
+}
+
+// Close removes snapshots backed by an internally-created temporary
+// directory. Explicit destinations remain available to the caller.
+func (s *RepositorySnapshot) Close() error {
+	if s == nil || !s.removeOnClose || s.Root == "" {
+		return nil
+	}
+	return os.RemoveAll(s.Root)
+}
+
+func newArchiveHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 2 * time.Minute,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxArchiveRedirects {
+				return errors.New("too many archive redirects")
+			}
+			if req.URL.Scheme != "https" {
+				return fmt.Errorf("repository archive redirect must use HTTPS, got %q", req.URL.Scheme)
+			}
+			// GitHub archive links are pre-signed. Never copy Authorization or
+			// other caller headers across hosts.
+			req.Header.Del("Authorization")
+			return nil
+		},
+	}
+}
+
+// MaterializePullRequest resolves a PR, verifies its expected head SHA,
+// downloads the repository archive at that immutable SHA, and safely extracts
+// it. The full repository is materialized so project-wide lint rules can read
+// configuration, lockfiles, local actions, and reusable workflows.
+func (f *Fetcher) MaterializePullRequest(
+	ctx context.Context,
+	owner string,
+	repo string,
+	pullNumber int,
+	opts *PullRequestSnapshotOptions,
+) (*RepositorySnapshot, error) {
+	if pullNumber <= 0 {
+		return nil, fmt.Errorf("pull request number must be greater than zero")
+	}
+	if opts == nil {
+		opts = &PullRequestSnapshotOptions{}
+	}
+
+	pr, _, err := f.client.PullRequests.Get(ctx, owner, repo, pullNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch pull request #%d: %w", pullNumber, err)
+	}
+	headSHA := strings.ToLower(pr.GetHead().GetSHA())
+	if headSHA == "" {
+		return nil, fmt.Errorf("pull request #%d has no head SHA", pullNumber)
+	}
+	baseSHA := strings.ToLower(pr.GetBase().GetSHA())
+	if baseSHA == "" {
+		return nil, fmt.Errorf("pull request #%d has no base SHA", pullNumber)
+	}
+	if opts.ExpectedHeadSHA != "" && !strings.EqualFold(opts.ExpectedHeadSHA, headSHA) {
+		return nil, fmt.Errorf(
+			"pull request head changed: expected %s, got %s",
+			opts.ExpectedHeadSHA,
+			headSHA,
+		)
+	}
+	if pr.GetChangedFiles() > maxPullRequestFiles {
+		return nil, fmt.Errorf(
+			"pull request changes %d files, exceeding GitHub's %d-file listing limit; refusing an incomplete scan",
+			pr.GetChangedFiles(),
+			maxPullRequestFiles,
+		)
+	}
+
+	targets, err := f.fetchPullRequestWorkflowPaths(ctx, owner, repo, pullNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	// ListFiles is a mutable PR endpoint. Re-read both sides of the comparison
+	// after pagination so a synchronize event or base-branch update cannot pair
+	// one revision's target list with another revision's archive. The archive
+	// itself is fetched by the immutable head SHA captured above.
+	currentPR, _, err := f.client.PullRequests.Get(ctx, owner, repo, pullNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to revalidate pull request #%d: %w", pullNumber, err)
+	}
+	currentHeadSHA := strings.ToLower(currentPR.GetHead().GetSHA())
+	currentBaseSHA := strings.ToLower(currentPR.GetBase().GetSHA())
+	if currentHeadSHA != headSHA || currentBaseSHA != baseSHA {
+		return nil, fmt.Errorf(
+			"pull request revision changed while listing files: expected head %s and base %s, got head %s and base %s",
+			headSHA,
+			baseSHA,
+			currentHeadSHA,
+			currentBaseSHA,
+		)
+	}
+	if currentPR.GetChangedFiles() > maxPullRequestFiles {
+		return nil, fmt.Errorf(
+			"pull request changes %d files, exceeding GitHub's %d-file listing limit; refusing an incomplete scan",
+			currentPR.GetChangedFiles(),
+			maxPullRequestFiles,
+		)
+	}
+
+	root, removeOnClose, err := createSnapshotDestination(opts.Destination)
+	if err != nil {
+		return nil, err
+	}
+	cleanupOnError := func() {
+		if removeOnClose || opts.Destination != "" {
+			_ = os.RemoveAll(root)
+		}
+	}
+
+	archiveURL, _, err := f.client.Repositories.GetArchiveLink(
+		ctx,
+		owner,
+		repo,
+		github.Tarball,
+		&github.RepositoryContentGetOptions{Ref: headSHA},
+		0,
+	)
+	if err != nil {
+		cleanupOnError()
+		return nil, fmt.Errorf("failed to resolve repository archive: %w", err)
+	}
+	if archiveURL == nil {
+		cleanupOnError()
+		return nil, errors.New("GitHub returned an empty repository archive URL")
+	}
+	if err := f.downloadAndExtractArchive(ctx, archiveURL, root); err != nil {
+		cleanupOnError()
+		return nil, err
+	}
+
+	// Project discovery intentionally requires a .git marker. An archive has no
+	// Git metadata, so create an empty marker directory after extraction.
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		cleanupOnError()
+		return nil, fmt.Errorf("failed to create snapshot project marker: %w", err)
+	}
+
+	workflows, err := collectWorkflowPaths(root)
+	if err != nil {
+		cleanupOnError()
+		return nil, err
+	}
+	if err := ensureTargetsExist(targets, workflows); err != nil {
+		cleanupOnError()
+		return nil, err
+	}
+
+	return &RepositorySnapshot{
+		Root:                root,
+		HeadSHA:             headSHA,
+		WorkflowPaths:       workflows,
+		TargetWorkflowPaths: targets,
+		removeOnClose:       removeOnClose,
+	}, nil
+}
+
+func createSnapshotDestination(destination string) (root string, removeOnClose bool, err error) {
+	if destination == "" {
+		root, err = os.MkdirTemp("", "sisakulint-remote-")
+		if err != nil {
+			return "", false, fmt.Errorf("failed to create snapshot directory: %w", err)
+		}
+		return root, true, nil
+	}
+
+	root, err = filepath.Abs(destination)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to resolve snapshot destination: %w", err)
+	}
+	if err := os.Mkdir(root, 0o700); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return "", false, fmt.Errorf("snapshot destination already exists: %s", root)
+		}
+		return "", false, fmt.Errorf("failed to create snapshot destination: %w", err)
+	}
+	return root, false, nil
+}
+
+func (f *Fetcher) fetchPullRequestWorkflowPaths(
+	ctx context.Context,
+	owner string,
+	repo string,
+	pullNumber int,
+) ([]string, error) {
+	options := &github.ListOptions{PerPage: 100}
+	seen := make(map[string]struct{})
+	var targets []string
+	for {
+		files, response, err := f.client.PullRequests.ListFiles(ctx, owner, repo, pullNumber, options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list pull request files: %w", err)
+		}
+		for _, file := range files {
+			filename := path.Clean(file.GetFilename())
+			if file.GetStatus() == "removed" || !isWorkflowPath(filename) {
+				continue
+			}
+			if _, ok := seen[filename]; ok {
+				continue
+			}
+			seen[filename] = struct{}{}
+			targets = append(targets, filename)
+		}
+		if response == nil || response.NextPage == 0 {
+			break
+		}
+		options.Page = response.NextPage
+	}
+	sort.Strings(targets)
+	return targets, nil
+}
+
+func isWorkflowPath(name string) bool {
+	if name == "." || path.IsAbs(name) || strings.HasPrefix(name, "../") {
+		return false
+	}
+	if !strings.HasPrefix(name, ".github/workflows/") {
+		return false
+	}
+	return strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")
+}
+
+func (f *Fetcher) downloadAndExtractArchive(ctx context.Context, archiveURL *url.URL, root string) error {
+	if archiveURL.Scheme != "https" && !(f.allowInsecureArchive && archiveURL.Scheme == "http") {
+		return fmt.Errorf("repository archive URL must use HTTPS, got %q", archiveURL.Scheme)
+	}
+	client := f.archiveClient
+	if client == nil {
+		client = newArchiveHTTPClient()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create repository archive request: %w", err)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	req.Header.Set("User-Agent", "sisakulint")
+	response, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download repository archive: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("repository archive download returned %s", response.Status)
+	}
+
+	compressed := &countingReader{
+		reader: io.LimitReader(response.Body, defaultMaxArchiveBytes+1),
+	}
+	gzipReader, err := gzip.NewReader(compressed)
+	if err != nil {
+		return fmt.Errorf("failed to open repository archive: %w", err)
+	}
+	defer gzipReader.Close()
+	if err := extractTar(gzipReader, root); err != nil {
+		return err
+	}
+	if compressed.count > defaultMaxArchiveBytes {
+		return fmt.Errorf("repository archive exceeds compressed size limit of %d bytes", defaultMaxArchiveBytes)
+	}
+	return nil
+}
+
+type countingReader struct {
+	reader io.Reader
+	count  int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.count += int64(n)
+	return n, err
+}
+
+func extractTar(reader io.Reader, root string) error {
+	tarReader := tar.NewReader(reader)
+	var prefix string
+	var extractedBytes int64
+	fileCount := 0
+	seen := make(map[string]struct{})
+
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read repository archive: %w", err)
+		}
+		fileCount++
+		if fileCount > defaultMaxArchiveFiles {
+			return fmt.Errorf("repository archive exceeds file limit of %d", defaultMaxArchiveFiles)
+		}
+		// GitHub tarballs may begin with a POSIX PAX global header. archive/tar
+		// already applies its metadata to following entries; it is not a
+		// repository path and must not participate in top-level prefix checks.
+		if header.Typeflag == tar.TypeXGlobalHeader || header.Typeflag == tar.TypeXHeader {
+			continue
+		}
+
+		rawName := strings.TrimPrefix(header.Name, "./")
+		for _, component := range strings.Split(rawName, "/") {
+			if component == ".." {
+				return fmt.Errorf("unsafe repository archive path %q", header.Name)
+			}
+		}
+		cleanName := path.Clean(rawName)
+		if cleanName == "." || path.IsAbs(cleanName) || strings.HasPrefix(cleanName, "../") {
+			return fmt.Errorf("unsafe repository archive path %q", header.Name)
+		}
+		parts := strings.Split(cleanName, "/")
+		if prefix == "" {
+			prefix = parts[0]
+		}
+		if parts[0] != prefix {
+			return fmt.Errorf("repository archive has multiple top-level directories")
+		}
+		if len(parts) == 1 {
+			if header.Typeflag != tar.TypeDir {
+				return fmt.Errorf("invalid repository archive root entry %q", header.Name)
+			}
+			continue
+		}
+
+		rel := path.Clean(strings.Join(parts[1:], "/"))
+		if rel == "." || path.IsAbs(rel) || strings.HasPrefix(rel, "../") {
+			return fmt.Errorf("unsafe repository archive path %q", header.Name)
+		}
+		if _, ok := seen[rel]; ok {
+			return fmt.Errorf("duplicate repository archive path %q", rel)
+		}
+		seen[rel] = struct{}{}
+
+		destination := filepath.Join(root, filepath.FromSlash(rel))
+		if !pathInsideRoot(root, destination) {
+			return fmt.Errorf("repository archive path %q escapes destination", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(destination, 0o755); err != nil {
+				return fmt.Errorf("failed to create archive directory %q: %w", rel, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if header.Size < 0 || header.Size > defaultMaxFileBytes {
+				return fmt.Errorf("repository archive file %q exceeds size limit", rel)
+			}
+			extractedBytes += header.Size
+			if extractedBytes > defaultMaxExtractedBytes {
+				return fmt.Errorf("repository archive exceeds extracted size limit of %d bytes", defaultMaxExtractedBytes)
+			}
+			if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+				return fmt.Errorf("failed to create archive parent for %q: %w", rel, err)
+			}
+			file, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+			if err != nil {
+				return fmt.Errorf("failed to create archive file %q: %w", rel, err)
+			}
+			written, copyErr := io.CopyN(file, tarReader, header.Size)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return fmt.Errorf("failed to extract archive file %q: %w", rel, copyErr)
+			}
+			if written != header.Size {
+				return fmt.Errorf("repository archive file %q was truncated", rel)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("failed to close archive file %q: %w", rel, closeErr)
+			}
+		default:
+			// Symlinks, hardlinks, devices, and FIFOs can make a repository
+			// snapshot escape its destination or change subsequent reads.
+			return fmt.Errorf("unsupported repository archive entry type for %q", rel)
+		}
+	}
+	if prefix == "" {
+		return errors.New("repository archive is empty")
+	}
+	return nil
+}
+
+func pathInsideRoot(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	return err == nil && rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func collectWorkflowPaths(root string) ([]string, error) {
+	workflowRoot := filepath.Join(root, ".github", "workflows")
+	if _, err := os.Stat(workflowRoot); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to inspect workflow directory: %w", err)
+	}
+	var workflows []string
+	err := filepath.WalkDir(workflowRoot, func(filename string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, filename)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if isWorkflowPath(rel) {
+			workflows = append(workflows, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect workflow files: %w", err)
+	}
+	sort.Strings(workflows)
+	return workflows, nil
+}
+
+func ensureTargetsExist(targets, workflows []string) error {
+	available := make(map[string]struct{}, len(workflows))
+	for _, workflow := range workflows {
+		available[workflow] = struct{}{}
+	}
+	for _, target := range targets {
+		if _, ok := available[target]; !ok {
+			return fmt.Errorf("changed workflow %q is missing from pull request head snapshot", target)
+		}
+	}
+	return nil
+}

--- a/pkg/remote/snapshot.go
+++ b/pkg/remote/snapshot.go
@@ -240,7 +240,11 @@ func (f *Fetcher) fetchPullRequestWorkflowPaths(
 	options := &github.ListOptions{PerPage: 100}
 	seen := make(map[string]struct{})
 	var targets []string
-	for {
+	maxPages := maxPullRequestFiles/options.PerPage + 1
+	for page := 0; ; page++ {
+		if page >= maxPages {
+			return nil, fmt.Errorf("pull request file listing exceeded %d pages", maxPages)
+		}
 		files, response, err := f.client.PullRequests.ListFiles(ctx, owner, repo, pullNumber, options)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list pull request files: %w", err)
@@ -306,13 +310,11 @@ func (f *Fetcher) downloadAndExtractArchive(ctx context.Context, archiveURL *url
 		return fmt.Errorf("failed to open repository archive: %w", err)
 	}
 	defer gzipReader.Close()
-	if err := extractTar(gzipReader, root); err != nil {
-		return err
-	}
+	extractErr := extractTar(gzipReader, root)
 	if compressed.count > defaultMaxArchiveBytes {
 		return fmt.Errorf("repository archive exceeds compressed size limit of %d bytes", defaultMaxArchiveBytes)
 	}
-	return nil
+	return extractErr
 }
 
 type countingReader struct {
@@ -395,7 +397,7 @@ func extractTar(reader io.Reader, root string) error {
 			if err := os.MkdirAll(destination, 0o755); err != nil {
 				return fmt.Errorf("failed to create archive directory %q: %w", rel, err)
 			}
-		case tar.TypeReg, tar.TypeRegA:
+		case tar.TypeReg:
 			if header.Size < 0 || header.Size > defaultMaxFileBytes {
 				return fmt.Errorf("repository archive file %q exceeds size limit", rel)
 			}

--- a/pkg/remote/snapshot_test.go
+++ b/pkg/remote/snapshot_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-github/v68/github"
@@ -102,9 +103,9 @@ func TestMaterializePullRequestUsesVerifiedImmutableHead(t *testing.T) {
 }
 
 func TestMaterializePullRequestRejectsChangedHeadBeforeDownloading(t *testing.T) {
-	requestCount := 0
+	var requestCount atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		if r.URL.Path != "/repos/owner/repo/pulls/9" {
 			t.Fatalf("unexpected request after head mismatch: %s", r.URL.Path)
 		}
@@ -124,15 +125,15 @@ func TestMaterializePullRequestRejectsChangedHeadBeforeDownloading(t *testing.T)
 	if err == nil || !strings.Contains(err.Error(), "pull request head changed") {
 		t.Fatalf("error = %v, want head changed error", err)
 	}
-	if requestCount != 1 {
-		t.Fatalf("request count = %d, want 1", requestCount)
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
 	}
 }
 
 func TestMaterializePullRequestRejectsGitHubFileListTruncation(t *testing.T) {
-	requestCount := 0
+	var requestCount atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		if r.URL.Path != "/repos/owner/repo/pulls/10" {
 			t.Fatalf("unexpected request after file-limit rejection: %s", r.URL.Path)
 		}
@@ -152,21 +153,21 @@ func TestMaterializePullRequestRejectsGitHubFileListTruncation(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "file listing limit") {
 		t.Fatalf("error = %v, want file-list limit error", err)
 	}
-	if requestCount != 1 {
-		t.Fatalf("request count = %d, want 1", requestCount)
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
 	}
 }
 
 func TestMaterializePullRequestRejectsRevisionChangeDuringFileListing(t *testing.T) {
 	const changedHeadSHA = "fedcba9876543210fedcba9876543210fedcba98"
-	pullRequestReads := 0
-	archiveRequested := false
+	var pullRequestReads atomic.Int64
+	var archiveRequested atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/owner/repo/pulls/11":
-			pullRequestReads++
+			readCount := pullRequestReads.Add(1)
 			headSHA := snapshotTestSHA
-			if pullRequestReads > 1 {
+			if readCount > 1 {
 				headSHA = changedHeadSHA
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -175,7 +176,7 @@ func TestMaterializePullRequestRejectsRevisionChangeDuringFileListing(t *testing
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `[{"filename":".github/workflows/ci.yml","status":"modified"}]`)
 		default:
-			archiveRequested = true
+			archiveRequested.Store(true)
 			t.Fatalf("unexpected request after revision change: %s", r.URL.Path)
 		}
 	}))
@@ -192,11 +193,43 @@ func TestMaterializePullRequestRejectsRevisionChangeDuringFileListing(t *testing
 	if err == nil || !strings.Contains(err.Error(), "pull request revision changed") {
 		t.Fatalf("error = %v, want revision changed error", err)
 	}
-	if pullRequestReads != 2 {
-		t.Fatalf("pull request read count = %d, want 2", pullRequestReads)
+	if got := pullRequestReads.Load(); got != 2 {
+		t.Fatalf("pull request read count = %d, want 2", got)
 	}
-	if archiveRequested {
+	if archiveRequested.Load() {
 		t.Fatal("archive was requested after the pull request revision changed")
+	}
+}
+
+func TestNewArchiveHTTPClientRedirectPolicy(t *testing.T) {
+	checkRedirect := newArchiveHTTPClient().CheckRedirect
+	if checkRedirect == nil {
+		t.Fatal("CheckRedirect is nil")
+	}
+
+	valid, err := http.NewRequest(http.MethodGet, "https://objects.githubusercontent.com/archive.tar.gz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid.Header.Set("Authorization", "Bearer secret")
+	if err := checkRedirect(valid, nil); err != nil {
+		t.Fatalf("valid redirect rejected: %v", err)
+	}
+	if got := valid.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization header was retained: %q", got)
+	}
+
+	insecure, err := http.NewRequest(http.MethodGet, "http://objects.githubusercontent.com/archive.tar.gz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkRedirect(insecure, nil); err == nil || !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Fatalf("insecure redirect error = %v", err)
+	}
+
+	via := make([]*http.Request, maxArchiveRedirects)
+	if err := checkRedirect(valid, via); err == nil || !strings.Contains(err.Error(), "too many archive redirects") {
+		t.Fatalf("redirect limit error = %v", err)
 	}
 }
 
@@ -230,11 +263,34 @@ func TestFetchPullRequestWorkflowPathsPaginates(t *testing.T) {
 	}
 }
 
+func TestFetchPullRequestWorkflowPathsRejectsExcessivePages(t *testing.T) {
+	var requestCount atomic.Int64
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/pulls/3/files?page=1>; rel="next"`, server.URL))
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	fetcher := newSnapshotTestFetcher(t, server)
+	_, err := fetcher.fetchPullRequestWorkflowPaths(context.Background(), "owner", "repo", 3)
+	maxPages := maxPullRequestFiles/100 + 1
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeded %d pages", maxPages)) {
+		t.Fatalf("error = %v, want page-limit error", err)
+	}
+	if got := requestCount.Load(); got != int64(maxPages) {
+		t.Fatalf("request count = %d, want %d", got, maxPages)
+	}
+}
+
 func TestExtractTarRejectsUnsafeEntries(t *testing.T) {
 	tests := []struct {
 		name     string
 		header   tar.Header
 		contents string
+		wantErr  string
 	}{
 		{
 			name: "parent traversal",
@@ -245,6 +301,7 @@ func TestExtractTarRejectsUnsafeEntries(t *testing.T) {
 				Typeflag: tar.TypeReg,
 			},
 			contents: "x",
+			wantErr:  "unsafe repository archive path",
 		},
 		{
 			name: "symlink",
@@ -254,6 +311,7 @@ func TestExtractTarRejectsUnsafeEntries(t *testing.T) {
 				Mode:     0o777,
 				Typeflag: tar.TypeSymlink,
 			},
+			wantErr: "unsupported repository archive entry type",
 		},
 	}
 
@@ -277,7 +335,20 @@ func TestExtractTarRejectsUnsafeEntries(t *testing.T) {
 			if err == nil {
 				t.Fatal("extractTar unexpectedly accepted unsafe entry")
 			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
 		})
+	}
+}
+
+func TestEnsureTargetsExistRejectsMissingWorkflow(t *testing.T) {
+	err := ensureTargetsExist(
+		[]string{".github/workflows/missing.yml"},
+		[]string{".github/workflows/present.yml"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "is missing from pull request head snapshot") {
+		t.Fatalf("error = %v, want missing-workflow error", err)
 	}
 }
 

--- a/pkg/remote/snapshot_test.go
+++ b/pkg/remote/snapshot_test.go
@@ -1,0 +1,374 @@
+package remote
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v68/github"
+)
+
+const snapshotTestSHA = "0123456789abcdef0123456789abcdef01234567"
+const snapshotTestBaseSHA = "89abcdef0123456789abcdef0123456789abcdef"
+
+func TestMaterializePullRequestUsesVerifiedImmutableHead(t *testing.T) {
+	archive := makeTarGzip(t, map[string]string{
+		"repository-root/.github/workflows/changed.yml":  "name: Changed\non: push\njobs: {}\n",
+		"repository-root/.github/workflows/context.yaml": "name: Context\non: workflow_call\njobs: {}\n",
+		"repository-root/.github/dependabot.yaml":        "version: 2\nupdates: []\n",
+		"repository-root/package-lock.json":              "{}\n",
+	})
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/7":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"number":7,"head":{"sha":%q},"base":{"sha":%q}}`, snapshotTestSHA, snapshotTestBaseSHA)
+		case "/repos/owner/repo/pulls/7/files":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[
+                    {"filename":".github/workflows/changed.yml","status":"modified"},
+                    {"filename":".github/workflows/deleted.yml","status":"removed"},
+                    {"filename":"README.md","status":"modified"}
+                ]`)
+		case "/repos/owner/repo/tarball/" + snapshotTestSHA:
+			http.Redirect(w, r, server.URL+"/signed/archive.tar.gz", http.StatusFound)
+		case "/signed/archive.tar.gz":
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archive)
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := newSnapshotTestFetcher(t, server)
+	destination := filepath.Join(t.TempDir(), "checkout")
+	snapshot, err := fetcher.MaterializePullRequest(
+		context.Background(),
+		"owner",
+		"repo",
+		7,
+		&PullRequestSnapshotOptions{
+			ExpectedHeadSHA: strings.ToUpper(snapshotTestSHA),
+			Destination:     destination,
+		},
+	)
+	if err != nil {
+		t.Fatalf("MaterializePullRequest returned error: %v", err)
+	}
+	defer snapshot.Close()
+
+	if snapshot.HeadSHA != snapshotTestSHA {
+		t.Fatalf("HeadSHA = %q, want %q", snapshot.HeadSHA, snapshotTestSHA)
+	}
+	if !slices.Equal(snapshot.TargetWorkflowPaths, []string{".github/workflows/changed.yml"}) {
+		t.Fatalf("TargetWorkflowPaths = %#v", snapshot.TargetWorkflowPaths)
+	}
+	wantWorkflows := []string{
+		".github/workflows/changed.yml",
+		".github/workflows/context.yaml",
+	}
+	if !slices.Equal(snapshot.WorkflowPaths, wantWorkflows) {
+		t.Fatalf("WorkflowPaths = %#v, want %#v", snapshot.WorkflowPaths, wantWorkflows)
+	}
+	for _, name := range []string{
+		".git",
+		".github/dependabot.yaml",
+		".github/workflows/changed.yml",
+		"package-lock.json",
+	} {
+		if _, err := os.Stat(filepath.Join(destination, filepath.FromSlash(name))); err != nil {
+			t.Errorf("snapshot is missing %s: %v", name, err)
+		}
+	}
+	if err := snapshot.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(destination); err != nil {
+		t.Fatalf("explicit snapshot destination was removed: %v", err)
+	}
+}
+
+func TestMaterializePullRequestRejectsChangedHeadBeforeDownloading(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.URL.Path != "/repos/owner/repo/pulls/9" {
+			t.Fatalf("unexpected request after head mismatch: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"number":9,"head":{"sha":%q},"base":{"sha":%q}}`, snapshotTestSHA, snapshotTestBaseSHA)
+	}))
+	defer server.Close()
+
+	fetcher := newSnapshotTestFetcher(t, server)
+	_, err := fetcher.MaterializePullRequest(
+		context.Background(),
+		"owner",
+		"repo",
+		9,
+		&PullRequestSnapshotOptions{ExpectedHeadSHA: strings.Repeat("f", 40)},
+	)
+	if err == nil || !strings.Contains(err.Error(), "pull request head changed") {
+		t.Fatalf("error = %v, want head changed error", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+}
+
+func TestMaterializePullRequestRejectsGitHubFileListTruncation(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.URL.Path != "/repos/owner/repo/pulls/10" {
+			t.Fatalf("unexpected request after file-limit rejection: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"number":10,"changed_files":3001,"head":{"sha":%q},"base":{"sha":%q}}`, snapshotTestSHA, snapshotTestBaseSHA)
+	}))
+	defer server.Close()
+
+	fetcher := newSnapshotTestFetcher(t, server)
+	_, err := fetcher.MaterializePullRequest(
+		context.Background(),
+		"owner",
+		"repo",
+		10,
+		&PullRequestSnapshotOptions{ExpectedHeadSHA: snapshotTestSHA},
+	)
+	if err == nil || !strings.Contains(err.Error(), "file listing limit") {
+		t.Fatalf("error = %v, want file-list limit error", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+}
+
+func TestMaterializePullRequestRejectsRevisionChangeDuringFileListing(t *testing.T) {
+	const changedHeadSHA = "fedcba9876543210fedcba9876543210fedcba98"
+	pullRequestReads := 0
+	archiveRequested := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/11":
+			pullRequestReads++
+			headSHA := snapshotTestSHA
+			if pullRequestReads > 1 {
+				headSHA = changedHeadSHA
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"number":11,"head":{"sha":%q},"base":{"sha":%q}}`, headSHA, snapshotTestBaseSHA)
+		case "/repos/owner/repo/pulls/11/files":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[{"filename":".github/workflows/ci.yml","status":"modified"}]`)
+		default:
+			archiveRequested = true
+			t.Fatalf("unexpected request after revision change: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := newSnapshotTestFetcher(t, server)
+	_, err := fetcher.MaterializePullRequest(
+		context.Background(),
+		"owner",
+		"repo",
+		11,
+		&PullRequestSnapshotOptions{ExpectedHeadSHA: snapshotTestSHA},
+	)
+	if err == nil || !strings.Contains(err.Error(), "pull request revision changed") {
+		t.Fatalf("error = %v, want revision changed error", err)
+	}
+	if pullRequestReads != 2 {
+		t.Fatalf("pull request read count = %d, want 2", pullRequestReads)
+	}
+	if archiveRequested {
+		t.Fatal("archive was requested after the pull request revision changed")
+	}
+}
+
+func TestFetchPullRequestWorkflowPathsPaginates(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/pulls/3/files" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/pulls/3/files?page=2>; rel="next", <%s/repos/owner/repo/pulls/3/files?page=2>; rel="last"`, server.URL, server.URL))
+			fmt.Fprint(w, `[{"filename":".github/workflows/a.yml","status":"modified"}]`)
+		case "2":
+			fmt.Fprint(w, `[{"filename":".github/workflows/b.yaml","status":"added"}]`)
+		default:
+			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	fetcher := newSnapshotTestFetcher(t, server)
+	paths, err := fetcher.fetchPullRequestWorkflowPaths(context.Background(), "owner", "repo", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{".github/workflows/a.yml", ".github/workflows/b.yaml"}
+	if !slices.Equal(paths, want) {
+		t.Fatalf("paths = %#v, want %#v", paths, want)
+	}
+}
+
+func TestExtractTarRejectsUnsafeEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   tar.Header
+		contents string
+	}{
+		{
+			name: "parent traversal",
+			header: tar.Header{
+				Name:     "root/../outside.yml",
+				Mode:     0o644,
+				Size:     1,
+				Typeflag: tar.TypeReg,
+			},
+			contents: "x",
+		},
+		{
+			name: "symlink",
+			header: tar.Header{
+				Name:     "root/link",
+				Linkname: "../../outside",
+				Mode:     0o777,
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var archive bytes.Buffer
+			writer := tar.NewWriter(&archive)
+			if err := writer.WriteHeader(&tt.header); err != nil {
+				t.Fatal(err)
+			}
+			if tt.contents != "" {
+				if _, err := writer.Write([]byte(tt.contents)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			err := extractTar(bytes.NewReader(archive.Bytes()), t.TempDir())
+			if err == nil {
+				t.Fatal("extractTar unexpectedly accepted unsafe entry")
+			}
+		})
+	}
+}
+
+func TestExtractTarIgnoresPAXGlobalHeader(t *testing.T) {
+	var archive bytes.Buffer
+	writer := tar.NewWriter(&archive)
+	if err := writer.WriteHeader(&tar.Header{
+		Name:       "pax_global_header",
+		Typeflag:   tar.TypeXGlobalHeader,
+		PAXRecords: map[string]string{"comment": "github archive metadata"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	contents := "name: CI\non: push\njobs: {}\n"
+	if err := writer.WriteHeader(&tar.Header{
+		Name:     "root/.github/workflows/ci.yml",
+		Mode:     0o644,
+		Size:     int64(len(contents)),
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write([]byte(contents)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	if err := extractTar(bytes.NewReader(archive.Bytes()), root); err != nil {
+		t.Fatalf("extractTar rejected PAX global header: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".github", "workflows", "ci.yml")); err != nil {
+		t.Fatalf("workflow was not extracted: %v", err)
+	}
+}
+
+func newSnapshotTestFetcher(t *testing.T, server *httptest.Server) *Fetcher {
+	t.Helper()
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := github.NewClient(server.Client())
+	client.BaseURL = baseURL
+	client.UploadURL = baseURL
+	return &Fetcher{
+		client:               client,
+		archiveClient:        server.Client(),
+		allowInsecureArchive: true,
+		limit:                1,
+	}
+}
+
+func makeTarGzip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name:     "repository-root/",
+		Mode:     0o755,
+		Typeflag: tar.TypeDir,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	paths := make([]string, 0, len(files))
+	for filename := range files {
+		paths = append(paths, filename)
+	}
+	slices.Sort(paths)
+	for _, filename := range paths {
+		contents := files[filename]
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Name:     filename,
+			Mode:     0o644,
+			Size:     int64(len(contents)),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tarWriter.Write([]byte(contents)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}


### PR DESCRIPTION
## Summary

- Add pull-request URLs and `-pr` support to the sisakulint remote CLI.
- Resolve and verify the PR head, materialize the complete repository archive at the immutable SHA, and analyze every workflow with local project context.
- Limit rendered findings and autofix output to changed workflow targets while unchanged workflows remain available for cross-file analysis.
- Add archive traversal, link, entry-count, compressed-size, extracted-size, and per-file safety checks.
- Preserve existing remote authentication fallback through environment variables, `gh auth`, and Git credentials.
- Document the three-repository design and rollout order.

## Why

The sisakulint-agent PR previously needed to fetch Dependabot configuration as a rule-specific context file. That approach does not scale to lockfiles, Renovate configuration, local actions, reusable workflows, or future project-wide rules.

Repository acquisition and PR scan semantics belong in sisakulint so the CLI, API, and other integrations can reuse one immutable snapshot implementation. This addresses the design question raised in [sisakulint-agent#18](https://github.com/sisaku-security/sisakulint-agent/pull/18#issuecomment-5027897981).

## Impact

A caller can scan a PR with:

```console
sisakulint -remote owner/repo -pr 123 -expected-head-sha <sha>
```

The full PR head supplies analysis context, while only changed workflows are reported. Head and base SHAs are revalidated after the mutable PR files endpoint is paginated, preventing a mixed-revision scan.

PR-mode fixes remain workflow-scoped. Repository-file fixers, such as Dependabot configuration creation, stay available for local scans but are disabled when the response contract cannot persist them.

## Validation

- `go test ./...`
- `go test -race ./pkg/core ./pkg/remote`
- `go vet ./...`
- `git diff --check`
- Live private scan of `sisakulint-agent#18`
- Live workflow-changing scan of `agent-idea#6`, including a root `go.sum` ecosystem finding
- Live fork PR archive materialization

## Related PRs and rollout

1. Merge this PR and release sisakulint `v0.3.6`.
2. Merge and deploy [sisakulint-api#50](https://github.com/sisaku-security/sisakulint-api/pull/50).
3. Deploy the updated [sisakulint-agent#18](https://github.com/sisaku-security/sisakulint-agent/pull/18).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * リモートPull Requestを指定したコミットでスキャンできるようになりました。
  * リポジトリ全体を解析し、変更されたワークフローのみを報告・自動修正できます。
  * リモート修正時のチェックアウト先や対象ワークフローを指定できます。
  * SHA検証、安全なアーカイブ展開、サイズ・パス制限によりスキャンの信頼性を向上しました。

* **ドキュメント**
  * リモートPRスキャンの利用方法、トークン要件、制約を追加しました。
  * スナップショットスキャンと従来方式の動作差異を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->