### PR TITLE
config: make the file written by `-init` usable

### DIFF
--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -252,7 +252,7 @@ func (cmd *Command) Main(args []string) int {
 	flags.BoolVar(&generateBoilerplate, "boilerplate", false, "Generate a costomized template file for GitHub Actions workflow")
 	flags.StringVar(&linterOpts.CustomErrorMessageFormat, "format", "", "Custom template to format error messages in Go template syntax.")
 	flags.StringVar(&linterOpts.ConfigurationFilePath, "config-file", "", "File path to config file")
-	flags.BoolVar(&initConfig, "init", false, "Generate default config file at .github/action.yaml in current project. see : https://docs.github.com/ja/actions/creating-actions/metadata-syntax-for-github-actions#github-actions%E3%81%AEyaml%E6%A7%8B%E6%96%87%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6")
+	flags.BoolVar(&initConfig, "init", false, "Generate default config file at .github/sisakulint.yaml in current project")
 	flags.BoolVar(&generateActionList, "generate-action-list", false, "Generate action list configuration from existing workflow files")
 	flags.BoolVar(&linterOpts.IsVerboseOutputEnabled, "verbose", false, "Enable verbose output")
 	flags.BoolVar(&linterOpts.IsDebugOutputEnabled, "debug", false, "Enable debug output (for development)")

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -112,15 +112,13 @@ func loadRepoConfig(root string) (*Config, error) {
 
 // writeDefaultConfigFileは指定されたファイルパスにデフォルトの設定ファイルを書き込む
 func writeDefaultConfigFile(path string) error {
-	b := []byte(`
-# Configuration file for sisakulint
+	b := []byte(`# Configuration file for sisakulint
 # Use this file to customize the behavior of sisakulint
+
 # self-hosted-runner section is for configuring self-hosted runners.
 self-hosted-runner:
-  # Use the labels key to specify labels for self-hosted runners used in your project as an array of strings.
-  # This allows sisakulint to verify that these labels are correctly configured.
+  # Labels of the self-hosted runners used in your project, as an array of strings.
   # 🧠 Example: labels: ["linux-large", "windows-2xlarge"]
-  # Note: Ensure that the labels match those configured in your self-hosted runner settings.
   labels: []
 
 # config-variables section is for specifying configuration variables defined in your repository or organization.
@@ -130,17 +128,16 @@ self-hosted-runner:
 # Note: List all the configuration variables that are used in your GitHub Actions workflows.
 config-variables: null
 
-# action-list section is for specifying which GitHub Actions are allowed or blocked in your workflows.
-# You can define a whitelist (only these actions are allowed) or a blacklist (these actions are blocked).
-# Using wildcards is supported: actions/checkout@* matches any version of actions/checkout.
-action-list:
-  whitelist:
-    - actions/checkout@*
-    - actions/setup-node@*
-    - actions/cache@*
-  blacklist:
-    - untrusted/*@*
-    - suspicious/*@*
+# action-list section is an allowlist of the actions that may appear in "uses:".
+# When it is empty or omitted, the action-list rule reports nothing.
+# When it has one or more patterns, every "uses:" value that matches none of them is reported.
+# The whole "uses:" value is matched, including the part after "@", and "*" stands for any
+# string. So "actions/checkout" does NOT match "actions/checkout@v4"; write "actions/checkout@*".
+# 🧠 Example:
+# action-list:
+#   - actions/checkout@*
+#   - actions/setup-node@*
+action-list: []
 
 # secret-exfiltration section configures the secret-exfiltration rule.
 # allowed-hosts suppresses findings whose destination hostname matches any
@@ -159,11 +156,7 @@ action-list:
 #     - "*.example.com"
 secret-exfiltration:
   allowed-hosts: []
-
-# Add other optional settings below.
-# 🧠 Example: some-option: value
-# Note: Refer to the sisakulint documentation for more information on available settings.
-	`)
+`)
 	if err := os.WriteFile(path, b, 0644); err != nil { //nolint:gosec // config file is committed to git and must be readable by CI
 		return fmt.Errorf("failed to write config file %q: %w", path, err)
 	}

--- a/pkg/core/config_test.go
+++ b/pkg/core/config_test.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDefaultConfigFileIsParseable は -init が書き出す設定を parseConfig が読めることを確かめる。
+//
+// この検査が無かったため、生成テンプレートが Config の型から外れたまま 1 年以上残っていた。
+// テンプレートは raw string なので、型を変えてもコンパイルは通る。書いたものを自分で読む検査を
+// 1 つ置けば、その種のずれはここで落ちる。
+func TestDefaultConfigFileIsParseable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sisakulint.yaml")
+
+	if err := writeDefaultConfigFile(path); err != nil {
+		t.Fatalf("writeDefaultConfigFile: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if _, err := parseConfig(b, path); err != nil {
+		t.Fatalf("生成した設定を読み直せない: %v", err)
+	}
+}
+
+// TestDefaultConfigFileHasNoTabs は生成物にタブ文字が無いことを確かめる。
+//
+// raw string の閉じインデントがそのまま出力へ入ると、YAML はタブを受け付けないので解釈に失敗する。
+// 実際にそうなっていた。
+func TestDefaultConfigFileHasNoTabs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sisakulint.yaml")
+	if err := writeDefaultConfigFile(path); err != nil {
+		t.Fatalf("writeDefaultConfigFile: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	for i, line := range splitLines(string(b)) {
+		for _, r := range line {
+			if r == '\t' {
+				t.Fatalf("%d 行目にタブ文字がある: %q", i+1, line)
+			}
+		}
+	}
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i, r := range s {
+		if r == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}

--- a/pkg/core/linter.go
+++ b/pkg/core/linter.go
@@ -316,7 +316,7 @@ func (l *Linter) GenerateDefaultConfig(dir string) error {
 		return errors.New("project not found, Make sure the current project is initialized as a Git repository and the \".github/workflows\" directory exists")
 	}
 
-	configPath := filepath.Join(project.RootDirectory(), ".github", "action.yaml")
+	configPath := filepath.Join(project.RootDirectory(), ".github", "sisakulint.yaml")
 	if _, err := os.Stat(configPath); err == nil {
 		return fmt.Errorf("config file already exists: %q", configPath)
 	}


### PR DESCRIPTION
# config: make the file written by `-init` usable

**TL;DR** — `sisakulint -init` writes a config file that the linter never reads, and that would
not parse even if it were read. This changes the write path to match the read path and fixes the
generated template so it round-trips.

## Problem

Following `-init` and then running the linter, the config has no effect. Peeling it back, four
independent defects sit on top of each other.

1. **The file lands where nothing looks for it.** `-init` writes `.github/action.yaml`, while
   `loadRepoConfig` only reads `.github/sisakulint.yaml` and `.yml`. Leaving the generated file
   in place and scanning reports nothing from the allowlist rule, exactly as if no config
   existed.

2. **Renaming it to the read path still fails.** The generated bytes end with a literal tab
   character — the closing indent of the Go raw string leaks into the output — and YAML does not
   accept tabs.

3. **Removing the tab still fails.** The template writes `action-list` as a map
   (`whitelist:` / `blacklist:`), but the field it parses into is a `[]string`:

   ```go
   ActionList []string `yaml:"action-list"`
   ```
   ([source](https://github.com/sisaku-security/sisakulint/blob/dea1408b296a54edc30206ee844daf5ea185b79e/pkg/core/config.go))

4. **Two documented settings have no implementation.** Written as a sequence, `action-list`
   works and its meaning is an allowlist; the `blacklist` the template describes has no
   corresponding field. The template also states that the runner labels are verified:

   ```
   # This allows sisakulint to verify that these labels are correctly configured.
   ```
   ([source](https://github.com/sisaku-security/sisakulint/blob/dea1408b296a54edc30206ee844daf5ea185b79e/pkg/core/config.go))

   Setting or clearing that list does not change what the self-hosted-runner rule reports.

All four are independently reproduced (see Verification).

**How this survived.** The write/read mismatch dates back to the commit that introduced config
loading — it added the reader as `sisakulint.yaml` and the writer as `sisaku.yaml` in the same
change — and a later commit moved the writer to `action.yaml` without touching the reader. The
type mismatch came from narrowing `ActionList` to `[]string`; that change also updated this
repository's own `.github/sisakulint.yaml`, but not the generated template a few lines away in
the same file. The template is a raw string, so changing the struct it feeds still compiles.
Nothing reads the generated file back, so nothing failed.

## Change

| File | What |
|---|---|
| `pkg/core/linter.go` | `-init` writes `.github/sisakulint.yaml` instead of `.github/action.yaml` |
| `pkg/core/command.go` | `-init` help text updated; it pointed at GitHub's *action metadata* syntax page, which documents a different file |
| `pkg/core/config.go` | Template: drop the leading blank line and the trailing tab; write `action-list` as a sequence; remove the `blacklist` description and the claim that labels are verified |
| `pkg/core/config_test.go` | New: generated config must parse, and must contain no tabs |

Three choices worth flagging, since they could reasonably go the other way:

- **`action-list` defaults to `[]`.** The old template shipped a populated example. With a
  non-empty allowlist the rule becomes active immediately and reports every action outside it,
  which changes behaviour for anyone who runs `-init`. An empty list keeps the rule inert; the
  example is retained as a comment.
- **The `self-hosted-runner.labels` section stays.** It is not consumed, but removing the key
  would turn it into an unknown field for anyone who already has it in their config. Only the
  sentence claiming verification is removed.
- **`blacklist` is not implemented.** See *Not in this PR*.

## Verification

The new tests fail against the current template:

```
--- FAIL: TestDefaultConfigFileIsParseable
    生成した設定を読み直せない: failed to parse config file ".../sisakulint.yaml":
    yaml: line 52: found character that cannot start any token
--- FAIL: TestDefaultConfigFileHasNoTabs
```

With the change: `go build ./...` clean, `go test ./pkg/core/` passes.

End to end, following the path a user takes:

```
$ sisakulint -init
generated default config file: ".../.github/sisakulint.yaml"

$ sisakulint          # before: exit 3, config not parsed. now: scans normally
$ printf 'action-list:\n  - actions/checkout@*\n' > .github/sisakulint.yaml
$ sisakulint
.github/workflows/w.yaml:10:9: action 'unknown/x@v1' is not in the whitelist in step '<unnamed>' [action-list]
```

The four defects were each reproduced against a pinned build before the change; the reproduction
runs `-init`, moves the output to the read path, strips the tab, and rewrites `action-list`,
asserting the failure at each stage.

## Not in this PR

- **Implementing `blacklist`.** [#162](https://github.com/sisaku-security/sisakulint/issues/162)
  asked for both an allowlist and a blocklist, and the template still describes both. The
  implementation was deliberately narrowed to allowlist-only later. Restoring the blocklist is a
  feature decision rather than a consistency fix, so this PR removes the stale description
  instead of adding the feature. Happy to follow up if you'd prefer the other direction.
- **Making `self-hosted-runner.labels` affect detection.** Same reasoning — currently the value
  is only echoed back when the config is regenerated.

## Compatibility

- Anyone who already keeps a hand-written `.github/sisakulint.yaml` is unaffected; that path was
  always the one being read.
- `.github/action.yaml` written by an earlier `-init` was never read, so no behaviour depended on
  it. `-init` will now create `sisakulint.yaml` alongside it; the old file can be deleted.
- `action.yaml` is also the filename GitHub uses for action metadata. The spec fixes the
  filename only — "the metadata filename must be either `action.yml` or `action.yaml`"
  ([source](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions))
  — not the location, so `.github/action.yaml` is not a standard location — but a repository that references
  `uses: ./.github` would have had the two meanings collide, since this tool reads
  `action.yaml`/`action.yml` from a referenced local action directory. Moving off that name
  removes the overlap.

## Status

This is a proposal from an outside review of the tool's docs and behaviour; the findings above
are recorded and reproduced on our side, but nothing here reflects a maintainer decision. Happy
to split it into smaller commits or drop the template changes if you would rather handle those
separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * `-init` オプションで生成される設定ファイルを `.github/sisakulint.yaml` に変更しました。
  * デフォルト設定の `action-list` を、`uses:` 全体に適用できるワイルドカード付き許可パターン形式に更新しました。
  * self-hosted runner の説明を簡略化し、設定例を整理しました。
  * 生成される設定ファイルの構文解析や、タブ文字を含まないことを確認する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->